### PR TITLE
[lineuparr]: Update to v1.26.1091027

### DIFF
--- a/plugins/lineuparr/AU_Foxtel_lineup.json
+++ b/plugins/lineuparr/AU_Foxtel_lineup.json
@@ -1,0 +1,180 @@
+{
+  "package": "Foxtel Platinum Plus",
+  "date": "2026-04-10",
+  "description": "Foxtel Platinum Plus AU lineup with sports, movies, and entertainment add-on packs",
+  "source": "Foxtel Channel Lineup",
+  "notes": "Lineup excludes local network affiliates and their digital multi-channels (Seven, Nine, Ten, ABC, SBS). High-definition (HD) swaps are applied where available. Some channels are delivered over the internet or as on-demand services as noted. Regional availability of free-to-air channels may vary by postcode.",
+  "categories": {
+    "News": [
+      { "name": "Sky News", "number": 103 },
+      { "name": "Sky News HD", "number": 600 },
+      { "name": "Sky News Weather", "number": 601 },
+      { "name": "Sky News Extra", "number": 603 },
+      { "name": "Sky News UK", "number": 604 },
+      { "name": "Fox News Channel", "number": 608 },
+      { "name": "CNN International", "number": 609 },
+      { "name": "MS NOW", "number": 612 },
+      { "name": "NBC News NOW", "number": 613 },
+      { "name": "CNBC", "number": 620 },
+      { "name": "Bloomberg Television", "number": 621 },
+      { "name": "ABC News", "number": 642 },
+      { "name": "SBS WorldWatch", "number": 644 },
+      { "name": "Al Jazeera English", "number": 651 },
+      { "name": "CGTN", "number": 653 },
+      { "name": "NHK World", "number": 656 },
+      { "name": "GB News", "number": 658 }
+    ],
+    "Sports": [
+      { "name": "Fox Sports News", "number": 500 },
+      { "name": "Fox Cricket", "number": 501, "addon": "Sports" },
+      { "name": "Fox League", "number": 502, "addon": "Sports" },
+      { "name": "Fox Sports 503", "number": 503, "addon": "Sports" },
+      { "name": "Fox Footy", "number": 504, "addon": "Sports" },
+      { "name": "Fox Sports 505", "number": 505, "addon": "Sports" },
+      { "name": "Fox Sports 506", "number": 506, "addon": "Sports" },
+      { "name": "Fox Sports More+", "number": 507, "addon": "Sports" },
+      { "name": "ESPN", "number": 509, "addon": "Sports" },
+      { "name": "ESPN2", "number": 510, "addon": "Sports" },
+      { "name": "Main Event", "number": 522, "notes": "Pay-per-view" },
+      { "name": "Main Event UFC", "number": 523 },
+      { "name": "Sky Racing 1", "number": 526 },
+      { "name": "Sky Racing 2", "number": 527 },
+      { "name": "Sky Thoroughbred Central", "number": 528 },
+      { "name": "Racing.com", "number": 529 },
+      { "name": "Fox Sports Ultra HD", "number": 592, "addon": "Sports", "notes": "Channels 592-595" }
+    ],
+    "Regional Sports": [],
+    "Movies": [
+      { "name": "Movies 4K Ultra HD", "number": 400, "addon": "Movies" },
+      { "name": "Movies Premiere", "number": 401, "addon": "Movies" },
+      { "name": "Movies Hits", "number": 402, "addon": "Movies" },
+      { "name": "Movies Family", "number": 403, "addon": "Movies" },
+      { "name": "Movies Action", "number": 405, "addon": "Movies" },
+      { "name": "Movies Comedy", "number": 406, "addon": "Movies" },
+      { "name": "Movies Romance", "number": 408, "addon": "Movies" },
+      { "name": "Movies Drama", "number": 409, "addon": "Movies" },
+      { "name": "Movies Greats", "number": 410, "addon": "Movies" },
+      { "name": "British Cinema", "number": 413 },
+      { "name": "Aussie Classics", "number": 414 },
+      { "name": "PULP", "number": 415, "addon": "Movies" },
+      { "name": "SBS World Movies", "number": 433 },
+      { "name": "More Movies", "number": 424, "addon": "Movies", "notes": "On-demand" }
+    ],
+    "Kids": [
+      { "name": "DreamWorks", "number": 717 }
+    ],
+    "Entertainment": [
+      { "name": "Foxtel One", "number": 101 },
+      { "name": "BBC UKTV", "number": 105 },
+      { "name": "FOX8", "number": 108 },
+      { "name": "Showcase", "number": 112 },
+      { "name": "Classics", "number": 117 },
+      { "name": "British", "number": 118 },
+      { "name": "Universal TV", "number": 120 },
+      { "name": "Foxtel Pop Up", "number": 128 },
+      { "name": "More Drama", "number": 145, "notes": "On-demand" },
+      { "name": "More British", "number": 146, "notes": "On-demand" },
+      { "name": "More Classics", "number": 147, "notes": "On-demand" },
+      { "name": "BoxSets", "number": 150 },
+      { "name": "Aurora Community Channel", "number": 173 },
+      { "name": "NITV", "number": 172 }
+    ],
+    "Reality & Lifestyle": [
+      { "name": "Lifestyle", "number": 106 },
+      { "name": "Arena", "number": 111 },
+      { "name": "Real Life", "number": 121 },
+      { "name": "TLC", "number": 123 },
+      { "name": "LifeStyle Home", "number": 126 },
+      { "name": "More Lifestyle", "number": 127, "notes": "On-demand" },
+      { "name": "Fashion TV", "number": 151 }
+    ],
+    "Comedy": [
+      { "name": "Comedy", "number": 114 },
+      { "name": "Seinfeld", "number": 115 },
+      { "name": "More Comedy", "number": 144, "notes": "On-demand" }
+    ],
+    "Discovery": [
+      { "name": "DocPlay Channel", "number": 119 },
+      { "name": "Real History", "number": 130 },
+      { "name": "Trace Sport Stars", "number": 132 },
+      { "name": "Discovery", "number": 133 },
+      { "name": "Nature Time", "number": 134 },
+      { "name": "HauntTV", "number": 137 },
+      { "name": "Love Pets", "number": 138 },
+      { "name": "More Docos", "number": 140, "notes": "On-demand" },
+      { "name": "Animal Planet", "number": 141 },
+      { "name": "Discovery Turbo", "number": 143 },
+      { "name": "CGTN Documentary", "number": 654 }
+    ],
+    "Crime": [
+      { "name": "Crime", "number": 113 },
+      { "name": "Real Crime", "number": 135 },
+      { "name": "Investigation Discovery", "number": 136 }
+    ],
+    "Faith": [
+      { "name": "GOOD.", "number": 182 },
+      { "name": "Daystar", "number": 185 },
+      { "name": "SBN", "number": 186 }
+    ],
+    "Music": [
+      { "name": "Trending", "number": 801 },
+      { "name": "Kids Music", "number": 802 },
+      { "name": "Club", "number": 803 },
+      { "name": "Retro", "number": 804 },
+      { "name": "CMC", "number": 805 },
+      { "name": "Max", "number": 806 },
+      { "name": "Australian Played", "number": 807 },
+      { "name": "Vevo Pop", "number": 810 },
+      { "name": "Vevo 2K", "number": 811 },
+      { "name": "Vevo '90s", "number": 812 },
+      { "name": "Vevo '70s", "number": 813 },
+      { "name": "Vevo Retro Rock", "number": 814 },
+      { "name": "Vevo Country", "number": 815 },
+      { "name": "Good Vibes", "number": 830, "notes": "Audio" },
+      { "name": "Triple M 70s", "number": 831, "notes": "Audio" },
+      { "name": "Oldskool 80s Hits", "number": 832, "notes": "Audio" },
+      { "name": "Triple M 90s", "number": 833, "notes": "Audio" },
+      { "name": "Triple M 2000s", "number": 834, "notes": "Audio" },
+      { "name": "Almost Acoustic", "number": 835, "notes": "Audio" },
+      { "name": "Rock 'n' Road Trip", "number": 836, "notes": "Audio" },
+      { "name": "Triple M Classic Rock", "number": 837, "notes": "Audio" },
+      { "name": "Indie & Alt", "number": 838, "notes": "Audio" },
+      { "name": "60s Hits", "number": 839, "notes": "Audio" },
+      { "name": "Blender Beats", "number": 840, "notes": "Audio" },
+      { "name": "Triple M 80s", "number": 841, "notes": "Audio" },
+      { "name": "Almost Acoustic Pop", "number": 842, "notes": "Audio" },
+      { "name": "Easy Hits", "number": 843, "notes": "Audio" },
+      { "name": "Deep Calm", "number": 844, "notes": "Audio" },
+      { "name": "RnB Chill", "number": 845, "notes": "Audio" },
+      { "name": "Chill Pop Hits", "number": 847, "notes": "Audio" },
+      { "name": "Oldskool 90s Hits", "number": 848, "notes": "Audio" },
+      { "name": "Top 30", "number": 851, "notes": "Audio" },
+      { "name": "90s Soft Pop", "number": 852, "notes": "Audio" },
+      { "name": "RnB Fridays Radio", "number": 853, "notes": "Audio" },
+      { "name": "Dance Hits", "number": 854, "notes": "Audio" },
+      { "name": "2010s", "number": 855, "notes": "Audio" },
+      { "name": "Triple M Country", "number": 856, "notes": "Audio" },
+      { "name": "Country Classics", "number": 857, "notes": "Audio" },
+      { "name": "BBC World Service", "number": 858, "notes": "Audio" },
+      { "name": "SBS Radio 1", "number": 867, "notes": "Audio" },
+      { "name": "SBS Radio 2", "number": 868, "notes": "Audio" },
+      { "name": "SBS Chill", "number": 869, "notes": "Audio" },
+      { "name": "Easy 97.2", "number": 940, "addon": "Antenna Pacific", "notes": "Audio" },
+      { "name": "Rai Radio 1", "number": 943, "addon": "RAI International", "notes": "Audio" }
+    ],
+    "Shopping": [
+      { "name": "TVSN", "number": 176 }
+    ],
+    "Spanish": [
+      { "name": "Antenna Pacific", "number": 941, "addon": "Antenna Pacific", "notes": "Greek" },
+      { "name": "Rai Italia", "number": 942, "addon": "RAI International", "notes": "Italian" }
+    ],
+    "Outdoors": [
+      { "name": "Outdoor Channel", "number": 131 }
+    ],
+    "Food & Travel": [
+      { "name": "LifeStyle Food", "number": 125 },
+      { "name": "SBS Food", "number": 171 }
+    ]
+  }
+}

