### PR TITLE
[Repo]: Enhance README with badge generation for repo & discord links

### DIFF
--- a/.github/scripts/publish/plugin-readmes.sh
+++ b/.github/scripts/publish/plugin-readmes.sh
@@ -37,6 +37,9 @@ for plugin_dir in plugins/*/; do
   license=$(jq -r '.license // ""' "$plugin_file")
   min_dispatcharr=$(jq -r '.min_dispatcharr_version // empty' "$plugin_file")
   max_dispatcharr=$(jq -r '.max_dispatcharr_version // empty' "$plugin_file")
+  version=$(jq -r '.version' "$plugin_file")
+  last_updated=$(git log -1 --format=%cI origin/$SOURCE_BRANCH -- "$plugin_dir" 2>/dev/null \
+    || date -u +"%Y-%m-%dT%H:%M:%SZ")
   has_readme=false
   [[ -f "$plugin_dir/README.md" ]] && has_readme=true
 
@@ -44,6 +47,8 @@ for plugin_dir in plugins/*/; do
     echo "[Back to All Plugins](../../README.md)"
     echo ""
     echo "# $name"
+    echo ""
+    echo "**Version:** \`$version\` | **Author:** $author | **Last Updated:** $(fmt_date "$last_updated")"
     echo ""
     echo "$description"
     echo ""
@@ -56,20 +61,20 @@ for plugin_dir in plugins/*/; do
         local_discord_link="$discord_thread"
       fi
     fi
-    badges="![Author](https://img.shields.io/badge/Author-$(shields_encode "$author")-grey?style=flat-square)"
+    badges=""
     if [[ -n "$license" ]]; then
-      badges+=" [![License: $license](https://img.shields.io/badge/License-$(shields_encode "$license")-blue?style=flat-square)](https://spdx.org/licenses/${license}.html)"
+      badges="[![License: $license](https://img.shields.io/badge/License-$(shields_encode "$license")-blue?style=flat-square)](https://spdx.org/licenses/${license}.html)"
     fi
     if [[ -n "$local_discord_link" ]]; then
-      badges+=" [![Discord](https://img.shields.io/badge/Discord-Discussion-5865F2?style=flat-square&logo=discord&logoColor=white)]($local_discord_link)"
+      [[ -n "$badges" ]] && badges+=" "
+      badges+="[![Discord](https://img.shields.io/badge/Discord-Discussion-5865F2?style=flat-square&logo=discord&logoColor=white)]($local_discord_link)"
     fi
     if [[ -n "$repo_url" ]]; then
-      badges+=" [![Repository](https://img.shields.io/badge/GitHub-Repository-181717?style=flat-square&logo=github&logoColor=white)]($repo_url)"
+      [[ -n "$badges" ]] && badges+=" "
+      badges+="[![Repository](https://img.shields.io/badge/GitHub-Repository-181717?style=flat-square&logo=github&logoColor=white)]($repo_url)"
     fi
-    echo "$badges"
-    echo ""
-    if [[ -n "$maintainers" ]]; then
-      echo "**Maintainers:** $maintainers"
+    if [[ -n "$badges" ]]; then
+      echo "$badges"
       echo ""
     fi
     if [[ -n "$min_dispatcharr" || -n "$max_dispatcharr" ]]; then
@@ -162,7 +167,10 @@ for plugin_dir in plugins/*/; do
     echo ""
     echo "---"
     echo ""
-    echo "**Source:** [Browse Plugin](https://github.com/${GITHUB_REPOSITORY}/tree/$SOURCE_BRANCH/plugins/${plugin_name})"
+    local_footer=""
+    [[ -n "$maintainers" ]] && local_footer="**Maintainers:** $maintainers | "
+    local_footer+="**Source:** [Browse Plugin](https://github.com/${GITHUB_REPOSITORY}/tree/$SOURCE_BRANCH/plugins/${plugin_name})"
+    echo "$local_footer"
     echo ""
     echo "**Metadata:** [View full manifest](./manifest.json)"
 

