### PR TITLE
Gate OUTSIDE_FILES messaging on OUTSIDE_VIOLATION check

### DIFF
--- a/.github/scripts/validate/report.sh
+++ b/.github/scripts/validate/report.sh
@@ -106,7 +106,7 @@ done
   else
     echo "$COMBINED_BODY"
 
-    if [[ -n "${OUTSIDE_FILES:-}" ]]; then
+  if [[ -n "${OUTSIDE_FILES:-}" && "${OUTSIDE_VIOLATION:-}" == "true" ]]; then
       OVERALL_FAILED=1
       echo ""
       echo "⚠️ This PR modifies files outside of \`plugins/\`, which requires write access to the repository. These changes will block merging."

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -630,6 +630,7 @@ jobs:
           CODEQL_WARNINGS: ${{ needs.codeql-analyze.outputs.codeql_warnings }}
           CODEQL_MEDIUMS: ${{ needs.codeql-analyze.outputs.codeql_mediums }}
           OUTSIDE_FILES: ${{ needs.detect-changes.outputs.outside_files }}
+          OUTSIDE_VIOLATION: ${{ needs.detect-changes.outputs.outside_violation }}
           PUB_KEY_CHANGED: ${{ needs.detect-changes.outputs.pub_key_changed }}
         run: |
           chmod +x .github/scripts/validate/*.sh


### PR DESCRIPTION
This pull request updates the validation workflow and reporting script to more accurately detect and handle pull requests that modify files outside of the `plugins/` directory. The changes ensure that warnings about modifying outside files are only triggered when an actual violation occurs, avoiding false positives.

Workflow and script improvements:

* Updated `.github/scripts/validate/report.sh` to only block merging and display a warning if both `OUTSIDE_FILES` are present and `OUTSIDE_VIOLATION` is true, ensuring stricter and more accurate enforcement.
* Modified `.github/workflows/validate-plugin.yml` to pass the new `OUTSIDE_VIOLATION` output from the `detect-changes` job to the validation scripts, supporting the improved logic in the reporting script.