### PR TITLE
[epgeditarr] Add EPGeditARR plugin

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "EPGeditARR",
+  "version": "0.1.7",
+  "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and sorts SiriusXM channels into official lineup order with automatic seasonal channel handling.",
+  "author": "jstevenscl",
+  "license": "MIT",
+  "repo_url": "https://github.com/jstevenscl/epgeditarr",
+  "help_url": "https://jstevenscl.github.io/epgeditarr/designer.html",
+  "source_type": "external",
+  "source_url": "https://github.com/jstevenscl/epgeditarr/releases/download/v{version}/epgeditarr-v{version}.zip"
+}


### PR DESCRIPTION
## Summary

- Adds EPGeditARR as an external plugin (source hosted at https://github.com/jstevenscl/epgeditarr)
- Transforms EPG source programs using per-source, per-field regex and find/replace rules; virtual copies are kept in sync automatically after every EPG refresh — originals are never touched
- Fills placeholder EPG schedules for channels with no program data
- Sorts SiriusXM channels into official Wikipedia lineup order with automatic seasonal channel handling

## Test plan

- [ ] Validate `plugin.json` passes CI checks (required fields, semver, external source_url format)
- [ ] Confirm `source_url` artifact is reachable at https://github.com/jstevenscl/epgeditarr/releases/download/v0.1.7/epgeditarr-v0.1.7.zip
- [ ] ClamAV / CodeQL scans pass on the downloaded ZIP

🤖 Generated with [Claude Code](https://claude.com/claude-code)