--- a/.github/scripts/publish/plugin-readmes.sh
+++ b/.github/scripts/publish/plugin-readmes.sh
@@ -60,7 +60,7 @@ for plugin_dir in plugins/*/; do
       badges+=" [![License: $license](https://img.shields.io/badge/License-$(shields_encode "$license")-blue?style=flat-square)](https://spdx.org/licenses/${license}.html)"
     fi
     if [[ -n "$local_discord_link" ]]; then
-      badges+=" [![Discord](https://img.shields.io/badge/Discord-Discussion_Thread-5865F2?style=flat-square&logo=discord&logoColor=white)]($local_discord_link)"
+      badges+=" [![Discord](https://img.shields.io/badge/Discord-Discussion-5865F2?style=flat-square&logo=discord&logoColor=white)]($local_discord_link)"
     fi
     if [[ -n "$repo_url" ]]; then
       badges+=" [![Repository](https://img.shields.io/badge/GitHub-Repository-181717?style=flat-square&logo=github&logoColor=white)]($repo_url)"

--- a/.github/scripts/publish/plugin-readmes.sh
+++ b/.github/scripts/publish/plugin-readmes.sh
@@ -12,6 +12,16 @@ set -e
 # Format an ISO8601 timestamp as "Mon DD, HH:MM UTC"
 fmt_date() { date -d "$1" -u +"%b %d %Y, %H:%M UTC" 2>/dev/null || echo "$1"; }
 
+# Encode a string for use in a shields.io badge path segment
+# spaces -> _, underscores -> __, hyphens -> --
+shields_encode() {
+  local s="$1"
+  s="${s//_/__}"
+  s="${s//-/--}"
+  s="${s// /_}"
+  printf '%s' "$s"
+}
+
 for plugin_dir in plugins/*/; do
   [[ ! -d "$plugin_dir" ]] && continue
   plugin_name=$(basename "$plugin_dir")
@@ -36,20 +46,27 @@ for plugin_dir in plugins/*/; do
     echo ""
     echo "$description"
     echo ""
-    echo "**Author:** $author"
-    echo ""
-    if [[ -n "$repo_url" ]]; then
-      echo "**Repository:** [$repo_url]($repo_url)"
-      echo ""
-    fi
+    # Build badge row
+    local_discord_link=""
     if [[ -n "$discord_thread" ]]; then
-      echo "**Discord:** [Discussion Thread]($discord_thread)"
-      echo ""
+      if [[ "$discord_thread" == https://discord.com/* ]]; then
+        local_discord_link="discord://${discord_thread#https://}"
+      else
+        local_discord_link="$discord_thread"
+      fi
     fi
+    badges="![Author](https://img.shields.io/badge/Author-$(shields_encode "$author")-grey?style=flat-square)"
     if [[ -n "$license" ]]; then
-      echo "**License:** [$license](https://spdx.org/licenses/${license}.html)"
-      echo ""
+      badges+=" [![License: $license](https://img.shields.io/badge/License-$(shields_encode "$license")-blue?style=flat-square)](https://spdx.org/licenses/${license}.html)"
     fi
+    if [[ -n "$local_discord_link" ]]; then
+      badges+=" [![Discord](https://img.shields.io/badge/Discord-Discussion_Thread-5865F2?style=flat-square&logo=discord&logoColor=white)]($local_discord_link)"
+    fi
+    if [[ -n "$repo_url" ]]; then
+      badges+=" [![Repository](https://img.shields.io/badge/GitHub-Repository-181717?style=flat-square&logo=github&logoColor=white)]($repo_url)"
+    fi
+    echo "$badges"
+    echo ""
     if [[ -n "$min_dispatcharr" || -n "$max_dispatcharr" ]]; then
       compat=""
       if [[ -n "$min_dispatcharr" && -n "$max_dispatcharr" ]]; then

--- a/.github/scripts/publish/plugin-readmes.sh
+++ b/.github/scripts/publish/plugin-readmes.sh
@@ -31,6 +31,7 @@ for plugin_dir in plugins/*/; do
   name=$(jq -r '.name' "$plugin_file")
   description=$(jq -r '.description' "$plugin_file")
   author=$(jq -r '.author // ""' "$plugin_file")
+  maintainers=$(jq -r '[.maintainers[]?] | join(", ")' "$plugin_file")
   repo_url=$(jq -r '.repo_url // empty' "$plugin_file")
   discord_thread=$(jq -r '.discord_thread // empty' "$plugin_file")
   license=$(jq -r '.license // ""' "$plugin_file")
