### PR TITLE
[repo]: Add external plugin source support

### DIFF
--- a/.github/scripts/publish/build-zips.sh
+++ b/.github/scripts/publish/build-zips.sh
@@ -37,22 +37,37 @@ for plugin_dir in plugins/*/; do
     fi
   fi
 
-  echo "  $plugin_name v$version - building"
-  echo "$plugin_key@$version" >> changed_plugins.txt
-
-  commit_sha=$(git log -1 --format=%H origin/$SOURCE_BRANCH -- "$plugin_dir")
-  commit_sha_short=$(git log -1 --format=%h origin/$SOURCE_BRANCH -- "$plugin_dir")
+  source_type=$(jq -r '.source_type // "local"' "$plugin_dir/plugin.json")
   build_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  last_updated=$(git log -1 --format=%cI origin/$SOURCE_BRANCH -- "$plugin_dir" 2>/dev/null \
-    || date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-  (
-    abspath="$(pwd)/$zip_path"
-    tmpdir=$(mktemp -d)
-    trap 'rm -rf "$tmpdir"' EXIT
-    cp -r "plugins/$plugin_name" "$tmpdir/$plugin_key"
-    cd "$tmpdir" && zip -r "$abspath" "$plugin_key" -q
-  )
+  if [[ "$source_type" == "external" ]]; then
+    source_url_template=$(jq -r '.source_url' "$plugin_dir/plugin.json")
+    source_url_resolved="${source_url_template//\{version\}/$version}"
+    echo "  $plugin_name v$version - fetching external ZIP from $source_url_resolved"
+    echo "$plugin_key@$version" >> changed_plugins.txt
+    curl -fsSL "$source_url_resolved" -o "$zip_path" || {
+      echo "::error::Failed to download external ZIP from $source_url_resolved"
+      exit 1
+    }
+    commit_sha=""
+    commit_sha_short=""
+    last_updated="$build_timestamp"
+  else
+    echo "  $plugin_name v$version - building"
+    echo "$plugin_key@$version" >> changed_plugins.txt
+    commit_sha=$(git log -1 --format=%H origin/$SOURCE_BRANCH -- "$plugin_dir")
+    commit_sha_short=$(git log -1 --format=%h origin/$SOURCE_BRANCH -- "$plugin_dir")
+    last_updated=$(git log -1 --format=%cI origin/$SOURCE_BRANCH -- "$plugin_dir" 2>/dev/null \
+      || date -u +"%Y-%m-%dT%H:%M:%SZ")
+    source_url_resolved=""
+    (
+      abspath="$(pwd)/$zip_path"
+      tmpdir=$(mktemp -d)
+      trap 'rm -rf "$tmpdir"' EXIT
+      cp -r "plugins/$plugin_name" "$tmpdir/$plugin_key"
+      cd "$tmpdir" && zip -r "$abspath" "$plugin_key" -q
+    )
+  fi
 
   checksum_md5=$(md5sum "$zip_path" | awk '{print $1}')
   checksum_sha256=$(shasum -a 256 "$zip_path" | awk '{print $1}')
@@ -71,15 +86,17 @@ for plugin_dir in plugins/*/; do
     --arg checksum_sha256 "$checksum_sha256" \
     --arg min_da_version "$min_da_version" \
     --arg max_da_version "$max_da_version" \
+    --arg source_url "$source_url_resolved" \
     '{      version: $version,
-      commit_sha: $commit_sha,
-      commit_sha_short: $commit_sha_short,
+      commit_sha: (if $commit_sha != "" then $commit_sha else null end),
+      commit_sha_short: (if $commit_sha_short != "" then $commit_sha_short else null end),
       build_timestamp: $build_timestamp,
       last_updated: $last_updated,
       checksum_md5: $checksum_md5,
       checksum_sha256: $checksum_sha256,
       min_dispatcharr_version: (if $min_da_version != "" then $min_da_version else null end),
-      max_dispatcharr_version: (if $max_da_version != "" then $max_da_version else null end)
+      max_dispatcharr_version: (if $max_da_version != "" then $max_da_version else null end),
+      source_url: (if $source_url != "" then $source_url else null end)
     } | with_entries(select(.value != null))' \
     > "$BUILD_META_DIR/$plugin_key/${plugin_key}-${version}.json"
 

