### PR TITLE
[repo]: Fix output handling for unscanned file types in validate-plugin workflow

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -425,12 +425,12 @@ jobs:
             echo "found=true" >> "$GITHUB_OUTPUT"
             echo "languages=$LANG_CSV" >> "$GITHUB_OUTPUT"
             echo "Detected languages for CodeQL: $LANG_CSV"
-            [[ -n "$UNSCANNED_CSV" ]] && echo "Unscanned (no CodeQL support): $UNSCANNED_CSV"
+            if [[ -n "$UNSCANNED_CSV" ]]; then echo "Unscanned (no CodeQL support): $UNSCANNED_CSV"; fi
           else
             echo "found=false" >> "$GITHUB_OUTPUT"
             echo "languages=" >> "$GITHUB_OUTPUT"
             echo "No supported language files found in changed plugins - skipping CodeQL."
-            [[ -n "$UNSCANNED_CSV" ]] && echo "Unscanned file types detected (no CodeQL support): $UNSCANNED_CSV"
+            if [[ -n "$UNSCANNED_CSV" ]]; then echo "Unscanned file types detected (no CodeQL support): $UNSCANNED_CSV"; fi
           fi
 
       - name: Get merge commit SHA


### PR DESCRIPTION
The "Detect supported languages" step ran under bash -e, so [[ -n "$UNSCANNED_CSV" ]] && echo "..." would exit non-zero when UNSCANNED_CSV was empty, causing the step to fail. Replaced the two &&-guarded echo lines with proper if blocks so the step always exits cleanly.