@@ -67,16 +68,20 @@ for plugin_dir in plugins/*/; do
     fi
     echo "$badges"
     echo ""
+    if [[ -n "$maintainers" ]]; then
+      echo "**Maintainers:** $maintainers"
+      echo ""
+    fi
     if [[ -n "$min_dispatcharr" || -n "$max_dispatcharr" ]]; then
-      compat=""
-      if [[ -n "$min_dispatcharr" && -n "$max_dispatcharr" ]]; then
-        compat="$min_dispatcharr – $max_dispatcharr"
-      elif [[ -n "$min_dispatcharr" ]]; then
-        compat="$min_dispatcharr+"
-      else
-        compat="up to $max_dispatcharr"
+      compat_badges=""
+      if [[ -n "$min_dispatcharr" ]]; then
+        compat_badges="![Dispatcharr min](https://img.shields.io/badge/Dispatcharr_min-$(shields_encode "$min_dispatcharr")-brightgreen?style=flat-square)"
       fi
-      echo "**Dispatcharr Compatibility:** $compat"
+      if [[ -n "$max_dispatcharr" ]]; then
+        [[ -n "$compat_badges" ]] && compat_badges+=" "
+        compat_badges+="![Dispatcharr max](https://img.shields.io/badge/Dispatcharr_max-$(shields_encode "$max_dispatcharr")-orange?style=flat-square)"
+      fi
+      echo "$compat_badges"
       echo ""
     fi
     echo "## Downloads"

--- a/.github/scripts/publish/plugin-readmes.sh
+++ b/.github/scripts/publish/plugin-readmes.sh
@@ -53,14 +53,7 @@ for plugin_dir in plugins/*/; do
     echo "$description"
     echo ""
     # Build badge row
