### PR TITLE
[Repo]: Fix plugin key formatting in manifest generation

### DIFF
--- a/.github/scripts/publish/generate-manifest.sh
+++ b/.github/scripts/publish/generate-manifest.sh
@@ -109,6 +109,7 @@ for plugin_dir in plugins/*/; do
   plugin_file="$plugin_dir/plugin.json"
   [[ ! -f "$plugin_file" ]] && continue
   plugin_name=$(basename "$plugin_dir")
+  plugin_key=${plugin_name//-/_}
   [[ "$(jq -r '.unlisted // false' "$plugin_file")" == "true" ]] && continue
 
   echo "  $plugin_name"
@@ -127,7 +128,7 @@ for plugin_dir in plugins/*/; do
     zip_url="zips/${plugin_name}/${zip_basename}"
 
     # Fresh metadata from this run takes priority; fall back to existing manifest
-    fresh_meta_file="${BUILD_META_DIR:-}/$plugin_name/${plugin_name}-${zip_version}.json"
+    fresh_meta_file="${BUILD_META_DIR:-}/$plugin_key/${plugin_key}-${zip_version}.json"
     metadata="{}"
     if [[ -n "${BUILD_META_DIR:-}" && -f "$fresh_meta_file" ]]; then
       metadata=$(cat "$fresh_meta_file")


### PR DESCRIPTION
This pull request updates the manifest generation script to improve consistency in how plugin metadata is handled, especially for plugin names containing hyphens. The main change is the introduction of a normalized plugin key that replaces hyphens with underscores, ensuring consistent file and directory naming throughout the script.

**Manifest generation improvements:**

* Introduced a `plugin_key` variable by replacing hyphens with underscores in `plugin_name`, which is then used for directory and file naming to ensure consistency and prevent issues with hyphenated plugin names. (.github/scripts/publish/generate-manifest.sh)
* Updated the construction of `fresh_meta_file` to use `plugin_key` instead of `plugin_name`, aligning file paths with the new naming convention. (.github/scripts/publish/generate-manifest.sh)