--- a/plugins/lineuparr/fuzzy_matcher.py
+++ b/plugins/lineuparr/fuzzy_matcher.py
@@ -60,6 +60,76 @@ MISC_PATTERNS = [
     r'\s*\([^)]*\)\s*',
 ]
 
+# ISO-2 country codes Lineuparr lineup filenames use (keep in sync with
+# PROVIDER_PREFIX_PATTERNS above and PluginConfig.COUNTRY_DIR_MAP).
+_KNOWN_COUNTRY_CODES = {
+    "US", "UK", "CA", "AU", "DE", "FR", "IT", "ES", "NL", "BR", "MX", "IN",
+    "IE", "SE", "NO", "DK", "PT", "PL", "AT", "CH", "BE", "FI",
+}
+
+# ISO-3 or colloquial codes seen in M3U streams → ISO-2.
+_ISO3_TO_ISO2 = {
+    "USA": "US", "MEX": "MX", "IRE": "IE", "GER": "DE", "FRA": "FR",
+    "ITA": "IT", "ESP": "ES", "NLD": "NL", "BRA": "BR", "IND": "IN",
+}
+
+# (PLUTO <COUNTRY>) full-name variants seen in the M3U.
+_PLUTO_COUNTRY_MAP = {
+    "USA": "US", "US": "US", "UK": "UK",
+    "BRAZIL": "BR", "SWEDEN": "SE", "NORWAY": "NO", "DENMARK": "DK",
+    "GERMANY": "DE", "SPAIN": "ES", "FRANCE": "FR", "ITALY": "IT",
+    "CANADA": "CA", "MEXICO": "MX", "INDIA": "IN", "IRELAND": "IE",
+    "AUSTRALIA": "AU", "NETHERLANDS": "NL",
+    # "LATIN"/"EUROPE" etc. intentionally omitted — ambiguous region.
+}
+
+# Country pairs that share enough cross-border channels (CBS, ABC, ESPN, A&E,
+# TSN, etc.) that users consider them interchangeable. A US lineup should still
+# accept a `(CA) ESPN` stream and vice versa.
+_COMPATIBLE_COUNTRIES = {
+    "US": {"CA"},
+    "CA": {"US"},
+}
+
+
+def _normalize_country_token(tok):
+    """Map a raw prefix token to a whitelisted ISO-2 code, else None."""
+    tok = tok.upper()
+    if tok in _KNOWN_COUNTRY_CODES:
+        return tok
+    mapped = _ISO3_TO_ISO2.get(tok)
+    return mapped if mapped in _KNOWN_COUNTRY_CODES else None
+
+
+def detect_stream_country(name):
+    """Detect ISO-2 country code from a stream name's leading prefix marker.
+
+    Recognizes: `(US) ...`, `(USA) ...`, `US: ...`, `MEX: ...`, `(PLUTO UK) ...`
+    (case-insensitive).
+    Returns None when no recognized marker is present (so callers can accept
+    unlabeled streams). Also returns None for look-alike prefixes like `NBC`
+    or `FOX` that match the shape but aren't in the country whitelist.
+    """
+    if not name:
+        return None
+
+    # Pluto path uses its own full-country-name map rather than _normalize_country_token
+    # (which reads _ISO3_TO_ISO2). The whitelist intersection is still enforced here.
+    m = re.match(r'^\s*\(\s*PLUTO\s+([A-Za-z]+)\s*\)', name, re.IGNORECASE)
+    if m:
+        mapped = _PLUTO_COUNTRY_MAP.get(m.group(1).upper())
+        return mapped if mapped in _KNOWN_COUNTRY_CODES else None
+
+    m = re.match(r'^\s*\(\s*([A-Za-z]{2,3})\s*\)', name)
+    if m:
+        return _normalize_country_token(m.group(1))
+
+    m = re.match(r'^\s*([A-Za-z]{2,3})\s*[:|]', name)
+    if m:
+        return _normalize_country_token(m.group(1))
+
+    return None
+
 
 class FuzzyMatcher:
     """Handles fuzzy matching for Lineuparr with alias support and channel number boosting."""
