### PR TITLE
Fix PGP Signature change warning

### DIFF
--- a/.github/scripts/validate/detect-changes.sh
+++ b/.github/scripts/validate/detect-changes.sh
@@ -69,12 +69,17 @@ if [[ -z "$PLUGIN_LIST" ]]; then
   fi
   if [[ "$(has_write_access "$PR_AUTHOR")" -eq 1 ]]; then
     # Repo maintainer with no plugin changes - skip plugin validation entirely and pass
+    PUB_KEY_CHANGED=false
+    if echo "$OUTSIDE_CHANGES" | grep -q "^\.github/scripts/keys/dispatcharr-plugins\.pub$"; then
+      PUB_KEY_CHANGED=true
+    fi
     echo "matrix=[]"               >> "$GITHUB_OUTPUT"
     echo "plugin_count=0"          >> "$GITHUB_OUTPUT"
     echo "close_pr=false"          >> "$GITHUB_OUTPUT"
     echo "close_reason="           >> "$GITHUB_OUTPUT"
     echo "skip_validation=true"    >> "$GITHUB_OUTPUT"
     echo "outside_violation=false" >> "$GITHUB_OUTPUT"
+    echo "pub_key_changed=$PUB_KEY_CHANGED" >> "$GITHUB_OUTPUT"
     echo "No plugin changes detected - skipping plugin validation (author has write access)."
     exit 0
   fi

--- a/.github/scripts/validate/report.sh
+++ b/.github/scripts/validate/report.sh
@@ -135,7 +135,7 @@ done
       echo "**Before merging, confirm:**"
       echo "- The corresponding private key and passphrase secrets (\`GPG_PRIVATE_KEY\`, \`GPG_PASSPHRASE\`) have been updated in the repository settings."
       echo "- The new public key has been bundled into the Dispatcharr application."
-      echo "- Existing \`.sig\` files on the \`releases\` branch will be regenerated on next publish."
+      echo "- Existing embedded signatures in \`manifest.json\` files on the \`releases\` branch will be regenerated on next publish."
       echo ""
     fi
 

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -401,7 +401,7 @@ jobs:
   # --------------------------------------------------------------------------
   report:
     needs: [detect-changes, validate-plugin, codeql-analyze]
-    if: always() && needs.detect-changes.result == 'success' && needs.detect-changes.outputs.close_pr == 'false' && needs.detect-changes.outputs.skip_validation != 'true'
+    if: always() && needs.detect-changes.result == 'success' && needs.detect-changes.outputs.close_pr == 'false' && (needs.detect-changes.outputs.skip_validation != 'true' || needs.detect-changes.outputs.pub_key_changed == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
This pull request updates the validation workflow for plugin changes, with a particular focus on handling updates to the public key used for plugin signature verification. The main improvements ensure that changes to the public key are properly detected and that the reporting step is always run when the key changes, regardless of whether plugin validation is skipped.

Key workflow and script changes:

**Public key change detection and reporting:**
* The `detect-changes.sh` script now checks if the public key file (`.github/scripts/keys/dispatcharr-plugins.pub`) has changed, and sets a new output variable `pub_key_changed` accordingly.
* The workflow condition for the `report` job in `.github/workflows/validate-plugin.yml` is updated to always run the report step if the public key has changed, even if plugin validation is skipped.

**Reporting improvements:**
* The report script's message is clarified to indicate that existing embedded signatures in `manifest.json` files (rather than just `.sig` files) will be regenerated on the next publish, reflecting the actual files affected by a key change.