### PR TITLE
[waybill]: Fix plugin manifest JSON description and minimum supported Dispatcharr version

### DIFF
--- a/plugins/waybill/plugin.json
+++ b/plugins/waybill/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "Waybill",
   "version": "1.3.0",
-  "description": "Waybill matches, renames, and organizes any streams—no matter the provider. Infinitely configurable pipelines for total control.",
+  "description": "Waybill matches, renames, and organizes any streams no matter the provider. Infinitely configurable pipelines for total control.",
   "author": "Matthew-Beckett",
   "license": "MIT",
-  "min_dispatcharr_version": "0.24.0",
+  "min_dispatcharr_version": "0.23.0",
   "max_dispatcharr_version": "0.24.0",
   "repo_url": "https://github.com/Matthew-Beckett/waybill",
   "help_url": "https://github.com/Matthew-Beckett/waybill",


### PR DESCRIPTION
## About this submission

This PR fixes Waybill's manifest to remove an errant character from the description and the minimum supported Dispatcharr version.

## Pre-submission checklist

<!-- Tick each box that applies. The bot will validate automatically, but catching issues here saves time. -->

**If this is a new plugin:**
- [x] Plugin folder is named `lowercase-kebab-case`
- [x] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
- [x] My GitHub username is in `author` or `maintainers`
- [x] `license` is a valid [OSI-approved SPDX identifier](https://spdx.org/licenses/) (e.g. `MIT`, `Apache-2.0`)
- [x] I have tested the plugin against a running Dispatcharr instance

**If this is an update to an existing plugin:**
- [x] `version` in `plugin.json` is incremented (unless this is a metadata-only change - see [Versioning](https://github.com/Dispatcharr/Plugins/blob/main/CONTRIBUTING.md#versioning))
- [x] I am listed in `author` or `maintainers` of the existing plugin
