### PR TITLE
[event-channel-managarr]: Bump to v1.26.1172336 — DD/MM date support + single-line profile field

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.1152350",
+  "version": "1.26.1172336",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "license": "MIT",
@@ -10,9 +10,10 @@
   "fields": [
     {"id": "_section_scope", "label": "📍 Scope", "type": "info", "description": "Which channels this plugin monitors and how it identifies them."},
     {"id": "timezone", "label": "🌍 Timezone", "type": "select", "default": "America/Chicago"},
-    {"id": "channel_profile_name", "label": "📺 Channel Profile Names (Required)", "type": "text", "default": "", "placeholder": "e.g. All, Favorites"},
+    {"id": "channel_profile_name", "label": "📺 Channel Profile Names (Required)", "type": "string", "default": "", "placeholder": "e.g. All, Favorites"},
     {"id": "channel_groups", "label": "📂 Channel Groups", "type": "text", "default": "", "placeholder": "e.g. PPV Live Events, Sports"},
     {"id": "name_source", "label": "🔤 Name Source", "type": "select", "default": "Channel_Name"},
+    {"id": "date_format", "label": "📅 Date Format in Channel Names", "type": "select", "default": "Auto"},
 
     {"id": "_section_rules", "label": "🎯 Hide Rules", "type": "info", "description": "Priority-ordered rules that decide which channels to hide."},
     {"id": "hide_rules_priority", "label": "📜 Hide Rules Priority", "type": "text", "default": "[InactiveRegex],[BlankName],[WrongDayOfWeek],[NoEventPattern],[EmptyPlaceholder],[PastDate:0],[FutureDate:2],[UndatedAge:2],[ShortDescription],[ShortChannelName]"},

--- a/plugins/event-channel-managarr/plugin.py
+++ b/plugins/event-channel-managarr/plugin.py
@@ -41,7 +41,7 @@ _scheduler_lock = threading.Lock()  # Prevent concurrent scheduler starts
 class PluginConfig:
     """Centralized configuration constants for Event Channel Managarr."""
 
-    PLUGIN_VERSION = "1.26.1152350"
+    PLUGIN_VERSION = "1.26.1172336"
 
     # Default timezone for scheduling
     DEFAULT_TIMEZONE = "America/Chicago"
@@ -338,7 +338,7 @@ class Plugin:
             {
                 "id": "channel_profile_name",
                 "label": "📺 Channel Profile Names (Required)",
-                "type": "text",
+                "type": "string",
                 "default": "",
                 "placeholder": "e.g. All, Favorites",
                 "help_text": "REQUIRED: Channel Profile(s) containing channels to monitor. Use comma-separated names for multiple profiles.",
@@ -360,6 +360,18 @@ class Plugin:
                 "options": [
                     {"label": "Channel Name", "value": "Channel_Name"},
                     {"label": "Stream Name", "value": "Stream_Name"}
+                ]
+            },
+            {
+                "id": "date_format",
+                "label": "📅 Date Format in Channel Names",
+                "type": "select",
+                "default": "Auto",
+                "help_text": "How to interpret numeric dates like 04/05 in channel names. Auto = try MM/DD first; if month > 12, treat as DD/MM (handles most regional data). US = always MM/DD. EU = always DD/MM.",
+                "options": [
+                    {"label": "Auto-detect (recommended)", "value": "Auto"},
+                    {"label": "US (MM/DD)", "value": "US"},
+                    {"label": "EU (DD/MM)", "value": "EU"}
                 ]
             },
             {
@@ -1120,7 +1132,35 @@ class Plugin:
 
         return None
 
-    def _extract_date_from_channel_name(self, channel_name, logger):
+    def _resolve_numeric_date_pair(self, first, second, current_year, date_format):
+        """Resolve a (first, second) numeric pair into a datetime using the configured format.
+
+        date_format: "US" → MM/DD, "EU" → DD/MM, "Auto" → MM/DD with DD/MM fallback if month > 12.
+        Returns datetime or None if the pair can't form a valid date.
+        """
+        fmt = (date_format or "Auto").strip()
+        if fmt == "EU":
+            day, month = first, second
+            try:
+                return datetime(current_year, month, day)
+            except ValueError:
+                return None
+        if fmt == "US":
+            month, day = first, second
+            try:
+                return datetime(current_year, month, day)
+            except ValueError:
+                return None
+        # Auto: MM/DD first; if month > 12 (or invalid), retry DD/MM.
+        try:
+            return datetime(current_year, first, second)
+        except ValueError:
+            try:
+                return datetime(current_year, second, first)
+            except ValueError:
+                return None
+
+    def _extract_date_from_channel_name(self, channel_name, logger, settings=None):
         """Extract date from channel name using various patterns, including hour if present"""
         if not channel_name:
             return None
@@ -1128,6 +1168,7 @@ class Plugin:
 
         current_year = datetime.now().year
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        date_format = (settings or {}).get("date_format", "Auto")
 
         # Pattern 0: start:YYYY-MM-DD HH:MM:SS or stop:YYYY-MM-DD HH:MM:SS
         for prefix in ["start:", "stop:"]:
@@ -1152,18 +1193,16 @@ class Plugin:
             except ValueError:
                 pass
 
-        # Pattern 1: MM/DD/YYYY or MM/DD/YY
+        # Pattern 1: M/D/YYYY or M/D/YY — interpreted per date_format setting.
         pattern1 = re.search(r'\b(\d{1,2})/(\d{1,2})/(\d{2,4})\b', channel_name)
         if pattern1:
-            month, day, year = map(int, pattern1.groups())
+            first, second, year = map(int, pattern1.groups())
             if year < 100:
                 year += 2000
-            try:
-                extracted_date = datetime(year, month, day)
-                logger.debug(f"Extracted date {extracted_date.date()} from pattern MM/DD/YYYY in '{channel_name}'")
+            extracted_date = self._resolve_numeric_date_pair(first, second, year, date_format)
+            if extracted_date is not None:
+                logger.debug(f"Extracted date {extracted_date.date()} from pattern M/D/YYYY ({date_format}) in '{channel_name}'")
                 return extracted_date
-            except ValueError:
-                pass
 
         # Pattern 2c: DDth MONTH e.g., "28th Apr"
         pattern2c = re.search(r'\b(\d{1,2})(?:st|nd|rd|th)?\s+(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)\b', channel_name, re.IGNORECASE)
@@ -1196,29 +1235,25 @@ class Plugin:
             except (ValueError, dateutil_parser.ParserError):
                 pass
 
-        # Pattern 3: MM.DD e.g., "10.25"
+        # Pattern 3: M.D without year e.g., "10.25" — interpreted per date_format setting.
         pattern3 = re.search(r'\b(\d{1,2})\.(\d{1,2})\b', channel_name)
         if pattern3:
-            month, day = map(int, pattern3.groups())
-            try:
-                extracted_date = datetime(current_year, month, day)
-                logger.debug(f"Extracted date {extracted_date.date()} from pattern MM.DD in '{channel_name}'")
+            first, second = map(int, pattern3.groups())
+            extracted_date = self._resolve_numeric_date_pair(first, second, current_year, date_format)
+            if extracted_date is not None:
+                logger.debug(f"Extracted date {extracted_date.date()} from pattern M.D ({date_format}) in '{channel_name}'")
                 return extracted_date
-            except ValueError:
-                pass
 
-        # Pattern 4: MM/DD without year e.g., "10/27"
+        # Pattern 4: M/D without year e.g., "10/27" or "15/04" — interpreted per date_format setting.
         # Lookahead excludes "/" (year follows, handled by Pattern 1) and ":" (time
         # range like "1/3:30pm" — second number is hours, not a day).
         pattern4 = re.search(r'\b(\d{1,2})/(\d{1,2})\b(?![/:])', channel_name)
         if pattern4:
-            month, day = map(int, pattern4.groups())
-            try:
-                extracted_date = datetime(current_year, month, day)
-                logger.debug(f"Extracted date {extracted_date.date()} from pattern MM/DD in '{channel_name}'")
+            first, second = map(int, pattern4.groups())
+            extracted_date = self._resolve_numeric_date_pair(first, second, current_year, date_format)
+            if extracted_date is not None:
+                logger.debug(f"Extracted date {extracted_date.date()} from pattern M/D ({date_format}) in '{channel_name}'")
                 return extracted_date
-            except ValueError:
-                pass
 
         logger.debug(f"No date found in channel name: '{channel_name}'")
         return None
@@ -1402,7 +1437,7 @@ class Plugin:
             return False, None
 
         elif rule_name == "PastDate":
-            extracted_date = self._extract_date_from_channel_name(channel_name, logger)
+            extracted_date = self._extract_date_from_channel_name(channel_name, logger, settings)
             if extracted_date is None:
                 return False, None  # Skip rule if no date found
 
@@ -1441,7 +1476,7 @@ class Plugin:
             return False, None
         
         elif rule_name == "FutureDate":
-            extracted_date = self._extract_date_from_channel_name(channel_name, logger)
+            extracted_date = self._extract_date_from_channel_name(channel_name, logger, settings)
             if extracted_date is None:
                 return False, None  # Skip rule if no date found
             
@@ -2524,7 +2559,7 @@ class Plugin:
 
                 # Update undated-channel tracker: record channels with no extractable date,
                 # drop those that now have a date.
-                if self._extract_date_from_channel_name(channel_name, logger) is None:
+                if self._extract_date_from_channel_name(channel_name, logger, settings) is None:
                     self._record_undated_channel(self._undated_tracker, channel.id, channel_name, today_str)
                     tracked_this_scan.add(str(channel.id))
                 else:


### PR DESCRIPTION
## Summary

Bumps Event Channel Managarr to **v1.26.1172336**.

### 🌍 Configurable date format (Auto / US / EU)
European users with channel names like `UEFA Champions League 02: ... 15/04` or `... 15/04/2026` were getting no date extracted because Patterns 1, 3, and 4 hard-coded MM/DD ordering. Adds a new **📅 Date Format in Channel Names** setting:

- **Auto (default, recommended)** — try MM/DD first; if month is invalid (> 12), retry as DD/MM.
- **US (MM/DD)** — always month first.
- **EU (DD/MM)** — always day first.

Auto only swaps when MM/DD is invalid, so existing US installs are unaffected.

### 🎨 UI: single-line Channel Profile Names field
Field type changed from `text` to `string` so it renders as a single-line input instead of a multi-line textarea, matching other Dispatcharr plugins.

## Files changed
- `plugins/event-channel-managarr/plugin.json` — new `date_format` field, `channel_profile_name` type → `string`, version bump.
- `plugins/event-channel-managarr/plugin.py` — new `_resolve_numeric_date_pair` helper, Patterns 1/3/4 routed through it, three callers updated to pass settings.

## Verification
Smoke-tested in a live Dispatcharr container against `15/04`, `16/04`, `15/04/2026`, `10/27/2025`, `04/05`, `1/3:30pm`, `13/13` across all three format modes — results match expectations. Full scan of 502 channels (US data) shows no regression in date-rule firing counts.

Source release: https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/tag/1.26.1172336