### PR TITLE
[repo]: PR report links, empty-dir validation, and metadata manifest fix

### DIFF
--- a/.github/scripts/publish/generate-manifest.sh
+++ b/.github/scripts/publish/generate-manifest.sh
@@ -110,6 +110,9 @@ for plugin_dir in plugins/*/; do
   [[ ! -f "$plugin_file" ]] && continue
   plugin_name=$(basename "$plugin_dir")
   plugin_key=${plugin_name//-/_}
+  current_version=$(jq -r '.version' "$plugin_file")
+  min_da_version=$(jq -r '.min_dispatcharr_version // ""' "$plugin_file")
+  max_da_version=$(jq -r '.max_dispatcharr_version // ""' "$plugin_file")
   unlisted=false
   [[ "$(jq -r '.unlisted // false' "$plugin_file")" == "true" ]] && unlisted=true
 
@@ -173,6 +176,19 @@ for plugin_dir in plugins/*/; do
   done < <(ls -1 "zips/$plugin_name/${plugin_name}"-*.zip 2>/dev/null \
       | grep -v latest | sort -t- -k2 -V -r)
 
+  # Overwrite min/max_dispatcharr_version for the current version's entry from plugin.json,
+  # so metadata-only updates (no version bump) are reflected without a rebuild.
+  versioned_zips=$(jq \
+    --arg v "$current_version" \
+    --arg min "$min_da_version" \
+    --arg max "$max_da_version" \
+    'map(if .version == $v then
+      . + {
+        min_dispatcharr_version: (if $min != "" then $min else null end),
+        max_dispatcharr_version: (if $max != "" then $max else null end)
+      } | with_entries(select(.value != null))
+    else . end)' <<< "$versioned_zips")
+
   plugin_entry=$(jq \
     --arg plugin_name "$plugin_name" \
     --arg latest_url "$latest_url" \
@@ -204,8 +220,8 @@ for plugin_dir in plugins/*/; do
         last_updated: $latest_metadata.last_updated,
         checksum_md5: $latest_metadata.checksum_md5,
         checksum_sha256: $latest_metadata.checksum_sha256,
-        min_dispatcharr_version: $latest_metadata.min_dispatcharr_version,
-        max_dispatcharr_version: $latest_metadata.max_dispatcharr_version,
+        min_dispatcharr_version: (.min_dispatcharr_version // null),
+        max_dispatcharr_version: (.max_dispatcharr_version // null),
         source_url: $latest_metadata.source_url,
         latest_url: $latest_url,
         url: $versioned_zips[0].url,
@@ -246,6 +262,8 @@ for plugin_dir in plugins/*/; do
     --arg license "$(jq -r '.license // ""' "$plugin_file")" \
     --argjson deprecated "$(jq 'if .deprecated == true then true else null end' "$plugin_file")" \
     --argjson latest_size_kb "$latest_size_kb" \
+    --arg min_da_version "$min_da_version" \
+    --arg max_da_version "$max_da_version" \
     '{
       slug: $slug,
       name: $name,
@@ -260,8 +278,8 @@ for plugin_dir in plugins/*/; do
       latest_sha256: ($latest_metadata.checksum_sha256 // null),
       latest_url: ($versioned_zips[0].url // null),
       latest_size: (if $latest_size_kb > 0 then $latest_size_kb else null end),
-      min_dispatcharr_version: ($latest_metadata.min_dispatcharr_version // null),
-      max_dispatcharr_version: ($latest_metadata.max_dispatcharr_version // null)
+      min_dispatcharr_version: (if $min_da_version != "" then $min_da_version else null end),
+      max_dispatcharr_version: (if $max_da_version != "" then $max_da_version else null end)
     } | with_entries(select(.value != null))')
   root_entries+=("$root_entry")
 done

--- a/.github/scripts/validate/validate.sh
+++ b/.github/scripts/validate/validate.sh
@@ -78,11 +78,16 @@ has_permission="false"
 {
   echo "### Plugin: \`$PLUGIN_NAME\`"
   echo ""
-  # Show description as italicized subtext if plugin.json is readable
+  # Show description and repo link as header subtext if plugin.json is readable
   if [[ -f "$PLUGIN_JSON" ]]; then
     _desc=$(jq -r '.description // ""' "$PLUGIN_JSON" 2>/dev/null || true)
+    REPO_URL=$(jq -r '.repo_url // ""' "$PLUGIN_JSON" 2>/dev/null || true)
     if [[ -n "$_desc" ]]; then
       echo "_${_desc}_"
+      echo ""
+    fi
+    if [[ -n "$REPO_URL" ]]; then
+      echo "[Source Repository]($REPO_URL)"
       echo ""
     fi
   fi
@@ -148,8 +153,31 @@ has_permission="false"
   MAINTAINERS=$(jq -r '[.maintainers[]?] | join(" ")' "$PLUGIN_JSON")
   VERSION=$(jq -r '.version' "$PLUGIN_JSON")
 
+  # Pre-fetch base branch plugin.json once - reused for version bump check and compare link
+  _base_pjson=""
+  OLD_VERSION=""
+  OLD_SOURCE_URL_TMPL=""
+  if git show "origin/${BASE_REF}:${PLUGIN_JSON}" > /dev/null 2>&1; then
+    _base_pjson=$(git show "origin/${BASE_REF}:${PLUGIN_JSON}")
+    OLD_VERSION=$(echo "$_base_pjson" | jq -r '.version // ""')
+    OLD_SOURCE_URL_TMPL=$(echo "$_base_pjson" | jq -r '.source_url // ""')
+  fi
+
   # ── External source checks ────────────────────────────────────────────────────
   source_type=$(jq -r '.source_type // "local"' "$PLUGIN_JSON")
+  release_link=""
+  compare_link=""
+  _gh_tag=""
+  _old_gh_tag=""
+  if [[ "$source_type" != "external" ]]; then
+    _src_count=$(find "$PLUGIN_DIR" -type f \
+      ! -name 'plugin.json' ! -name 'README.md' ! -name 'logo.png' \
+      | wc -l | tr -d ' ')
+    if [[ "$_src_count" -eq 0 ]]; then
+      TABLE_ROWS+=("| Plugin files | ❌ | No source files found in \`plugins/$PLUGIN_NAME/\`. Add your plugin source (e.g. \`main.py\`) or set \`\"source_type\": \"external\"\` in \`plugin.json\` if your plugin is hosted elsewhere |")
+      failed=1
+    fi
+  fi
   if [[ "$source_type" == "external" ]]; then
     ext_source_url=$(jq -r '.source_url // ""' "$PLUGIN_JSON")
     ext_repo_url=$(jq -r '.repo_url // ""' "$PLUGIN_JSON")
@@ -170,6 +198,19 @@ has_permission="false"
         http_code=$(curl -o /dev/null -s -w "%{http_code}" --max-time 15 -L "$resolved_url" || echo "000")
         if [[ "$http_code" == "200" ]]; then
           TABLE_ROWS+=("| Release artifact | ✅ | Artifact reachable at resolved URL |")
+          if [[ "$resolved_url" =~ ^https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/ ]]; then
+            _gh_owner="${BASH_REMATCH[1]}"
+            _gh_repo="${BASH_REMATCH[2]}"
+            _gh_tag="${BASH_REMATCH[3]}"
+            release_link="https://github.com/${_gh_owner}/${_gh_repo}/releases/tag/${_gh_tag}"
+            if [[ -n "$OLD_VERSION" && -n "$OLD_SOURCE_URL_TMPL" ]]; then
+              _old_resolved="${OLD_SOURCE_URL_TMPL//\{version\}/$OLD_VERSION}"
+              if [[ "$_old_resolved" =~ ^https://github\.com/[^/]+/[^/]+/releases/download/([^/]+)/ ]]; then
+                _old_gh_tag="${BASH_REMATCH[1]}"
+                compare_link="https://github.com/${_gh_owner}/${_gh_repo}/compare/${_old_gh_tag}...${_gh_tag}"
+              fi
+            fi
+          fi
         else
           TABLE_ROWS+=("| Release artifact | ❌ | Could not reach \`$resolved_url\` (HTTP \`$http_code\`) — ensure the release exists |")
           failed=1
@@ -261,13 +302,12 @@ has_permission="false"
   METADATA_ONLY_FIELDS=("description" "repo_url" "discord_thread"
     "min_dispatcharr_version" "max_dispatcharr_version" "deprecated" "unlisted" "maintainers")
 
-  if git show "origin/${BASE_REF}:${PLUGIN_JSON}" > /dev/null 2>&1; then
-    OLD_VERSION=$(git show "origin/${BASE_REF}:${PLUGIN_JSON}" | jq -r '.version')
+  if [[ -n "$_base_pjson" ]]; then
     if version_greater_than "$VERSION" "$OLD_VERSION"; then
       TABLE_ROWS+=("| Version bump | ✅ | \`$OLD_VERSION\` → \`$VERSION\` |")
     else
       # Version unchanged - check if every changed field is in the metadata-only allowlist
-      OLD_JSON=$(git show "origin/${BASE_REF}:${PLUGIN_JSON}")
+      OLD_JSON="$_base_pjson"
       NEW_JSON=$(cat "$PLUGIN_JSON")
 
       # Produce a newline-separated list of field names that differ (raw strings, no quotes)
@@ -330,7 +370,6 @@ has_permission="false"
 
   # ── Optional link fields (hidden if pass) ────────────────────────────────────
 
-  REPO_URL=$(jq -r '.repo_url // ""' "$PLUGIN_JSON")
   DISCORD_THREAD=$(jq -r '.discord_thread // ""' "$PLUGIN_JSON")
 
   if [[ -n "$REPO_URL" ]] && [[ ! "$REPO_URL" =~ ^https?:// ]]; then
@@ -344,6 +383,13 @@ has_permission="false"
   fi
 
   print_table
+
+  if [[ -n "$release_link" ]]; then
+    _link_line="[View release ${_gh_tag} on GitHub](${release_link})"
+    [[ -n "$compare_link" ]] && _link_line+=" · [Compare ${_old_gh_tag}...${_gh_tag}](${compare_link})"
+    echo "$_link_line"
+    echo ""
+  fi
 
   # Metadata row (tab-delimited, consumed by aggregate-report.sh)
   echo "<!--META_ROW:$(jq -r '[


### PR DESCRIPTION
**`validate.sh`**
- Plugin `repo_url` now appears as a link above the check table in every report fragment
- For external plugins hosted on GitHub Releases, the fragment now includes a release link (and a compare link when updating an existing version) after the table
- Non-external plugins with no source files (only `plugin.json`, `README.md`, or `logo.png`) now fail validation with a clear message pointing to `source_type: "external"` as an alternative
- Base branch `plugin.json` is now fetched once and reused across the version bump check and compare link logic (previously fetched up to 3 times)

**`generate-manifest.sh`**
- `min_dispatcharr_version` and `max_dispatcharr_version` in generated manifests (`latest` block, current version's `versions` entry, root manifest) are now read directly from `plugin.json` rather than from build-time metadata. This fixes a bug where metadata-only updates to these fields (no version bump) were not reflected in the manifests after publish.