### PR TITLE
[repo]: Update manifest generation for unlisted & deprecated plugins

### DIFF
--- a/.github/scripts/publish/generate-manifest.sh
+++ b/.github/scripts/publish/generate-manifest.sh
@@ -110,8 +110,8 @@ for plugin_dir in plugins/*/; do
   [[ ! -f "$plugin_file" ]] && continue
   plugin_name=$(basename "$plugin_dir")
   plugin_key=${plugin_name//-/_}
-  is_unlisted=false
-  [[ "$(jq -r '.unlisted // false' "$plugin_file")" == "true" ]] && is_unlisted=true
+  unlisted=false
+  [[ "$(jq -r '.unlisted // false' "$plugin_file")" == "true" ]] && unlisted=true
 
   echo "  $plugin_name"
 
@@ -186,7 +186,7 @@ for plugin_dir in plugins/*/; do
   plugin_entries+=("$plugin_entry")
 
   # Unlisted plugins get a per-plugin manifest but are excluded from the root manifest
-  [[ "$is_unlisted" == "true" ]] && continue
+  [[ "$unlisted" == "true" ]] && continue
 
   # Compact root manifest entry
   desc_raw=$(jq -r '.description // ""' "$plugin_file")

--- a/.github/scripts/publish/generate-manifest.sh
+++ b/.github/scripts/publish/generate-manifest.sh
@@ -110,7 +110,8 @@ for plugin_dir in plugins/*/; do
   [[ ! -f "$plugin_file" ]] && continue
   plugin_name=$(basename "$plugin_dir")
   plugin_key=${plugin_name//-/_}
-  [[ "$(jq -r '.unlisted // false' "$plugin_file")" == "true" ]] && continue
+  is_unlisted=false
+  [[ "$(jq -r '.unlisted // false' "$plugin_file")" == "true" ]] && is_unlisted=true
 
   echo "  $plugin_name"
 
@@ -184,6 +185,9 @@ for plugin_dir in plugins/*/; do
   fi
   plugin_entries+=("$plugin_entry")
 
+  # Unlisted plugins get a per-plugin manifest but are excluded from the root manifest
+  [[ "$is_unlisted" == "true" ]] && continue
+
   # Compact root manifest entry
   desc_raw=$(jq -r '.description // ""' "$plugin_file")
   if [[ ${#desc_raw} -gt 200 ]]; then
@@ -203,6 +207,7 @@ for plugin_dir in plugins/*/; do
     --arg manifest_url "$plugin_manifest_url" \
     --arg author "$(jq -r '.author // ""' "$plugin_file")" \
     --arg license "$(jq -r '.license // ""' "$plugin_file")" \
+    --argjson deprecated "$(jq 'if .deprecated == true then true else null end' "$plugin_file")" \
     '{
       slug: $slug,
       name: $name,
@@ -210,6 +215,7 @@ for plugin_dir in plugins/*/; do
       manifest_url: $manifest_url,
       author: $author,
       license: (if $license != "" then $license else null end),
+      deprecated: $deprecated,
       last_updated: ($latest_metadata.last_updated // null),
       latest_version: ($latest_metadata.version // null),
       latest_md5: ($latest_metadata.checksum_md5 // null),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ At least one of `author` or `maintainers` must include your GitHub username. `au
 | `repo_url` | `string` | URL to the plugin's source repository (must start with `http://` or `https://`) |
 | `discord_thread` | `string` | URL to the associated Discord thread (must start with `http://` or `https://`) |
 | `deprecated` | `boolean` | Marks the plugin as deprecated. Default: `false` |
-| `unlisted` | `boolean` | Excludes the plugin from `manifest.json` and hides it from the releases README. Default: `false` |
+| `unlisted` | `boolean` | Excludes the plugin from the root `manifest.json` (and the releases README) but still generates a per-plugin manifest. Default: `false` |
 
 ### Full Example
 


### PR DESCRIPTION
This pull request updates the plugin manifest generation process to better handle "unlisted" and "deprecated" plugins, and clarifies related documentation. The changes ensure that unlisted plugins are still provided with individual manifests but are excluded from the root manifest, and that deprecated status is explicitly included in manifest entries.

**Manifest generation improvements:**

* Unlisted plugins now get their own per-plugin manifest but are excluded from the root `manifest.json`, improving discoverability control without losing metadata for individual plugins. [[1]](diffhunk://#diff-9782b74083e0d3f4c84ace1744d2b5b217c07f96842aaa01ba54eef4a37e1115L113-R114) [[2]](diffhunk://#diff-9782b74083e0d3f4c84ace1744d2b5b217c07f96842aaa01ba54eef4a37e1115R188-R190)
* The `deprecated` field is now explicitly included in the generated manifest entries, allowing clients to easily detect deprecated plugins.

**Documentation updates:**

* The description of the `unlisted` field in `CONTRIBUTING.md` is clarified to specify that unlisted plugins are excluded from the root manifest but still receive a per-plugin manifest.