-    local_discord_link=""
-    if [[ -n "$discord_thread" ]]; then
-      if [[ "$discord_thread" == https://discord.com/* ]]; then
-        local_discord_link="discord://${discord_thread#https://}"
-      else
-        local_discord_link="$discord_thread"
-      fi
-    fi
+    local_discord_link="$discord_thread"
     badges=""
     if [[ -n "$license" ]]; then
       badges="[![License: $license](https://img.shields.io/badge/License-$(shields_encode "$license")-blue?style=flat-square)](https://spdx.org/licenses/${license}.html)"

--- a/.github/scripts/publish/releases-readme.sh
+++ b/.github/scripts/publish/releases-readme.sh
@@ -74,7 +74,7 @@ render_plugin() {
   fi
   if [[ -n "$discord_link" ]]; then
     [[ -n "$badges" ]] && badges+=" "
-    badges+="[![Discord](https://img.shields.io/badge/Discord-Discussion_Thread-5865F2?style=flat-square&logo=discord&logoColor=white)]($discord_link)"
+    badges+="[![Discord](https://img.shields.io/badge/Discord-Discussion-5865F2?style=flat-square&logo=discord&logoColor=white)]($discord_link)"
   fi
   if [[ -n "$repo_url" ]]; then
     [[ -n "$badges" ]] && badges+=" "
@@ -143,15 +143,11 @@ render_plugin() {
       version=$(jq -r '.version' "$plugin_file")
       author=$(jq -r '.author // ""' "$plugin_file")
       description=$(jq -r '.description' "$plugin_file")
-      table_license=$(jq -r '.license // ""' "$plugin_file")
+      table_license=$(jq -r '.license // "-"' "$plugin_file")
       anchor=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g')
       suffix=""
       [[ "$pass" == "deprecated" ]] && suffix=" (deprecated)"
-      if [[ -n "$table_license" ]]; then
-        license_cell="[![${table_license}](https://img.shields.io/badge/License-$(shields_encode "$table_license")-blue?style=flat-square)](https://spdx.org/licenses/${table_license}.html)"
-      else
-        license_cell="-"
-      fi
+      license_cell="${table_license}"
 
       echo "| [\`$name\`](#$anchor)$suffix | \`$version\` | $author | $license_cell | $description |"
     done

--- a/.github/scripts/publish/releases-readme.sh
+++ b/.github/scripts/publish/releases-readme.sh
@@ -12,6 +12,16 @@ set -e
 # Format an ISO8601 timestamp as "Mon DD, HH:MM UTC"
 fmt_date() { date -d "$1" -u +"%b %d %Y, %H:%M UTC" 2>/dev/null || echo "$1"; }
 
+# Encode a string for use in a shields.io badge path segment
+# spaces -> _, underscores -> __, hyphens -> --
+shields_encode() {
+  local s="$1"
+  s="${s//_/__}"
+  s="${s//-/--}"
+  s="${s// /_}"
+  printf '%s' "$s"
+}
+
 # Render a full plugin block (used in second pass)
 render_plugin() {
   local is_deprecated=$1
@@ -28,6 +38,8 @@ render_plugin() {
   local license=${12}
   local min_dispatcharr=${13}
   local max_dispatcharr=${14}
+  local repo_url=${15}
+  local discord_thread=${16}
 
   local zip_url="https://github.com/${GITHUB_REPOSITORY}/raw/$RELEASES_BRANCH/zips/${plugin_name}/${plugin_name}-latest.zip"
   local source_url="https://github.com/${GITHUB_REPOSITORY}/tree/$SOURCE_BRANCH/plugins/${plugin_name}"
@@ -47,8 +59,29 @@ render_plugin() {
   echo ""
   echo "$description"
   echo ""
+  # Build badges (license, discord, repo)
+  local discord_link=""
+  if [[ -n "$discord_thread" ]]; then
+    if [[ "$discord_thread" == https://discord.com/* ]]; then
+      discord_link="discord://${discord_thread#https://}"
+    else
+      discord_link="$discord_thread"
+    fi
+  fi
+  local badges=""
   if [[ -n "$license" ]]; then
-    echo "**License:** [$license](https://spdx.org/licenses/${license}.html)"
+    badges="[![License: $license](https://img.shields.io/badge/License-$(shields_encode "$license")-blue?style=flat-square)](https://spdx.org/licenses/${license}.html)"
+  fi
+  if [[ -n "$discord_link" ]]; then
+    [[ -n "$badges" ]] && badges+=" "
+    badges+="[![Discord](https://img.shields.io/badge/Discord-Discussion_Thread-5865F2?style=flat-square&logo=discord&logoColor=white)]($discord_link)"
+  fi
+  if [[ -n "$repo_url" ]]; then
+    [[ -n "$badges" ]] && badges+=" "
+    badges+="[![Repository](https://img.shields.io/badge/GitHub-Repository-181717?style=flat-square&logo=github&logoColor=white)]($repo_url)"
+  fi
+  if [[ -n "$badges" ]]; then
+    echo "$badges"
     echo ""
   fi
   if [[ -n "$min_dispatcharr" || -n "$max_dispatcharr" ]]; then
@@ -110,11 +143,15 @@ render_plugin() {
       version=$(jq -r '.version' "$plugin_file")
       author=$(jq -r '.author // ""' "$plugin_file")
       description=$(jq -r '.description' "$plugin_file")
-      table_license=$(jq -r '.license // "-"' "$plugin_file")
+      table_license=$(jq -r '.license // ""' "$plugin_file")
       anchor=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g')
       suffix=""
       [[ "$pass" == "deprecated" ]] && suffix=" (deprecated)"
-      license_cell="${table_license}"
+      if [[ -n "$table_license" ]]; then
+        license_cell="[![${table_license}](https://img.shields.io/badge/License-$(shields_encode "$table_license")-blue?style=flat-square)](https://spdx.org/licenses/${table_license}.html)"
+      else
+        license_cell="-"
+      fi
 
       echo "| [\`$name\`](#$anchor)$suffix | \`$version\` | $author | $license_cell | $description |"
     done
@@ -148,10 +185,12 @@ render_plugin() {
     plugin_license=$(jq -r '.license // ""' "$plugin_file")
     min_dispatcharr=$(jq -r '.min_dispatcharr_version // empty' "$plugin_file")
     max_dispatcharr=$(jq -r '.max_dispatcharr_version // empty' "$plugin_file")
+    repo_url=$(jq -r '.repo_url // ""' "$plugin_file")
+    discord_thread=$(jq -r '.discord_thread // ""' "$plugin_file")
 
     render_plugin "false" "$plugin_name" "$name" "$version" "$author" "$description" \
       "$maintainers" "$last_updated" "$commit_sha" "$commit_sha_short" "$version_count" "$plugin_license" \
-      "$min_dispatcharr" "$max_dispatcharr"
+      "$min_dispatcharr" "$max_dispatcharr" "$repo_url" "$discord_thread"
   done
 
   # Deprecated section (only if any exist)
@@ -195,10 +234,12 @@ render_plugin() {
       plugin_license=$(jq -r '.license // ""' "$plugin_file")
       min_dispatcharr=$(jq -r '.min_dispatcharr_version // empty' "$plugin_file")
       max_dispatcharr=$(jq -r '.max_dispatcharr_version // empty' "$plugin_file")
+      repo_url=$(jq -r '.repo_url // ""' "$plugin_file")
+      discord_thread=$(jq -r '.discord_thread // ""' "$plugin_file")
 
       render_plugin "true" "$plugin_name" "$name" "$version" "$author" "$description" \
         "$maintainers" "$last_updated" "$commit_sha" "$commit_sha_short" "$version_count" "$plugin_license" \
-        "$min_dispatcharr" "$max_dispatcharr"
+        "$min_dispatcharr" "$max_dispatcharr" "$repo_url" "$discord_thread"
     done
   fi
 

--- a/.github/scripts/publish/releases-readme.sh
+++ b/.github/scripts/publish/releases-readme.sh
@@ -85,15 +85,15 @@ render_plugin() {
     echo ""
   fi
   if [[ -n "$min_dispatcharr" || -n "$max_dispatcharr" ]]; then
-    compat=""
-    if [[ -n "$min_dispatcharr" && -n "$max_dispatcharr" ]]; then
-      compat="$min_dispatcharr – $max_dispatcharr"
-    elif [[ -n "$min_dispatcharr" ]]; then
-      compat="$min_dispatcharr+"
-    else
-      compat="up to $max_dispatcharr"
+    compat_badges=""
+    if [[ -n "$min_dispatcharr" ]]; then
+      compat_badges="![Dispatcharr min](https://img.shields.io/badge/Dispatcharr_min-$(shields_encode "$min_dispatcharr")-brightgreen?style=flat-square)"
     fi
-    echo "**Dispatcharr Compatibility:** $compat"
+    if [[ -n "$max_dispatcharr" ]]; then
+      [[ -n "$compat_badges" ]] && compat_badges+=" "
+      compat_badges+="![Dispatcharr max](https://img.shields.io/badge/Dispatcharr_max-$(shields_encode "$max_dispatcharr")-orange?style=flat-square)"
+    fi
+    echo "$compat_badges"
     echo ""
   fi
   echo "**Downloads:**"

--- a/.github/scripts/publish/releases-readme.sh
+++ b/.github/scripts/publish/releases-readme.sh
@@ -60,14 +60,7 @@ render_plugin() {
   echo "$description"
   echo ""
   # Build badges (license, discord, repo)
-  local discord_link=""
-  if [[ -n "$discord_thread" ]]; then
-    if [[ "$discord_thread" == https://discord.com/* ]]; then
-      discord_link="discord://${discord_thread#https://}"
-    else
-      discord_link="$discord_thread"
-    fi
-  fi
+  local discord_link="$discord_thread"
   local badges=""
   if [[ -n "$license" ]]; then
     badges="[![License: $license](https://img.shields.io/badge/License-$(shields_encode "$license")-blue?style=flat-square)](https://spdx.org/licenses/${license}.html)"


### PR DESCRIPTION
This pull request updates the plugin publishing scripts to improve the formatting and information in generated plugin README files, with a focus on richer badge displays and more complete metadata. The changes affect both `.github/scripts/publish/plugin-readmes.sh` and `.github/scripts/publish/releases-readme.sh`. The most important changes are:

**Badge and Formatting Enhancements:**

* Added a `shields_encode` helper function to properly encode badge labels for shields.io, ensuring that spaces, underscores, and hyphens are displayed correctly in badge URLs. [[1]](diffhunk://#diff-f4d4d6d4f13f6f5a107695b92a395bd1ea0edcb4ba6f81e52e2dabc5dfeaff48R15-R24) [[2]](diffhunk://#diff-4da60d462b885f20e76caae933dec1b18047a7f1fa2751569353bdce63032620R15-R24)
* Replaced plain-text metadata (like License, Discord, Repository, and Dispatcharr compatibility) with visually appealing shields.io badges in the plugin README output. [[1]](diffhunk://#diff-f4d4d6d4f13f6f5a107695b92a395bd1ea0edcb4ba6f81e52e2dabc5dfeaff48L37-R82) [[2]](diffhunk://#diff-4da60d462b885f20e76caae933dec1b18047a7f1fa2751569353bdce63032620R62-R89)

**Metadata Improvements:**

* Added new fields to the plugin manifest parsing, such as `maintainers`, `version`, and `last_updated` (the latter determined via git log), and included these in the README output for better traceability and context.
* Updated the footer of each plugin README to include a Maintainers section when available, and improved the Source link formatting.

**Script Consistency and Data Flow:**

* Modified the `render_plugin` function and its invocations in `releases-readme.sh` to accept and display the new `repo_url` and `discord_thread` fields, ensuring consistent badge and metadata display across both scripts. [[1]](diffhunk://#diff-4da60d462b885f20e76caae933dec1b18047a7f1fa2751569353bdce63032620R41-R42) [[2]](diffhunk://#diff-4da60d462b885f20e76caae933dec1b18047a7f1fa2751569353bdce63032620R177-R182) [[3]](diffhunk://#diff-4da60d462b885f20e76caae933dec1b18047a7f1fa2751569353bdce63032620R226-R231)