### PR TITLE
[repo] fix codeql-analyze bash -e abort on pure-Python plugin submissions

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -425,12 +425,12 @@ jobs:
             echo "found=true" >> "$GITHUB_OUTPUT"
             echo "languages=$LANG_CSV" >> "$GITHUB_OUTPUT"
             echo "Detected languages for CodeQL: $LANG_CSV"
-            [[ -n "$UNSCANNED_CSV" ]] && echo "Unscanned (no CodeQL support): $UNSCANNED_CSV"
+            if [[ -n "$UNSCANNED_CSV" ]]; then echo "Unscanned (no CodeQL support): $UNSCANNED_CSV"; fi
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
             echo "languages=" >> "$GITHUB_OUTPUT"
             echo "No supported language files found in changed plugins - skipping CodeQL."
-            [[ -n "$UNSCANNED_CSV" ]] && echo "Unscanned file types detected (no CodeQL support): $UNSCANNED_CSV"
+            if [[ -n "$UNSCANNED_CSV" ]]; then echo "Unscanned file types detected (no CodeQL support): $UNSCANNED_CSV"; fi
           fi
 
       - name: Get merge commit SHA


### PR DESCRIPTION
## Problem

The `codeql-analyze` job's "Detect supported languages" step runs under `bash -e` and aborts whenever a plugin contains only CodeQL-supported language files (no shell/php/lua/perl/rust files to populate `UNSCANNED_CSV`).

The failing line:

```bash
[[ -n "$UNSCANNED_CSV" ]] && echo "Unscanned (no CodeQL support): $UNSCANNED_CSV"
```

When `UNSCANNED_CSV` is empty, `[[ -n "" ]]` returns exit 1. The `&&` short-circuits; the entire compound line returns 1; `bash -e` aborts the script. The step fails with `Process completed with exit code 1` **after** language detection has already succeeded.

This pattern appears twice in the step — once in the `if` branch and once in the `else` branch.

## Reproducer

PR #34 ([epg-janitor]) — Python-only plugin. Run log shows:
```
Detected languages for CodeQL: python
##[error]Process completed with exit code 1.
```

Last successful pure-Python plugin submission before #33 (which introduced the enhanced detection script): channel-mapparr (2026-04-10 15:57), which passed CI with the prior workflow.

## Fix

Replace the `[[ condition ]] && echo` idiom (which is unsafe under `bash -e` when the condition can be false) with an explicit `if` block. Same behavior; no spurious non-zero exit when `UNSCANNED_CSV` is empty.

Two-line change in `.github/workflows/validate-plugin.yml`.

## Impact

Unblocks all pure-Python plugin submissions currently stuck in CI (PR #34 et al.).