### PR TITLE
[repo]: use ASCII output in jq signing to match Python json.dumps defaults

### DIFF
--- a/.github/scripts/publish/generate-manifest.sh
+++ b/.github/scripts/publish/generate-manifest.sh
@@ -85,7 +85,7 @@ sign_manifest() {
     gpg_opts+=(--passphrase "$GPG_PASSPHRASE" --pinentry-mode loopback)
   fi
   local sig
-  sig=$(jq -c '.manifest' "$file" | gpg "${gpg_opts[@]}" 2>/dev/null) || true
+  sig=$(jq -ca '.manifest' "$file" | gpg "${gpg_opts[@]}" 2>/dev/null) || true
   if [[ -z "$sig" ]]; then
     echo "::warning::GPG signing failed for ${file} - all signatures will be removed."
     gpg_signing_failed=1


### PR DESCRIPTION
The manifest signature verification in Dispatcharr uses Python's
json.dumps with ensure_ascii=True (the default), which escapes non-ASCII
characters as \uXXXX. The signing step used jq -c, which outputs raw
UTF-8. These produce different byte sequences for the same data, causing
BADSIG on any manifest containing non-ASCII characters.

Adding -a (--ascii-output) to the jq signing call makes both sides use
the same canonical form.

The currently published manifest will need a new publish run to pick up
a fresh signature.
