### PR TITLE
Revise pull request title format instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,14 @@
 <!--
   Read CONTRIBUTING.md before submitting: https://github.com/Dispatcharr/Plugins/blob/main/CONTRIBUTING.md
 
-  Suggested PR title format: [your-plugin-name]: brief summary of change
-  e.g. [dispatcharr-exporter]: add initial release   or   [my-plugin]: bump to 1.2.0
+  PR Title format:
+    If modifying a single plugin, use your plugin slug (the folder-name of your plugin)
+      [plugin-slug]: BRIEF description of changes
+      [dispatcharr-exporter]: Bump version to X.X.X
+
+    If modifying more than one plugin, use your github username:
+      [author]: BRIEF description of changes
+      [sethwv]: Update my plugins to new manifest formatting
 -->
 
 ## About this submission


### PR DESCRIPTION
This pull request updates the pull request template to clarify the required PR title format. The new instructions specify how to format the title depending on whether the change affects a single plugin or multiple plugins.

Improvements to PR title guidelines:

* Updated `.github/PULL_REQUEST_TEMPLATE.md` to provide clearer instructions for PR title formatting, distinguishing between single-plugin changes (use the plugin slug) and multi-plugin changes (use the GitHub username).