@@ -71,6 +141,10 @@ class FuzzyMatcher:
         self._norm_cache = {}  # raw_name -> normalized_lower
         self._norm_nospace_cache = {}  # raw_name -> normalized_nospace
         self._processed_cache = {}  # raw_name -> processed_for_matching
+        # Cumulative count of candidates dropped by the country filter across
+        # match_all_streams calls. Callers reset this before a matching loop
+        # and read it after, so they can log a summary.
+        self.country_filter_drops = 0
 
     def precompute_normalizations(self, names, user_ignored_tags=None):
         """
@@ -365,8 +439,12 @@ class FuzzyMatcher:
             effective_threshold = self._length_scaled_threshold(self.match_threshold, best_alias_len)
 
             if score >= effective_threshold and score < 100:
-                need_majority = score < 90
-                if not self._has_token_overlap(best_alias_norm, candidate_lower, require_majority=need_majority):
+                # Aliases are short/curated — a fuzzy alias match must share a
+                # majority of tokens, not just one. This rejects false positives
+                # like alias "ABC News" vs stream "BBC News" (93%, shares only
+                # "news"; the 3-char call sign "abc"/"bbc" is below the basic
+                # overlap guard's 4-char token floor).
+                if not self._has_token_overlap(best_alias_norm, candidate_lower, require_majority=True):
                     continue
 
             if score >= effective_threshold:
@@ -436,8 +514,7 @@ class FuzzyMatcher:
                             sub_score = int(sub_ratio * 100)
                             shorter_len = min(len(normalized_query_lower), len(candidate_lower))
                             effective_threshold = self._length_scaled_threshold(self.match_threshold, shorter_len)
-                            need_majority = sub_score < 90
-                            if sub_score >= effective_threshold and self._has_token_overlap(normalized_query_lower, candidate_lower, require_majority=need_majority):
+                            if sub_score >= effective_threshold and self._has_token_overlap(normalized_query_lower, candidate_lower, require_majority=True):
                                 best_match = candidate
                                 best_ratio = sub_ratio
                                 best_match_type = "substring"
@@ -469,14 +546,13 @@ class FuzzyMatcher:
         if percentage_score >= self.match_threshold:
             shorter_len = min(len(processed_query), len(best_fuzzy_proc_candidate))
             effective_threshold = self._length_scaled_threshold(self.match_threshold, shorter_len)
-            need_majority = percentage_score < 90
-            if percentage_score >= effective_threshold and self._has_token_overlap(processed_query, best_fuzzy_proc_candidate, require_majority=need_majority):
+            if percentage_score >= effective_threshold and self._has_token_overlap(processed_query, best_fuzzy_proc_candidate, require_majority=True):
                 return best_fuzzy, percentage_score, f"fuzzy ({percentage_score})"
 
         return None, 0, None
 
     def match_all_streams(self, lineup_name, candidate_names, alias_map, channel_number=None,
-                          user_ignored_tags=None):
+                          user_ignored_tags=None, lineup_country=None):
         """
         Full matching pipeline for Lineuparr: alias → exact → substring → fuzzy, with number boost.
         Returns ALL matching streams sorted by score.
@@ -544,8 +620,7 @@ class FuzzyMatcher:
                             sub_score = int(ratio * 100)
                             shorter_len = min(len(normalized_query_lower), len(candidate_lower))
                             sub_threshold = self._length_scaled_threshold(self.match_threshold, shorter_len)
