### PR TITLE
[dispatcharr-exporter]: Bump to v2.4.2

### DIFF
--- a/plugins/dispatcharr-exporter/plugin.json
+++ b/plugins/dispatcharr-exporter/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Dispatcharr Exporter",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Expose Dispatcharr metrics in Prometheus exporter-compatible format for monitoring",
   "license": "MIT",
   "discord_thread": "https://discord.com/channels/1340492560220684331/1451260201775923421",

--- a/plugins/dispatcharr-exporter/plugin.py
+++ b/plugins/dispatcharr-exporter/plugin.py
@@ -42,7 +42,7 @@ def _load_plugin_config():
         logger.warning(f"Could not load plugin.json, using fallback config: {e}")
         # Fallback configuration if JSON can't be loaded
         return {
-            "version": "2.4.1",
+            "version": "2.4.2",
             "name": "Dispatcharr Exporter",
             "author": "SethWV",
             "description": "Expose Dispatcharr metrics in Prometheus exporter-compatible format for monitoring",
@@ -2364,6 +2364,46 @@ class Plugin:
             'repo_url': repo_url
         }
     
+    @staticmethod
+    def _cleanup_stale_redis_state():
+        """Clean up all Redis keys this plugin has ever created.
+        
+        Called on startup before auto-start to ensure we're working from a clean
+        slate. This prevents stale keys from a previous container lifecycle (e.g.
+        failed upgrade, ungraceful shutdown) from blocking the server from starting.
+        """
+        # Every Redis key this plugin has ever set across all versions
+        ALL_PLUGIN_KEYS = [
+            "prometheus_exporter:server_running",
+            "prometheus_exporter:server_host",
+            "prometheus_exporter:server_port",
+            "prometheus_exporter:stop_requested",
+            "prometheus_exporter:autostart_completed",
+            "prometheus_exporter:update_available",
+            "prometheus_exporter:last_update_notification",
+        ]
+        
+        try:
+            from core.utils import RedisClient
+            redis_client = RedisClient.get_client()
+            if redis_client:
+                deleted = redis_client.delete(*ALL_PLUGIN_KEYS)
+                if deleted:
+                    logger.info(f"Startup cleanup: removed {deleted} stale Redis key(s)")
+                else:
+                    logger.debug("Startup cleanup: no stale Redis keys found")
+        except Exception as e:
+            logger.warning(f"Startup cleanup: could not clear Redis keys: {e}")
+        
+        # Also remove the lock file from a previous lifecycle
+        try:
+            lock_file = "/tmp/prometheus_exporter_autostart.lock"
+            if os.path.exists(lock_file):
+                os.remove(lock_file)
+                logger.debug("Startup cleanup: removed stale auto-start lock file")
+        except Exception as e:
+            logger.debug(f"Startup cleanup: could not remove lock file: {e}")
+
     def __init__(self):
         self.collector = PrometheusMetricsCollector()
 
@@ -2419,20 +2459,12 @@ class Plugin:
                 
                 logger.debug("Prometheus exporter: Lock acquired, checking config for auto-start")
                 
-                # We got the lock - we're the chosen worker for auto-start
-                try:
-                    from core.utils import RedisClient
-                    redis_client = RedisClient.get_client()
-                    if redis_client:
-                        # Check if server is already running
-                        running_flag = redis_client.get("prometheus_exporter:server_running")
-                        if running_flag == "1" or running_flag == b"1":
-                            logger.debug("Prometheus exporter: Server already running (detected via Redis), skipping auto-start")
-                            fcntl.flock(lock_fd.fileno(), fcntl.LOCK_UN)
-                            lock_fd.close()
-                            return
-                except Exception as e:
-                    logger.debug(f"Could not check Redis for running server: {e}")
+                # We got the lock - we're the chosen worker.
+                # Clean slate: wipe any Redis keys from a previous container lifecycle
+                # (e.g. failed upgrade, ungraceful shutdown) before checking state.
+                # This runs inside the flock so only one worker ever does it, and
+                # it happens before any new server state is set.
+                Plugin._cleanup_stale_redis_state()
                 
                 # Capture the INITIAL auto-start setting to lock in behavior at Dispatcharr startup
                 # This prevents runtime setting changes from triggering auto-start


### PR DESCRIPTION
<!--
  Read CONTRIBUTING.md before submitting: https://github.com/Dispatcharr/Plugins/blob/main/CONTRIBUTING.md

  Suggested PR title format: [your-plugin-name]: brief summary of change
  e.g. [dispatcharr-exporter]: add initial release   or   [my-plugin]: bump to 1.2.0
-->

## About this submission

This PR is to update the listed version of dispatcharr-exporter to v2.4.2
https://github.com/sethwv/dispatcharr-exporter/releases/tag/v2.4.2

### Fixed
- Prevent exporter auto-start from being blocked by stale state left behind after a failed upgrade or ungraceful shutdown by clearing prior Redis keys and removing the stale auto-start lock file on startup.

## Pre-submission checklist

<!-- Tick each box that applies. The bot will validate automatically, but catching issues here saves time. -->

**If this is a new plugin:**
- [ ] Plugin folder is named `lowercase-kebab-case`
- [ ] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
- [ ] My GitHub username is in `author` or `maintainers`
- [ ] `license` is a valid [OSI-approved SPDX identifier](https://spdx.org/licenses/) (e.g. `MIT`, `Apache-2.0`)
- [ ] I have tested the plugin against a running Dispatcharr instance

**If this is an update to an existing plugin:**
- [x] `version` in `plugin.json` is incremented (unless this is a metadata-only change - see [Versioning](https://github.com/Dispatcharr/Plugins/blob/main/CONTRIBUTING.md#versioning))
- [x] I am listed in `author` or `maintainers` of the existing plugin
