### PR TITLE
[event-channel-managarr]: Bump to v1.26.1291442 - TZ-localized dummy EPG titles

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.1172336",
+  "version": "1.26.1291442",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/plugins/event-channel-managarr/plugin.py
+++ b/plugins/event-channel-managarr/plugin.py
@@ -41,7 +41,7 @@ _scheduler_lock = threading.Lock()  # Prevent concurrent scheduler starts
 class PluginConfig:
     """Centralized configuration constants for Event Channel Managarr."""
 
-    PLUGIN_VERSION = "1.26.1172336"
+    PLUGIN_VERSION = "1.26.1291442"
 
     # Default timezone for scheduling
     DEFAULT_TIMEZONE = "America/Chicago"
@@ -2122,6 +2122,57 @@ class Plugin:
         
         return duplicate_hide_list
 
+    def _localized_template_props(self, settings):
+        """
+        Returns overrides for the three rewritable title templates plus
+        `output_timezone` for the managed dummy EPG source.
+
+        - When source TZ == display TZ, or either TZ is invalid/empty:
+          returns DEFAULTS (plain templates) and writes
+          `output_timezone=""` so any previously-saved value is cleared
+          (the diff-and-save loop never deletes keys).
+        - Otherwise: returns localized templates with the date placeholder
+          driven by `date_format` (US/Auto -> {month}/{day};
+          EU -> {day}/{month}) and a TZ abbreviation suffix computed for
+          "now" in the display TZ. If %Z returns a numeric offset
+          (e.g., +0530), the suffix is omitted but time conversion still
+          happens via Dispatcharr's output_timezone.
+
+        `fallback_title_template` is set in the base `managed_props` and
+        is never overridden here.
+        """
+        DEFAULTS = {
+            "output_timezone": "",
+            "title_template": "{title}",
+            "upcoming_title_template": "Upcoming at {starttime}: {title}",
+            "ended_title_template": "Ended at {endtime}: {title}",
+        }
+
+        source_tz_name = str(settings.get("dummy_epg_event_timezone", "")).strip()
+        display_tz_name = str(settings.get("timezone", "")).strip()
+
+        if not source_tz_name or not display_tz_name or source_tz_name == display_tz_name:
+            return DEFAULTS
+
+        try:
+            pytz.timezone(source_tz_name)  # validate only; renderer resolves source TZ itself
+            display_tz = pytz.timezone(display_tz_name)
+        except pytz.exceptions.UnknownTimeZoneError:
+            return DEFAULTS
+
+        abbrev = datetime.now(display_tz).strftime("%Z")
+        suffix = f" {abbrev}" if abbrev and abbrev.isalpha() else ""
+
+        fmt = str(settings.get("date_format", "Auto")).strip().upper()
+        date_ph = "{day}/{month}" if fmt == "EU" else "{month}/{day}"
+
+        return {
+            "output_timezone": display_tz_name,
+            "title_template": f"{{title}} {date_ph} {{starttime}}{suffix}",
+            "upcoming_title_template": f"Upcoming at {date_ph} {{starttime}}{suffix}: {{title}}",
+            "ended_title_template": f"Ended at {date_ph} {{endtime}}{suffix}: {{title}}",
+        }
+
     def _get_or_create_managed_epg_source(self, settings, logger):
         """Create (if missing) or refresh the shared plugin-managed dummy EPGSource.
 
@@ -2174,6 +2225,8 @@ class Plugin:
             "include_date": False,
             "managed_by": "event-channel-managarr",
         }
+
+        managed_props.update(self._localized_template_props(settings))
 
         try:
             source, created = EPGSource.objects.get_or_create(


### PR DESCRIPTION
## Summary

Bumps **Event-Channel-Managarr** to **v1.26.1291442**.

New feature: when the source TZ encoded in channel names (`dummy_epg_event_timezone`) differs from the user's display TZ (the existing scheduler `Timezone` setting), the managed dummy EPG titles are rewritten to show each program's local time + zone abbreviation. Reuses Dispatcharr's existing `output_timezone` custom-property on the dummy `EPGSource`; no renderer changes required.

## Examples

With Event TZ `US/Eastern`, scheduler TZ `America/Chicago`:

- Channel `Boxing 5/9 8:30 PM ET` -> title `Boxing 5/9 7:30 PM CDT` (DST active)
- Same setup in November -> `Boxing 11/9 7:30 PM CST`
- Source TZ == display TZ -> plain `Boxing` (today's behavior preserved)

## Implementation

- New private helper `_localized_template_props(self, settings)` on the `Plugin` class.
- One-line `managed_props.update(self._localized_template_props(settings))` in `_get_or_create_managed_epg_source` immediately before `EPGSource.objects.get_or_create(...)`.
- DEFAULTS branch explicitly writes `output_timezone=""` so reverting source==display cleanly clears any previously-saved value.
- No new settings, no new dependencies (`pytz` and `datetime` already imported).

## Behavior details

- Date format inside titles follows the existing `Date Format` setting (US/Auto -> `M/D`, EU -> `D/M`).
- Numeric-offset zones (e.g., `Etc/GMT+5`) suppress the abbreviation suffix; time still converts.
- DST refresh: abbreviation is recomputed each ECM run; manual run after a transition gives an immediate refresh.

## Verification

All 7 spec scenarios were verified live against `EPGSource.custom_properties` in a running Dispatcharr container, including the revert-clears-`output_timezone` case and graceful degrade on bogus/empty TZs.

## Release

- Source: https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin
- Tag: https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/tag/v1.26.1291442