--- a/.github/scripts/publish/generate-manifest.sh
+++ b/.github/scripts/publish/generate-manifest.sh
@@ -159,6 +159,7 @@ for plugin_dir in plugins/*/; do
           checksum_sha256: $metadata.checksum_sha256,
           min_dispatcharr_version: $metadata.min_dispatcharr_version,
           max_dispatcharr_version: $metadata.max_dispatcharr_version,
+          source_url: $metadata.source_url,
           url: $url,
           size: $size
         } | with_entries(select(.value != null))]' <<< "$versioned_zips")
@@ -188,6 +189,8 @@ for plugin_dir in plugins/*/; do
       maintainers: (.maintainers // null),
       license: (.license // null),
       deprecated: (if .deprecated == true then true else null end),
+      source_type: (if .source_type == "external" then "external" else null end),
+      source_url: (.source_url // null),
       repo_url: (.repo_url // null),
       discord_thread: (.discord_thread // null),
       registry_url: $registry_url,
@@ -203,6 +206,7 @@ for plugin_dir in plugins/*/; do
         checksum_sha256: $latest_metadata.checksum_sha256,
         min_dispatcharr_version: $latest_metadata.min_dispatcharr_version,
         max_dispatcharr_version: $latest_metadata.max_dispatcharr_version,
+        source_url: $latest_metadata.source_url,
         latest_url: $latest_url,
         url: $versioned_zips[0].url,
         size: $latest_size_kb

--- a/.github/scripts/validate/report.sh
+++ b/.github/scripts/validate/report.sh
@@ -244,16 +244,6 @@ fi
       fi
     fi
 
-    if [[ -n "${CODEQL_RESULT:-}" && "${CODEQL_RESULT:-}" != "skipped" && "${CODEQL_RESULT:-}" != "success" ]] || \
-       [[ -n "${CODEQL_MEDIUMS:-}" && "${CODEQL_MEDIUMS}" != "0" && "${CODEQL_RESULT:-}" != "skipped" ]] || \
-       [[ -n "${CODEQL_LOWS:-}" && "${CODEQL_LOWS}" != "0" && "${CODEQL_RESULT:-}" != "skipped" ]] || \
-       [[ "${CODEQL_RESULT:-}" == "skipped" && -n "${CODEQL_UNSCANNED_LANGS:-}" ]] || \
-       [[ "${CODEQL_RESULT:-}" != "skipped" && -n "${CODEQL_RESULT:-}" && -n "${CODEQL_UNSCANNED_LANGS:-}" ]]; then
-      echo ""
-      echo "---"
-      echo ""
-    fi
-
     if [[ -n "${CODEQL_RESULT:-}" && "${CODEQL_RESULT:-}" != "skipped" && "${CODEQL_RESULT:-}" != "success" ]]; then
       # echo ""
       # echo "## Code Quality"

--- a/.github/scripts/validate/validate.sh
+++ b/.github/scripts/validate/validate.sh
@@ -157,8 +157,8 @@ has_permission="false"
     if [[ -z "$ext_source_url" ]]; then
       TABLE_ROWS+=("| \`source_url\` | ❌ | Required when \`source_type\` is \`external\` |")
       failed=1
-    elif [[ ! "$ext_source_url" =~ ^https://github\.com/[^/]+/[^/]+/releases/download/ ]]; then
-      TABLE_ROWS+=("| \`source_url\` | ❌ | Must be a GitHub Releases URL (\`https://github.com/owner/repo/releases/download/...\`) — required so the source can be analysed by CodeQL |")
+    elif [[ ! "$ext_source_url" =~ ^https:// ]]; then
+      TABLE_ROWS+=("| \`source_url\` | ❌ | Must be an HTTPS URL |")
       failed=1
     elif [[ "$ext_source_url" != *"{version}"* ]]; then
       TABLE_ROWS+=("| \`source_url\` | ❌ | Must contain a \`{version}\` placeholder (e.g. \`.../v{version}/plugin.zip\`) |")

--- a/.github/scripts/validate/validate.sh
+++ b/.github/scripts/validate/validate.sh
@@ -148,6 +148,41 @@ has_permission="false"
   MAINTAINERS=$(jq -r '[.maintainers[]?] | join(" ")' "$PLUGIN_JSON")
   VERSION=$(jq -r '.version' "$PLUGIN_JSON")
 
+  # ── External source checks ────────────────────────────────────────────────────
+  source_type=$(jq -r '.source_type // "local"' "$PLUGIN_JSON")
+  if [[ "$source_type" == "external" ]]; then
+    ext_source_url=$(jq -r '.source_url // ""' "$PLUGIN_JSON")
+    ext_repo_url=$(jq -r '.repo_url // ""' "$PLUGIN_JSON")
+
+    if [[ -z "$ext_source_url" ]]; then
+      TABLE_ROWS+=("| \`source_url\` | ❌ | Required when \`source_type\` is \`external\` |")
+      failed=1
+    elif [[ ! "$ext_source_url" =~ ^https://github\.com/[^/]+/[^/]+/releases/download/ ]]; then
+      TABLE_ROWS+=("| \`source_url\` | ❌ | Must be a GitHub Releases URL (\`https://github.com/owner/repo/releases/download/...\`) — required so the source can be analysed by CodeQL |")
+      failed=1
+    elif [[ "$ext_source_url" != *"{version}"* ]]; then
+      TABLE_ROWS+=("| \`source_url\` | ❌ | Must contain a \`{version}\` placeholder (e.g. \`.../v{version}/plugin.zip\`) |")
+      failed=1
+    else
+      # TABLE_ROWS+=("| \`source_url\` | ✅ | \`${ext_source_url}\` |")
+      if [[ $(validate_semver "$VERSION") -eq 1 ]]; then
+        resolved_url="${ext_source_url//\{version\}/$VERSION}"
+        http_code=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 -L "$resolved_url" || echo "000")
+        if [[ "$http_code" == "200" ]]; then
+          TABLE_ROWS+=("| Release artifact | ✅ | Artifact reachable at resolved URL |")
+        else
+          TABLE_ROWS+=("| Release artifact | ❌ | Could not reach \`$resolved_url\` (HTTP \`$http_code\`) — ensure the release exists |")
+          failed=1
+        fi
+      fi
+    fi
+
+    if [[ -z "$ext_repo_url" ]]; then
+      TABLE_ROWS+=("| \`repo_url\` | ❌ | Required for external plugins — set to the upstream source repository URL |")
+      failed=1
+    fi
+  fi
+
   # Maintainers
   if [[ -z "$AUTHOR" ]] && [[ -z "$MAINTAINERS" ]]; then
     TABLE_ROWS+=("| Maintainers | ❌ | At least one of \`author\` or \`maintainers\` must include your GitHub username |")

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -625,6 +625,18 @@ jobs:
           echo "codeql_mediums=$MEDIUM_COUNT" >> "$GITHUB_OUTPUT"
           echo "codeql_lows=$LOW_COUNT" >> "$GITHUB_OUTPUT"
 
+          # Build list of external plugin path prefixes so findings links are suppressed
+          # for files that came from a downloaded ZIP and don't exist in this repo.
+          EXTERNAL_PREFIXES='[]'
+          while IFS= read -r _plugin_name; do
+            _pjson="plugins/$_plugin_name/plugin.json"
+            [[ -f "$_pjson" ]] || continue
+            _stype=$(jq -r '.source_type // "local"' "$_pjson" 2>/dev/null || echo "local")
+            if [[ "$_stype" == "external" ]]; then
+              EXTERNAL_PREFIXES=$(printf '%s' "$EXTERNAL_PREFIXES" | jq --arg p "plugins/$_plugin_name/" '. + [$p]')
+            fi
+          done < <(echo '${{ needs.detect-changes.outputs.matrix }}' | jq -r '.[]')
+
           # Generate a findings detail file for inclusion in the PR comment
           if [[ "$RESULT_COUNT" -gt 0 ]]; then
             MERGE_SHA=$(git rev-parse HEAD)
@@ -641,6 +653,7 @@ jobs:
                 echo "$FC" | jq -r \
                   --arg repo "$GITHUB_REPOSITORY" \
                   --arg sha "$MERGE_SHA" \
+                  --argjson external_prefixes "$EXTERNAL_PREFIXES" \
                   '.runs[] |
                   . as $run |
                   (
@@ -655,7 +668,8 @@ jobs:
                   (.locations[0].physicalLocation.artifactLocation.uri // "?") as $uri |
                   ((.locations[0].physicalLocation.region.startLine // "?") | tostring) as $line |
                   (.message.text // "no description" | gsub("\n"; " ") | gsub("://"; "\u200b://") | gsub("www\\."; "www\u200b.") | gsub("#(?=[0-9])"; "#\u200b") | gsub("\\[(?<c>[^\\]]+)\\][(][0-9]+[)]"; .c) | gsub("\\["; "&#91;") | gsub("\\]"; "&#93;") | if length > 150 then .[0:150] + "\u2026" else . end) as $msg |
-                  (if $uri != "?" and $line != "?" then "[\($uri):\($line)](https://github.com/\($repo)/blob/\($sha)/\($uri)#L\($line))" else "\($uri):\($line)" end) as $loc |
+                  ([$external_prefixes[] | . as $p | $uri | startswith($p)] | any) as $is_external |
+                  (if ($uri != "?" and $line != "?" and ($is_external | not)) then "[\($uri):\($line)](https://github.com/\($repo)/blob/\($sha)/\($uri)#L\($line))" else "\($uri):\($line)" end) as $loc |
                   "| `\($rid)` | \($loc) | \($msg) |"'
               done
             } > codeql-findings.md
@@ -676,6 +690,7 @@ jobs:
                 echo "$FC" | jq -r \
                   --arg repo "$GITHUB_REPOSITORY" \
                   --arg sha "$MERGE_SHA" \
+                  --argjson external_prefixes "$EXTERNAL_PREFIXES" \
                   '.runs[] |
                   . as $run |
                   (
@@ -691,7 +706,8 @@ jobs:
                   (.locations[0].physicalLocation.artifactLocation.uri // "?") as $uri |
                   ((.locations[0].physicalLocation.region.startLine // "?") | tostring) as $line |
                   (.message.text // "no description" | gsub("\n"; " ") | gsub("://"; "\u200b://") | gsub("www\\."; "www\u200b.") | gsub("#(?=[0-9])"; "#\u200b") | gsub("\\[(?<c>[^\\]]+)\\][(][0-9]+[)]"; .c) | gsub("\\["; "&#91;") | gsub("\\]"; "&#93;") | if length > 150 then .[0:150] + "\u2026" else . end) as $msg |
-                  (if $uri != "?" and $line != "?" then "[\($uri):\($line)](https://github.com/\($repo)/blob/\($sha)/\($uri)#L\($line))" else "\($uri):\($line)" end) as $loc |
+                  ([$external_prefixes[] | . as $p | $uri | startswith($p)] | any) as $is_external |
+                  (if ($uri != "?" and $line != "?" and ($is_external | not)) then "[\($uri):\($line)](https://github.com/\($repo)/blob/\($sha)/\($uri)#L\($line))" else "\($uri):\($line)" end) as $loc |
                   "| `\($rid)` | \($loc) | \($msg) |"'
               done
             } > codeql-medium-findings.md
@@ -712,6 +728,7 @@ jobs:
                 echo "$FC" | jq -r \
                   --arg repo "$GITHUB_REPOSITORY" \
                   --arg sha "$MERGE_SHA" \
+                  --argjson external_prefixes "$EXTERNAL_PREFIXES" \
                   '.runs[] |
                   . as $run |
                   (
@@ -727,7 +744,8 @@ jobs:
                   (.locations[0].physicalLocation.artifactLocation.uri // "?") as $uri |
                   ((.locations[0].physicalLocation.region.startLine // "?") | tostring) as $line |
                   (.message.text // "no description" | gsub("\n"; " ") | gsub("://"; "\u200b://") | gsub("www\\."; "www\u200b.") | gsub("#(?=[0-9])"; "#\u200b") | gsub("\\[(?<c>[^\\]]+)\\][(][0-9]+[)]"; .c) | gsub("\\["; "&#91;") | gsub("\\]"; "&#93;") | if length > 150 then .[0:150] + "\u2026" else . end) as $msg |
-                  (if $uri != "?" and $line != "?" then "[\($uri):\($line)](https://github.com/\($repo)/blob/\($sha)/\($uri)#L\($line))" else "\($uri):\($line)" end) as $loc |
+                  ([$external_prefixes[] | . as $p | $uri | startswith($p)] | any) as $is_external |
+                  (if ($uri != "?" and $line != "?" and ($is_external | not)) then "[\($uri):\($line)](https://github.com/\($repo)/blob/\($sha)/\($uri)#L\($line))" else "\($uri):\($line)" end) as $loc |
                   "| `\($rid)` | \($loc) | \($msg) |"'
               done
             } > codeql-low-findings.md

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -466,6 +466,8 @@ jobs:
             extracted_dir=$(ls "/tmp/${plugin_name}-src/" | head -1)
             # Copy source into plugins dir without overwriting the registry plugin.json
             cp -rn "/tmp/${plugin_name}-src/${extracted_dir}/." "plugins/$plugin_name/"
+            # Strip CI/VCS metadata so workflow shell scripts don't pollute the CodeQL scan
+            rm -rf "plugins/$plugin_name/.github" "plugins/$plugin_name/.git"
             rm -rf "/tmp/${plugin_name}-source.zip" "/tmp/${plugin_name}-src"
             echo "Source for $plugin_name extracted into plugins/$plugin_name/"
           done < <(echo '${{ needs.detect-changes.outputs.matrix }}' | jq -r '.[]')

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -431,8 +431,6 @@ jobs:
           git checkout
 
       - name: Populate external plugin source for analysis
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           while IFS= read -r plugin_name; do
             plugin_json="plugins/$plugin_name/plugin.json"
@@ -445,31 +443,15 @@ jobs:
             source_url_template=$(jq -r '.source_url // ""' "$plugin_json")
             source_url="${source_url_template//\{version\}/$version}"
 
-            if [[ "$source_url" =~ ^https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/ ]]; then
-              gh_owner="${BASH_REMATCH[1]}"
-              gh_repo="${BASH_REMATCH[2]}"
-              gh_tag="${BASH_REMATCH[3]}"
-            else
-              echo "::warning::Cannot parse GitHub owner/repo from $source_url - CodeQL will analyse only plugin.json for $plugin_name"
-              continue
-            fi
-
-            echo "Fetching source archive for CodeQL: $gh_owner/$gh_repo@$gh_tag"
-            curl -fsSL \
-              -H "Authorization: Bearer $GH_TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/${gh_owner}/${gh_repo}/zipball/${gh_tag}" \
-              -o "/tmp/${plugin_name}-source.zip"
+            echo "Fetching release ZIP for CodeQL: $source_url"
+            curl -fsSL "$source_url" -o "/tmp/${plugin_name}-release.zip"
 
             mkdir -p "/tmp/${plugin_name}-src"
-            unzip -q "/tmp/${plugin_name}-source.zip" -d "/tmp/${plugin_name}-src"
-            extracted_dir=$(ls "/tmp/${plugin_name}-src/" | head -1)
-            # Copy source into plugins dir without overwriting the registry plugin.json
-            cp -rn "/tmp/${plugin_name}-src/${extracted_dir}/." "plugins/$plugin_name/"
-            # Strip CI/VCS metadata so workflow shell scripts don't pollute the CodeQL scan
-            rm -rf "plugins/$plugin_name/.github" "plugins/$plugin_name/.git"
-            rm -rf "/tmp/${plugin_name}-source.zip" "/tmp/${plugin_name}-src"
-            echo "Source for $plugin_name extracted into plugins/$plugin_name/"
+            unzip -q "/tmp/${plugin_name}-release.zip" -d "/tmp/${plugin_name}-src"
+            # Copy extracted files into plugins dir without overwriting the registry plugin.json
+            cp -rn "/tmp/${plugin_name}-src/." "plugins/$plugin_name/"
+            rm -rf "/tmp/${plugin_name}-release.zip" "/tmp/${plugin_name}-src"
+            echo "Release ZIP for $plugin_name extracted into plugins/$plugin_name/"
           done < <(echo '${{ needs.detect-changes.outputs.matrix }}' | jq -r '.[]')
 
       - name: Detect supported languages

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -430,6 +430,46 @@ jobs:
             | git sparse-checkout set --stdin
           git checkout
 
+      - name: Populate external plugin source for analysis
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          while IFS= read -r plugin_name; do
+            plugin_json="plugins/$plugin_name/plugin.json"
+            [[ ! -f "$plugin_json" ]] && continue
+
+            source_type=$(jq -r '.source_type // "local"' "$plugin_json")
+            [[ "$source_type" != "external" ]] && continue
+
+            version=$(jq -r '.version' "$plugin_json")
+            source_url_template=$(jq -r '.source_url // ""' "$plugin_json")
+            source_url="${source_url_template//\{version\}/$version}"
+
+            if [[ "$source_url" =~ ^https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/ ]]; then
+              gh_owner="${BASH_REMATCH[1]}"
+              gh_repo="${BASH_REMATCH[2]}"
+              gh_tag="${BASH_REMATCH[3]}"
+            else
+              echo "::warning::Cannot parse GitHub owner/repo from $source_url - CodeQL will analyse only plugin.json for $plugin_name"
+              continue
+            fi
+
+            echo "Fetching source archive for CodeQL: $gh_owner/$gh_repo@$gh_tag"
+            curl -fsSL \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${gh_owner}/${gh_repo}/zipball/${gh_tag}" \
+              -o "/tmp/${plugin_name}-source.zip"
+
+            mkdir -p "/tmp/${plugin_name}-src"
+            unzip -q "/tmp/${plugin_name}-source.zip" -d "/tmp/${plugin_name}-src"
+            extracted_dir=$(ls "/tmp/${plugin_name}-src/" | head -1)
+            # Copy source into plugins dir without overwriting the registry plugin.json
+            cp -rn "/tmp/${plugin_name}-src/${extracted_dir}/." "plugins/$plugin_name/"
+            rm -rf "/tmp/${plugin_name}-source.zip" "/tmp/${plugin_name}-src"
+            echo "Source for $plugin_name extracted into plugins/$plugin_name/"
+          done < <(echo '${{ needs.detect-changes.outputs.matrix }}' | jq -r '.[]')
+
       - name: Detect supported languages
         id: detect-langs
         run: |
@@ -823,15 +863,43 @@ jobs:
       - name: Scan changed plugin directories
         id: scan
         run: |
-          PLUGIN_DIRS=$(echo '${{ needs.detect-changes.outputs.matrix }}' \
-            | jq -r '.[] | "plugins/\(.)"' | tr '\n' ' ')
-          echo "Scanning: $PLUGIN_DIRS"
+          SCAN_TARGETS=()
+          EXT_SCAN_DIR="/tmp/external-scan"
+          mkdir -p "$EXT_SCAN_DIR"
+
+          while IFS= read -r plugin_name; do
+            plugin_json="plugins/$plugin_name/plugin.json"
+            [[ ! -f "$plugin_json" ]] && continue
+
+            source_type=$(jq -r '.source_type // "local"' "$plugin_json")
+
+            if [[ "$source_type" == "external" ]]; then
+              version=$(jq -r '.version' "$plugin_json")
+              source_url_template=$(jq -r '.source_url // ""' "$plugin_json")
+              source_url="${source_url_template//\{version\}/$version}"
+
+              echo "Downloading external ZIP for ClamAV scan: $source_url"
+              scan_dir="$EXT_SCAN_DIR/$plugin_name"
+              mkdir -p "$scan_dir/extracted"
+              zip_file="$scan_dir/${plugin_name}.zip"
+
+              if curl -fsSL "$source_url" -o "$zip_file" --max-time 60; then
+                unzip -q "$zip_file" -d "$scan_dir/extracted" || true
+                SCAN_TARGETS+=("$scan_dir/extracted")
+              else
+                echo "::warning::Could not download $source_url — scanning plugin.json only for $plugin_name"
+                SCAN_TARGETS+=("plugins/$plugin_name")
+              fi
+            else
+              SCAN_TARGETS+=("plugins/$plugin_name")
+            fi
+          done < <(echo '${{ needs.detect-changes.outputs.matrix }}' | jq -r '.[]')
+
+          echo "Scanning: ${SCAN_TARGETS[*]}"
           set +e
-          # SC2086: PLUGIN_DIRS is intentionally word-split to produce multiple args
-          # shellcheck disable=SC2086
           clamscan --database=/tmp/clamav-db \
             --recursive --infected --no-summary \
-            $PLUGIN_DIRS > clamav-output.txt 2>&1
+            "${SCAN_TARGETS[@]}" > clamav-output.txt 2>&1
           echo "exit_code=$?" >> $GITHUB_OUTPUT
           set -e
           cat clamav-output.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,8 @@
 
 ## Folder Structure
 
+### Standard plugin (full source)
+
 ```
 plugins/
   your-plugin-name/
@@ -23,6 +25,29 @@ plugins/
 ```
 
 All files inside your plugin folder - `main.py`, helper modules, assets, subdirectories - are automatically packaged into a ZIP on merge. There is no separate build step.
+
+### External plugin (source hosted elsewhere)
+
+If your plugin has complex build requirements or publishes releases from its own repository, you can submit a pointer-only directory. Only a `plugin.json` is required:
+
+```
+plugins/
+  your-plugin-name/
+    plugin.json       # required; includes source_type and source_url
+    README.md         # optional but recommended
+    logo.png          # optional; displayed in the plugin browser
+```
+
+On merge, the registry fetches the ZIP from your release, computes its checksums independently, re-hosts it on the releases branch, and GPG-signs the manifest. Clients always download from the registry, never directly from your upstream URL.
+
+**Requirements for external plugins:**
+
+- `source_url` must be a GitHub Releases URL (`https://github.com/owner/repo/releases/download/...`); required so the source archive can be fetched for CodeQL analysis
+- `source_url` must contain a `{version}` placeholder that is substituted at publish time
+- `repo_url` is required (points to your source repository)
+- The source repository must be public and under an OSI-approved open source license
+
+Each version bump requires a PR to this repository (updating `version` in `plugin.json`), which must be approved and merged before anything is published. How you automate or manage that is up to you.
 
 Plugin folder names must be **lowercase-kebab-case** (e.g. `my-plugin-name`).
 
@@ -79,12 +104,14 @@ At least one of `author` or `maintainers` must include your GitHub username. `au
 | `maintainers` | `string[]` | Additional GitHub usernames permitted to submit PRs for this plugin (in addition to `author`) |
 | `min_dispatcharr_version` | `string` | Minimum Dispatcharr version required (e.g. `v0.19.0` or `0.19.0`) |
 | `max_dispatcharr_version` | `string` | Maximum Dispatcharr version supported. Must be ≥ `min_dispatcharr_version` if both are set |
-| `repo_url` | `string` | URL to the plugin's source repository (must start with `http://` or `https://`) |
+| `repo_url` | `string` | URL to the plugin's source repository (must start with `http://` or `https://`). Required for external plugins |
 | `discord_thread` | `string` | URL to the associated Discord thread (must start with `http://` or `https://`) |
 | `deprecated` | `boolean` | Marks the plugin as deprecated. Default: `false` |
 | `unlisted` | `boolean` | Excludes the plugin from the root `manifest.json` (and the releases README) but still generates a per-plugin manifest. Default: `false` |
+| `source_type` | `string` | Set to `"external"` to declare this as an external plugin. Omit (or `"local"`) for standard plugins |
+| `source_url` | `string` | Required when `source_type` is `"external"`. Must be a GitHub Releases URL containing a `{version}` placeholder, e.g. `https://github.com/owner/repo/releases/download/v{version}/plugin.zip` |
 
-### Full Example
+### Full Example (standard plugin)
 
 ```json
 {
@@ -95,6 +122,22 @@ At least one of `author` or `maintainers` must include your GitHub username. `au
   "maintainers": ["collaborator-username"],
   "license": "MIT",
   "min_dispatcharr_version": "v0.19.0",
+  "repo_url": "https://github.com/your-github-username/my-plugin",
+  "discord_thread": "https://discord.com/channels/..."
+}
+```
+
+### Full Example (external plugin)
+
+```json
+{
+  "name": "My Plugin",
+  "version": "1.2.0",
+  "description": "Does something useful for Dispatcharr",
+  "author": "your-github-username",
+  "license": "MIT",
+  "source_type": "external",
+  "source_url": "https://github.com/your-github-username/my-plugin/releases/download/v{version}/my-plugin.zip",
   "repo_url": "https://github.com/your-github-username/my-plugin",
   "discord_thread": "https://discord.com/channels/..."
 }
@@ -117,7 +160,11 @@ Automated validation runs on every PR and posts a comment with results. The foll
 | `min_dispatcharr_version` | Must be semver if provided |
 | `max_dispatcharr_version` | Must be semver and ≥ `min_dispatcharr_version` if both provided |
 | `repo_url` / `discord_thread` | Must start with `http://` or `https://` if provided |
-| CodeQL | Python code is scanned for security issues (blocking) || ClamAV | All submitted files are scanned for malware (blocking) || `.github/` | Cannot be modified by non-maintainers of this repository |
+| CodeQL | Python code is scanned for security issues (blocking). For external plugins, the source archive is fetched from GitHub and scanned |
+| ClamAV | All submitted files are scanned for malware (blocking). For external plugins, the release ZIP is downloaded and scanned |
+| `source_url` | For external plugins: must be a GitHub Releases URL with a `{version}` placeholder; artifact must be reachable |
+| `repo_url` | Required for external plugins |
+| `.github/` | Cannot be modified by non-maintainers of this repository |
 
 PRs where the author has no permission for any of the modified plugins are **automatically closed** with instructions. PRs from accounts or plugins on the repository blocklist are also automatically closed.
 
@@ -125,12 +172,20 @@ PRs where the author has no permission for any of the modified plugins are **aut
 
 Once your PR merges to `main`, the publish workflow runs automatically:
 
+**Standard plugins:**
 1. Your plugin is packaged into a versioned ZIP (`your-plugin-1.0.0.zip`) and a latest ZIP (`your-plugin-latest.zip`)
 2. MD5 and SHA256 checksums are computed
-3. A per-plugin `zips/your-plugin-name/README.md` is generated with download links and version history
-4. `manifest.json` is updated with your plugin's metadata and download URLs
+3. `manifest.json` is updated with your plugin's metadata, checksums, and download URLs
+4. A per-plugin `zips/your-plugin-name/README.md` is generated with download links and version history
 5. The releases branch README is regenerated
 6. Up to 10 versioned ZIPs are retained; older ones are pruned
+
+**External plugins:**
+1. The ZIP is downloaded from your `source_url` (with `{version}` substituted)
+2. MD5 and SHA256 checksums are computed by the registry's infrastructure (not trusted from upstream)
+3. The ZIP is re-hosted on the releases branch; clients download from the registry, not your upstream URL
+4. `manifest.json` is updated with checksums and includes `source_url` pointing to the upstream release
+5. Steps 4–6 above apply identically
 
 Everything is pushed to the [`releases` branch](https://github.com/Dispatcharr/Plugins/tree/releases).
 
@@ -155,7 +210,7 @@ Version increments are enforced by the validation workflow. You cannot submit a 
 - `deprecated`
 - `unlisted`
 
-All other fields - including `name`, `author`, `license`, and any code changes - require a version bump.
+All other fields - including `name`, `author`, `license`, `source_url`, `source_type`, and any code changes - require a version bump.
 
 ## Licensing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ On merge, the registry fetches the ZIP from your release, computes its checksums
 
 **Requirements for external plugins:**
 
-- `source_url` must be a GitHub Releases download URL (`https://github.com/owner/repo/releases/download/...`)
+- `source_url` must be an HTTPS URL pointing directly to a downloadable ZIP
 - `source_url` must contain a `{version}` placeholder that is substituted at publish time
 - `repo_url` is required (points to your source repository)
 - The source repository must be public and under an OSI-approved open source license
@@ -162,7 +162,7 @@ Automated validation runs on every PR and posts a comment with results. The foll
 | `repo_url` / `discord_thread` | Must start with `http://` or `https://` if provided |
 | CodeQL | Python code is scanned for security issues (blocking). For external plugins, the release ZIP is downloaded and its contents scanned |
 | ClamAV | All submitted files are scanned for malware (blocking). For external plugins, the release ZIP is downloaded and scanned |
-| `source_url` | For external plugins: must be a GitHub Releases URL with a `{version}` placeholder; artifact must be reachable |
+| `source_url` | For external plugins: must be an HTTPS URL with a `{version}` placeholder; artifact must be reachable |
 | `repo_url` | Required for external plugins |
 | `.github/` | Cannot be modified by non-maintainers of this repository |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ On merge, the registry fetches the ZIP from your release, computes its checksums
 
 **Requirements for external plugins:**
 
-- `source_url` must be a GitHub Releases URL (`https://github.com/owner/repo/releases/download/...`); required so the source archive can be fetched for CodeQL analysis
+- `source_url` must be a GitHub Releases download URL (`https://github.com/owner/repo/releases/download/...`)
 - `source_url` must contain a `{version}` placeholder that is substituted at publish time
 - `repo_url` is required (points to your source repository)
 - The source repository must be public and under an OSI-approved open source license
@@ -160,7 +160,7 @@ Automated validation runs on every PR and posts a comment with results. The foll
 | `min_dispatcharr_version` | Must be semver if provided |
 | `max_dispatcharr_version` | Must be semver and ≥ `min_dispatcharr_version` if both provided |
 | `repo_url` / `discord_thread` | Must start with `http://` or `https://` if provided |
-| CodeQL | Python code is scanned for security issues (blocking). For external plugins, the source archive is fetched from GitHub and scanned |
+| CodeQL | Python code is scanned for security issues (blocking). For external plugins, the release ZIP is downloaded and its contents scanned |
 | ClamAV | All submitted files are scanned for malware (blocking). For external plugins, the release ZIP is downloaded and scanned |
 | `source_url` | For external plugins: must be a GitHub Releases URL with a `{version}` placeholder; artifact must be reachable |
 | `repo_url` | Required for external plugins |


### PR DESCRIPTION
Closes #60.

Adds a new `source_type: "external"` option for plugins that publish releases from their own repository. Instead of submitting full source, plugin authors submit only a `plugin.json` with a `source_url` template pointing to a downloadable ZIP.

On PR, the release ZIP is downloaded and scanned by both CodeQL and ClamAV. On merge, the registry fetches the ZIP, computes checksums independently, re-hosts it on the releases branch, and GPG-signs the manifest as normal. Clients always download from the registry.

**Using it**

The only difference from a standard plugin submission is two additional fields in `plugin.json`:

The following is an example using my plugin, dispatcharr-exporter.
```json
"source_type": "external",
"source_url": "https://github.com/swvn-dispatch/dispatcharr-exporter/releases/download/v{version}/dispatcharr-exporter-{version}.zip"
```

`{version}` is substituted automatically at publish time. Everything else works the same, and you can still include a `logo.png`, `README.md`, and all the usual optional fields.


**Changes:**
- `plugin.json` gains `source_type` and `source_url` fields; validation enforces HTTPS URL with a `{version}` placeholder and confirms the artifact is reachable
- `build-zips.sh` fetches the remote ZIP instead of packaging local source when `source_type` is `external`
- `generate-manifest.sh` surfaces `source_type` and `source_url` in per-plugin and versioned ZIP manifest entries
- `validate-plugin.yml` downloads and scans the release ZIP for both CodeQL and ClamAV; CodeQL finding links are suppressed for external plugin paths since the files don't exist in this repo
- `report.sh` fixes a duplicate horizontal rule that appeared when ClamAV passed but CodeQL had results
- `CONTRIBUTING.md` documents the external plugin schema and workflow