-                            need_majority = sub_score < 90
-                            if sub_score >= sub_threshold and self._has_token_overlap(normalized_query_lower, candidate_lower, require_majority=need_majority):
+                            if sub_score >= sub_threshold and self._has_token_overlap(normalized_query_lower, candidate_lower, require_majority=True):
                                 score = sub_score
                                 mtype = "substring"
 
@@ -557,8 +632,7 @@ class FuzzyMatcher:
                         fuzzy_score = int(ratio * 100)
                         shorter_len = min(len(processed_query), len(processed_candidate))
                         fuzzy_threshold = self._length_scaled_threshold(self.match_threshold, shorter_len)
-                        need_majority = fuzzy_score < 90
-                        if fuzzy_score >= fuzzy_threshold and self._has_token_overlap(processed_query, processed_candidate, require_majority=need_majority):
+                        if fuzzy_score >= fuzzy_threshold and self._has_token_overlap(processed_query, processed_candidate, require_majority=True):
                             score = fuzzy_score
                             mtype = f"fuzzy ({fuzzy_score})"
 
@@ -566,6 +640,28 @@ class FuzzyMatcher:
                     # Apply channel number boost
                     boost = self._channel_number_boost(candidate, channel_number)
                     all_matches[candidate] = (min(score + boost, 100), mtype)
+
+        # Filter out wrong-country matches. A stream whose name carries a
+        # recognized country marker (e.g. "UK: Discovery Channel", "(IN) Bloomberg",
+        # "(PLUTO Brazil) MTV") and that marker differs from the lineup's country
+        # is dropped. Streams without a country marker are kept — we can't prove
+        # they're wrong and over-filtering breaks lineups whose M3U sources don't
+        # tag country at all. Countries in _COMPATIBLE_COUNTRIES (US↔CA) are
+        # treated as a single compatibility class.
+        if lineup_country:
+            lc = lineup_country.upper()
+            # Defensive: if caller passes an unrecognized code, skip filtering
+            # rather than drop every country-marked candidate.
+            if lc in _KNOWN_COUNTRY_CODES:
+                accepted = _COMPATIBLE_COUNTRIES.get(lc, set()) | {lc}
+                kept = {}
+                for name, val in all_matches.items():
+                    sc = detect_stream_country(name)
+                    if sc is None or sc in accepted:
+                        kept[name] = val
+                    else:
+                        self.country_filter_drops += 1
+                all_matches = kept
 
         # Filter out wrong-region matches (East vs West vs Pacific)
         # Check both normalized query AND original name for regional indicators.
@@ -579,7 +675,11 @@ class FuzzyMatcher:
         _has_abbrev_pacific = bool(re.search(r'\(\s*p\s*\)', original_lower))
         query_has_east = "east" in query_lower or _has_abbrev_east
         query_has_west = ("west" in query_lower and "western" not in query_lower) or _has_abbrev_west
-        query_has_pacific = "pacific" in query_lower or _has_abbrev_pacific
+        # REGIONAL_PATTERNS strips the full word "pacific" during normalize_name
+        # (unlike east/west which are preserved), so we must detect it from the
+        # original lineup name. Without this, "Sportsnet Pacific" normalizes to
+        # "Sportsnet" and wrongly matches a regionless "Sportsnet" stream.
+        query_has_pacific = ("pacific" in original_lower) or _has_abbrev_pacific
 
         if query_has_east or query_has_west or query_has_pacific:
             filtered = {}

--- a/plugins/lineuparr/plugin.json
+++ b/plugins/lineuparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Lineuparr",
-  "version": "1.26.9520",
+  "version": "1.26.1091027",
   "description": "Mirror real-world provider channel lineups by creating channel groups, channels, and fuzzy-matching IPTV streams to them.",
   "author": "PiratesIRC",
   "license": "MIT",
@@ -42,6 +42,24 @@
         { "value": "strict", "label": "Strict \u2014 fewer matches, high confidence" },
         { "value": "exact", "label": "Exact \u2014 near-exact matches only" }
       ]
+    },
+    {
+      "id": "channel_numbering",
+      "label": "Channel Numbering",
+      "type": "select",
+      "default": "lineup",
+      "options": [
+        { "value": "lineup", "label": "Use Channel Database Numbers" },
+        { "value": "auto_next", "label": "Auto-Assign Next Available" },
+        { "value": "auto_highest", "label": "Auto-Assign After Highest" },
+        { "value": "specific", "label": "Use Specific Number" }
+      ]
+    },
+    {
+      "id": "starting_channel_number",
+      "label": "Starting Channel Number",
+      "type": "string",
+      "default": ""
     },
     {
       "id": "prioritize_quality",

--- a/plugins/lineuparr/plugin.py
+++ b/plugins/lineuparr/plugin.py
@@ -47,12 +47,27 @@ LOGGER.setLevel(logging.DEBUG)
 LOG_PREFIX = "[Lineuparr]"
 
 
+# BOM + zero-width characters that sneak in from rich-text paste (editors,
+# Slack/Discord, web docs). Python's str.strip() treats none of these as
+# whitespace, so they survive `.strip()` and trip json.loads with
+# "Expecting value: line 1 column 1 (char 0)".
+_INVISIBLE_CHARS = "\ufeff\u200b\u200c\u200d\u2060"
+
+
+def _clean_json_text(s):
+    """Strip whitespace and invisible paste artifacts from a JSON blob."""
+    if not s:
+        return ""
+    return s.strip().strip(_INVISIBLE_CHARS).strip()
+
+
 class PluginConfig:
-    PLUGIN_VERSION = "1.26.9520"
+    PLUGIN_VERSION = "1.26.1091027"
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True
     DEFAULT_RATE_LIMITING = "none"
+    DEFAULT_CHANNEL_NUMBERING = "lineup"
 
     RATE_LIMIT_NONE = 0.0
     RATE_LIMIT_LOW = 0.1
@@ -100,6 +115,15 @@ class PluginConfig:
         "Kids & Family": ["Kids", "Faith"],
         "Foreign Language": ["Spanish", "French"],
         "Music & Shopping": ["Music", "Shopping"],
+    }
+
+    REFINED_CATEGORIES = {
+        "News": ["News"],
+        "Sports": ["Sports", "Regional Sports"],
+        "Movies": ["Movies"],
+        "Family": ["Kids", "Faith"],
+        "Foreign": ["Spanish", "French"],
+        "Entertainment": ["Entertainment", "Reality & Lifestyle", "Comedy", "Discovery", "Crime", "Music", "Shopping", "Outdoors", "Food & Travel"],
     }
 
     CHANNEL_QUALITY_TAG_ORDER = ["[4K]", "[UHD]", "[FHD]", "[HD]", "[SD]", "[Unknown]", "[Slow]", ""]
