### PR TITLE
Update links in README and CONTRIBUTING files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ Once your PR merges to `main`, the publish workflow runs automatically:
 5. The releases branch README is regenerated
 6. Up to 10 versioned ZIPs are retained; older ones are pruned
 
-Everything is pushed to the [`releases` branch](https://github.com/sethwv/sample-plugin-repo/tree/releases).
+Everything is pushed to the [`releases` branch](https://github.com/Dispatcharr/Plugins/tree/releases).
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ A repository for publishing and distributing Dispatcharr Python plugins with aut
 
 | Resource | Description |
 |----------|-------------|
-| [Browse Plugins](https://github.com/sethwv/sample-plugin-repo/tree/releases) | All available plugins on the releases branch |
-| [Plugin Manifest](https://raw.githubusercontent.com/sethwv/sample-plugin-repo/releases/manifest.json) | Plugin metadata, checksums, and download URLs |
-| [Download Releases](https://github.com/sethwv/sample-plugin-repo/tree/releases/releases) | Plugin ZIP files |
-| [View Metadata](https://github.com/sethwv/sample-plugin-repo/tree/releases/metadata) | Version metadata with commit info and checksums |
+| [Browse Plugins](https://github.com/Dispatcharr/Plugins/tree/releases) | All available plugins on the releases branch |
+| [Plugin Manifest](https://raw.githubusercontent.com/Dispatcharr/Plugins/releases/manifest.json) | Plugin metadata, checksums, and download URLs |
+| [Download Releases](https://github.com/Dispatcharr/Plugins/tree/releases/releases) | Plugin ZIP files |
+| [View Metadata](https://github.com/Dispatcharr/Plugins/tree/releases/metadata) | Version metadata with commit info and checksums |
 
 ## How It Works
 
-Each plugin lives in `plugins/<plugin-name>/` and must contain a valid `plugin.json`. When a PR is merged to `main`, plugins are automatically packaged and published to the [`releases` branch](https://github.com/sethwv/sample-plugin-repo/tree/releases).
+Each plugin lives in `plugins/<plugin-name>/` and must contain a valid `plugin.json`. When a PR is merged to `main`, plugins are automatically packaged and published to the [`releases` branch](https://github.com/Dispatcharr/Plugins/tree/releases).
 
 ### PR Validation
 
@@ -47,8 +47,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide, including the `plugin
 
 ## Downloading Plugins
 
-Visit the [releases branch](https://github.com/sethwv/sample-plugin-repo/tree/releases) to browse and download plugins, or fetch `manifest.json` programmatically:
+Visit the [releases branch](https://github.com/Dispatcharr/Plugins/tree/releases) to browse and download plugins, or fetch `manifest.json` programmatically:
 
 ```bash
-curl https://raw.githubusercontent.com/sethwv/sample-plugin-repo/releases/manifest.json
+curl https://raw.githubusercontent.com/Dispatcharr/Plugins/releases/manifest.json
 ```


### PR DESCRIPTION
This pull request updates all repository URLs in documentation files from the old `sethwv/sample-plugin-repo` testing location to the new `Dispatcharr/Plugins` repository. This ensures that users and contributors are directed to the correct, current resources and download links.

Documentation updates:

* Updated all links in `README.md` to point to the new `Dispatcharr/Plugins` repository, including plugin browsing, manifest, releases, and metadata URLs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L50-R53)
* Updated the `CONTRIBUTING.md` workflow documentation to reference the new `Dispatcharr/Plugins` releases branch.