@@ -305,10 +329,11 @@ class Plugin:
                 "default": "normal",
                 "options": [
                     {"value": "none", "label": "None - single group (prefix only, no categories)"},
-                    {"value": "simple", "label": "Simple - merged categories (News & Info, Sports & Outdoors, etc.)"},
+                    {"value": "refined", "label": "Refined - 6 broad categories (News, Sports, Movies, Family, Foreign, Entertainment)"},
+                    {"value": "simple", "label": "Simple - 7 merged categories (News & Info, Sports & Outdoors, etc.)"},
                     {"value": "normal", "label": "Normal - all individual categories"},
                 ],
-                "help_text": "Controls how lineup categories are grouped. Simple merges 16 categories into 7.",
+                "help_text": "Controls how lineup categories are grouped. Refined merges into 6, Simple into 7, Normal keeps all original categories.",
             },
             {
                 "id": "match_sensitivity",
@@ -322,6 +347,26 @@ class Plugin:
                     {"value": "exact", "label": "Exact - near-exact matches only"},
                 ],
                 "help_text": "How closely stream and EPG names must match channel names. Lower = more matches but more errors.",
+            },
+            {
+                "id": "channel_numbering",
+                "label": "Channel Numbering",
+                "type": "select",
+                "default": "lineup",
+                "options": [
+                    {"value": "lineup", "label": "Use Channel Database Numbers"},
+                    {"value": "auto_next", "label": "Auto-Assign Next Available"},
+                    {"value": "auto_highest", "label": "Auto-Assign After Highest"},
+                    {"value": "specific", "label": "Use Specific Number"},
+                ],
+                "help_text": "How to assign channel numbers. Database uses tvg-chno/channel-number from stream metadata with auto-assign fallback. Auto modes find open slots. Specific starts from your chosen number.",
+            },
+            {
+                "id": "starting_channel_number",
+                "label": "Starting Channel Number",
+                "type": "string",
+                "default": "",
+                "help_text": "Starting channel number for 'Use Specific Number' mode. Channels are numbered sequentially from this value.",
             },
             {
                 "id": "prioritize_quality",
@@ -476,23 +521,24 @@ class Plugin:
             result["categories"] = {"All": all_channels}
             return result
 
-        if detail == "simple":
-            # Merge into simplified categories
-            simplified = {}
+        if detail in ("simple", "refined"):
+            # Merge into simplified/refined categories
+            cat_map = PluginConfig.REFINED_CATEGORIES if detail == "refined" else PluginConfig.SIMPLIFIED_CATEGORIES
+            merged_cats = {}
             mapped_originals = set()
-            for simple_name, originals in PluginConfig.SIMPLIFIED_CATEGORIES.items():
+            for group_name, originals in cat_map.items():
                 merged = []
                 for orig in originals:
                     if orig in original_cats:
                         merged.extend(original_cats[orig])
                         mapped_originals.add(orig)
                 if merged:
-                    simplified[simple_name] = merged
+                    merged_cats[group_name] = merged
             # Preserve any categories not in the mapping
             for orig_name, channels in original_cats.items():
                 if orig_name not in mapped_originals and channels:
-                    simplified[orig_name] = channels
-            result["categories"] = simplified
+                    merged_cats[orig_name] = channels
+            result["categories"] = merged_cats
             return result
 
         # Unknown detail value - treat as normal
@@ -507,11 +553,35 @@ class Plugin:
             return match.group(1), match.group(2)
         return None, None
 
+    @staticmethod
+    def _extract_epg_country(tvg_id):
+        """Extract 2-letter country code from a tvg_id like 'CNN.us' or 'CNN.US_source1'.
+        Returns lowercase country code or None."""
+        if not tvg_id:
+            return None
+        m = re.match(r'^.+\.([a-zA-Z]{2})(?:_.*)?$', tvg_id)
+        return m.group(1).lower() if m else None
+
+    @staticmethod
+    def _pick_epg_by_country(entries, country_code):
+        """From a list of EPG entries for the same name, prefer the one matching country_code.
+        Falls back to first entry if no country match found."""
+        if not entries:
+            return None
+        if not country_code:
+            return entries[0]
+        cc = country_code.lower()
+        for e in entries:
+            epg_cc = Plugin._extract_epg_country(e.get('tvg_id', ''))
+            if epg_cc == cc:
+                return e
+        return entries[0]
+
     def _get_group_prefix(self, settings, lineup_data):
         """Get the group prefix (user override or auto from lineup package name).
         'none' = no prefix (category names only). Blank = auto from package.
         Trailing separators preserved so 'US ' gives 'US News', not 'US: News'."""
-        prefix = settings.get("group_prefix", "").lstrip()
+        prefix = (settings.get("group_prefix") or "").lstrip()
         if prefix.strip().lower() == "none":
             return ""
         if prefix.strip():
@@ -541,6 +611,60 @@ class Plugin:
         # Return as-is for other formats (let Django handle/reject it)
         return raw
 
+    @staticmethod
+    def _resolve_numbering_mode(settings):
+        """Resolve the effective numbering mode, with backwards compatibility."""
+        mode = settings.get("channel_numbering", PluginConfig.DEFAULT_CHANNEL_NUMBERING)
+        if settings.get("ignore_channel_numbers") is True:
+            mode = "auto_next"
+        return mode
+
+    def _get_channel_number(self, settings, entry, assigner_state):
+        """Get the channel number for a lineup entry based on the channel_numbering setting.
+
+        assigner_state is a dict with 'next' key tracking the next number to assign.
+        It must be initialized before the first call using _init_assigner_state().
+        """
+        mode = self._resolve_numbering_mode(settings)
+
+        if mode == "lineup":
+            return self._parse_channel_number(entry.get("number"))
+
+        # For auto/specific modes, assign sequentially and skip used numbers
+        used = assigner_state['used']
+        n = assigner_state['next']
+        while n in used:
+            n += 1
+        used.add(n)
+        assigner_state['next'] = n + 1
+        return n
+
+    @classmethod
+    def _init_assigner_state(cls, settings):
+        """Initialize the channel number assigner state based on settings."""
+        mode = cls._resolve_numbering_mode(settings)
+
+        used = set()
+        if mode != "lineup":
+            for n in Channel.objects.values_list("channel_number", flat=True):
+                if n is not None:
+                    try:
+                        used.add(int(n))
+                    except (ValueError, TypeError):
+                        pass
+
+        if mode == "auto_next":
+            start = 1
+        elif mode == "auto_highest":
+            start = (max(used) + 1) if used else 1
+        elif mode == "specific":
+            raw = (settings.get("starting_channel_number") or "").strip()
+            start = int(raw) if raw.isdigit() and int(raw) > 0 else 1
+        else:
+            start = 1
+
+        return {'next': start, 'used': used}
+
     def _make_group_name(self, prefix, category):
         """Build full group name from prefix and category.
         If prefix ends with a separator character, append category directly.
@@ -554,7 +678,7 @@ class Plugin:
 
     def _resolve_m3u_sources(self, settings, logger):
         """Resolve M3U source names to account IDs. Returns (valid_ids, m3u_priority_map, warnings)."""
-        m3u_str = settings.get("m3u_sources", "").strip()
+        m3u_str = (settings.get("m3u_sources") or "").strip()
         if not m3u_str or m3u_str == "_all":
             return None, {}, []
 
@@ -596,7 +720,7 @@ class Plugin:
         """Merge built-in aliases with user custom aliases."""
         alias_map = dict(CHANNEL_ALIASES)
 
-        custom_str = settings.get("custom_aliases", "").strip()
+        custom_str = _clean_json_text(settings.get("custom_aliases") or "")
         if custom_str:
             try:
                 custom = json.loads(custom_str)
@@ -619,10 +743,10 @@ class Plugin:
             logger.warning(f"{LOG_PREFIX} EPG models not available. Skipping EPG matching.")
             return []
 
-        all_epg = list(EPGData.objects.all().values('id', 'name', 'epg_source'))
+        all_epg = list(EPGData.objects.all().values('id', 'name', 'tvg_id', 'epg_source'))
         logger.info(f"{LOG_PREFIX} Fetched {len(all_epg)} EPG data entries")
 
-        epg_sources_str = settings.get("epg_sources", "").strip()
+        epg_sources_str = (settings.get("epg_sources") or "").strip()
         if not epg_sources_str or epg_sources_str == "_all":
             return all_epg
 
@@ -692,7 +816,7 @@ class Plugin:
     def _resolve_channel_profiles(self, settings, logger):
         """Resolve comma-separated profile names to profile objects.
         Returns list of {'id': int, 'name': str} dicts, or empty list if not configured."""
-        profiles_str = settings.get("channel_profiles", "").strip()
+        profiles_str = (settings.get("channel_profiles") or "").strip()
         if not profiles_str or profiles_str == "_none":
             return []
 
@@ -945,8 +1069,26 @@ class Plugin:
                 results.append({"Setting": "Match Sensitivity", "Value": str(sensitivity), "Status": "ERROR: Invalid"})
                 errors += 1
 
+        # Check channel numbering
+        numbering = self._resolve_numbering_mode(settings)
+        labels = {"lineup": "Use Channel Database Numbers", "auto_next": "Auto-Assign Next Available",
+                  "auto_highest": "Auto-Assign After Highest", "specific": "Use Specific Number"}
+        label = labels.get(numbering, numbering)
+        if numbering == "specific":
+            raw = (settings.get("starting_channel_number") or "").strip()
+            if raw and raw.isdigit() and int(raw) > 0:
+                results.append({"Setting": "Channel Numbering", "Value": f"{label} (start: {raw})", "Status": "OK"})
+            else:
+                results.append({"Setting": "Channel Numbering", "Value": label, "Status": "ERROR: Starting channel number must be a positive integer (1 or higher)"})
+                errors += 1
+        elif numbering in labels:
+            results.append({"Setting": "Channel Numbering", "Value": label, "Status": "OK"})
+        else:
+            results.append({"Setting": "Channel Numbering", "Value": str(numbering), "Status": "ERROR: Invalid option"})
+            errors += 1
+
         # Check M3U sources
-        m3u_str = settings.get("m3u_sources", "").strip()
+        m3u_str = (settings.get("m3u_sources") or "").strip()
         if m3u_str and m3u_str != "_all":
             valid_ids, _, warnings = self._resolve_m3u_sources(settings, logger)
             if valid_ids:
@@ -961,7 +1103,7 @@ class Plugin:
             results.append({"Setting": "M3U Sources", "Value": "(all)", "Status": f"OK (using all - {stream_count} streams)"})
 
         # Check custom aliases
-        custom_str = settings.get("custom_aliases", "").strip()
+        custom_str = _clean_json_text(settings.get("custom_aliases") or "")
         if custom_str:
             try:
                 custom = json.loads(custom_str)
@@ -977,7 +1119,7 @@ class Plugin:
             results.append({"Setting": "Custom Aliases", "Value": "(none)", "Status": f"OK (using {len(CHANNEL_ALIASES)} built-in aliases)"})
 
         # Check channel profiles
-        profiles_str = settings.get("channel_profiles", "").strip()
+        profiles_str = (settings.get("channel_profiles") or "").strip()
         if profiles_str:
             resolved = self._resolve_channel_profiles(settings, logger)
             profile_names = [p.strip() for p in profiles_str.split(",") if p.strip()]
@@ -998,7 +1140,7 @@ class Plugin:
                 source_count = EPGSource.objects.count()
                 results.append({"Setting": "EPG Data", "Value": f"{epg_count} entries from {source_count} sources", "Status": "OK"})
 
-                epg_sources_str = settings.get("epg_sources", "").strip()
+                epg_sources_str = (settings.get("epg_sources") or "").strip()
                 if epg_sources_str and epg_sources_str != "_all":
                     filtered = self._get_filtered_epg_data(settings, logger)
                     results.append({"Setting": "EPG Sources Filter", "Value": epg_sources_str, "Status": f"OK ({len(filtered)} entries after filtering)"})
@@ -1090,6 +1232,7 @@ class Plugin:
         """Dry-run: show channels that would be created."""
         lineup = self._load_lineup(settings, logger)
         prefix = self._get_group_prefix(settings, lineup)
+        assigner = self._init_assigner_state(settings)
 
         # Build group name -> ID mapping
         existing_groups = {g['name']: g['id'] for g in ChannelGroup.objects.all().values('id', 'name')}
@@ -1105,7 +1248,7 @@ class Plugin:
 
             for entry in channels:
                 ch_name = entry["name"]
-                ch_number = self._parse_channel_number(entry.get("number"))
+                ch_number = self._get_channel_number(settings, entry, assigner)
                 key = (ch_name, group_id) if group_id else None
 
                 if key and key in existing_channels:
@@ -1165,10 +1308,16 @@ class Plugin:
     def _do_preview_stream_match(self, settings, logger):
         """Background thread for stream match preview."""
         try:
+            numbering_mode = self._resolve_numbering_mode(settings)
+            use_number_boost = (numbering_mode == "lineup")
             lineup = self._load_lineup(settings, logger)
             matcher = self._init_fuzzy_matcher(settings, logger)
             alias_map = self._build_alias_map(settings, logger)
             streams = self._get_all_streams(settings, logger)
+            assigner = self._init_assigner_state(settings)
+            lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
+            if lineup_cc:
+                logger.info(f"{LOG_PREFIX} Filtering streams to country: {lineup_cc}")
 
             if not streams:
                 logger.error(f"{LOG_PREFIX} No streams found. Check M3U sources.")
@@ -1184,6 +1333,7 @@ class Plugin:
 
             # Pre-normalize stream names for performance
             matcher.precompute_normalizations(unique_stream_names)
+            matcher.country_filter_drops = 0
 
             results = []
             matched_count = 0
@@ -1203,11 +1353,13 @@ class Plugin:
                         return
 
                     ch_name = entry["name"]
-                    ch_number = self._parse_channel_number(entry.get("number"))
+                    ch_number = self._get_channel_number(settings, entry, assigner)
+                    boost_number = self._parse_channel_number(entry.get("number")) if use_number_boost else None
 
                     matches = matcher.match_all_streams(
                         ch_name, unique_stream_names, alias_map,
-                        channel_number=ch_number
+                        channel_number=boost_number,
+                        lineup_country=lineup_cc,
                     )
 
                     if matches:
@@ -1245,6 +1397,12 @@ class Plugin:
                     progress.update()
 
             progress.finish()
+
+            if lineup_cc and matcher.country_filter_drops:
+                logger.info(
+                    f"{LOG_PREFIX} Country filter dropped "
+                    f"{matcher.country_filter_drops} cross-country candidate(s)"
+                )
 
             # Sort: unmatched first, then by score ascending
             results.sort(key=lambda r: (0 if r["Score"] == 0 else 1, r["Score"]))
@@ -1367,6 +1525,7 @@ class Plugin:
         lineup = self._load_lineup(settings, logger)
         prefix = self._get_group_prefix(settings, lineup)
         rate_limiter = SmartRateLimiter(settings.get("rate_limiting", PluginConfig.DEFAULT_RATE_LIMITING))
+        assigner = self._init_assigner_state(settings)
 
         # Ensure groups exist
         existing_groups = {g['name']: g['id'] for g in ChannelGroup.objects.all().values('id', 'name')}
@@ -1396,24 +1555,25 @@ class Plugin:
 
             for entry in channels:
                 ch_name = entry["name"]
-                ch_number = self._parse_channel_number(entry.get("number"))
+                ch_number = self._get_channel_number(settings, entry, assigner)
 
                 try:
                     if dry_run:
                         existing = Channel.objects.filter(name=ch_name, channel_group_id=group_id).values('id', 'channel_number').first()
                         if existing:
                             synced_channel_ids.append(existing['id'])
-                            if ch_number and existing['channel_number'] != ch_number:
+                            if ch_number is not None and existing['channel_number'] != ch_number:
                                 updated += 1
                             else:
                                 unchanged += 1
                         else:
                             created += 1
                     else:
+                        defaults = {"channel_number": ch_number} if ch_number is not None else {}
                         ch, was_created = Channel.objects.get_or_create(
                             name=ch_name,
                             channel_group_id=group_id,
-                            defaults={"channel_number": ch_number}
+                            defaults=defaults
                         )
                         synced_channel_ids.append(ch.id)
                         if was_created:
@@ -1421,7 +1581,7 @@ class Plugin:
                             logger.debug(f"{LOG_PREFIX} Created channel: '{ch_name}' #{ch_number} in '{group_name}'")
                         else:
                             # Update channel number if different
-                            if ch_number and ch.channel_number != ch_number:
+                            if ch_number is not None and ch.channel_number != ch_number:
                                 ch.channel_number = ch_number
                                 ch.save(update_fields=['channel_number'])
                                 updated += 1
@@ -1745,6 +1905,7 @@ class Plugin:
     def _do_apply_stream_match(self, settings, logger):
         """Core stream matching logic (called from thread)."""
         dry_run = settings.get("dry_run_mode", False)
+        use_number_boost = (self._resolve_numbering_mode(settings) == "lineup")
         prioritize_quality = settings.get("prioritize_quality", PluginConfig.DEFAULT_PRIORITIZE_QUALITY)
 
         if not self._acquire_lock(logger):
@@ -1756,6 +1917,9 @@ class Plugin:
             matcher = self._init_fuzzy_matcher(settings, logger)
             alias_map = self._build_alias_map(settings, logger)
             rate_limiter = SmartRateLimiter(settings.get("rate_limiting", PluginConfig.DEFAULT_RATE_LIMITING))
+            lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
+            if lineup_cc:
+                logger.info(f"{LOG_PREFIX} Filtering streams to country: {lineup_cc}")
 
             # Get streams
             all_streams = self._get_all_streams(settings, logger)
@@ -1773,6 +1937,7 @@ class Plugin:
 
             # Pre-normalize stream names for performance
             matcher.precompute_normalizations(unique_stream_names)
+            matcher.country_filter_drops = 0
 
             # Get existing groups and channels
             existing_groups = {g['name']: g['id'] for g in ChannelGroup.objects.all().values('id', 'name')}
@@ -1805,7 +1970,7 @@ class Plugin:
                         return {"status": "ok", "message": "Stream matching cancelled by user."}
 
                     ch_name = entry["name"]
-                    ch_number = self._parse_channel_number(entry.get("number"))
+                    ch_number = self._parse_channel_number(entry.get("number")) if use_number_boost else None
                     channel_id = existing_channels.get((ch_name, group_id))
 
                     if not channel_id:
@@ -1817,7 +1982,8 @@ class Plugin:
                     # Match streams using deduplicated names
                     matches = matcher.match_all_streams(
                         ch_name, unique_stream_names, alias_map,
-                        channel_number=ch_number
+                        channel_number=ch_number,
+                        lineup_country=lineup_cc,
                     )
 
                     if matches:
@@ -1875,6 +2041,12 @@ class Plugin:
                     progress.update()
 
             progress.finish()
+
+            if lineup_cc and matcher.country_filter_drops:
+                logger.info(
+                    f"{LOG_PREFIX} Country filter dropped "
+                    f"{matcher.country_filter_drops} cross-country candidate(s)"
+                )
 
             # Export CSV
             ts = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -1959,11 +2131,18 @@ class Plugin:
             return {"status": "error", "message": "Another operation is in progress. Try again later."}
 
         try:
+            use_number_boost = (self._resolve_numbering_mode(settings) == "lineup")
             lineup = self._load_lineup(settings, logger)
             prefix = self._get_group_prefix(settings, lineup)
             matcher = self._init_fuzzy_matcher(settings, logger)
             alias_map = self._build_alias_map(settings, logger)
             rate_limiter = SmartRateLimiter(settings.get("rate_limiting", PluginConfig.DEFAULT_RATE_LIMITING))
+
+            # Extract lineup country code for EPG country matching
+            lineup_file = settings.get("lineup_file", "")
+            lineup_cc, _ = self._parse_lineup_filename(os.path.basename(lineup_file))
+            if lineup_cc:
+                logger.info(f"{LOG_PREFIX} Lineup country code: {lineup_cc} (will prefer EPG entries with matching country)")
 
             # Fetch filtered EPG data
             epg_data = self._get_filtered_epg_data(settings, logger)
@@ -2037,7 +2216,7 @@ class Plugin:
                         return {"status": "ok", "message": "EPG matching cancelled by user."}
 
                     ch_name = entry["name"]
-                    ch_number = self._parse_channel_number(entry.get("number"))
+                    ch_number = self._parse_channel_number(entry.get("number")) if use_number_boost else None
                     ch_data = existing_channels.get((ch_name, group_id))
 
                     if not ch_data:
@@ -2070,7 +2249,7 @@ class Plugin:
                         top_name, top_score, top_method = matches[0]
                         top_entries = epg_by_name.get(top_name, [])
                         if top_entries:
-                            best_epg = top_entries[0]
+                            best_epg = self._pick_epg_by_country(top_entries, lineup_cc)
                             best_score = top_score
                             best_method = top_method
 
@@ -2084,7 +2263,7 @@ class Plugin:
                             top_name, top_score, top_method = fallback_matches[0]
                             top_entries = epg_by_name_all.get(top_name, [])
                             if top_entries:
-                                best_epg = top_entries[0]
+                                best_epg = self._pick_epg_by_country(top_entries, lineup_cc)
                                 best_score = top_score
                                 best_method = top_method
                                 has_program_data = False


### PR DESCRIPTION
## Summary

Bug fixes for the Lineuparr plugin (Lineup + fuzzy stream matching + EPG + logos).

### Matching fixes
- **Cross-network contamination (ABC/BBC/CBC)** — a 1-character substitution on short channel names produced 93% fuzzy scores above the guard's 90-gate, allowing `ABC News` to appear in match lists for `BBC News`/`CBC News`. Alias, substring, and fuzzy token-sort stages now unconditionally require majority token overlap.
- **Sportsnet Pacific → regionless Sportsnet false match** — `REGIONAL_PATTERNS` strips the word "pacific" during normalization (unlike east/west), so the regional filter never saw "pacific" in the query. Lineup entries like `Sportsnet Pacific` fell through to the regionless branch. Pacific is now detected from the original lineup name.

### Settings fix
- **Custom aliases JSON parse error on invisible chars** — BOM and zero-width characters (U+FEFF, U+200B, U+200C, U+200D, U+2060) pasted from rich-text sources survive `str.strip()` and caused `Expecting value: line 1 column 1 (char 0)`. Both parse sites now sanitize invisible characters before `json.loads`.

### Meta
- **Author**: PiratesIRC
- **Version**: 1.26.1091027 (calver)
- **License**: MIT
- **Min Dispatcharr Version**: v0.20.0
- **Source Repo**: https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin
- **Release**: https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin/releases/tag/v1.26.1091027