### PR TITLE
[iptv-checker]: Update to v1.26.1362003

### DIFF
--- a/plugins/iptv-checker/README.md
+++ b/plugins/iptv-checker/README.md
@@ -4,6 +4,8 @@
 
 [![Dispatcharr plugin](https://img.shields.io/badge/Dispatcharr-plugin-8A2BE2)](https://github.com/Dispatcharr/Dispatcharr)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin)
+[![Workflow Guide](https://img.shields.io/badge/%F0%9F%93%96-Workflow_Guide-1F6FEB?style=flat)](https://piratesirc.github.io/Dispatcharr-Plugin-Workflow/workflow/01-iptv-checker/)
+[![Discord](https://img.shields.io/badge/Discord-Discussion-5865F2?logo=discord&logoColor=white)](https://discord.gg/Sp45V5BcxU)
 
 [![GitHub Release](https://img.shields.io/github/v/release/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin?include_prereleases&logo=github)](https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin/releases)
 [![Downloads](https://img.shields.io/github/downloads/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin/total?color=success&label=Downloads&logo=github)](https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin/releases)
@@ -39,7 +41,11 @@ Before installing or using this plugin, it is **highly recommended** that you cr
 - **Enhanced Error Categorization:** Detailed error types (Timeout, 404, 403, Connection Refused, etc.)
 - **Webhook Notifications:** Send HTTP POST notifications after scheduled checks complete
 - **Auto-Delete Dead Channels:** Permanently remove dead channels with safety confirmation gate
-- **CSV Exports:** Export results with comprehensive statistics and URL masking
+- **CSV Exports:** Export results with comprehensive statistics and URL masking. Scheduled sessions emit a CSV every time a run ends — including windowed runs that close mid-list — so each window has its own audit record (v1.26.1191257+; the hoist regressed via the subfolder/root sync drift and was re-applied in v1.26.1212238).
+- **Video Bitrate Reporting:** Per-stream `video_bitrate` (kbps) captured via ffprobe per-packet data and stored in Dispatcharr's `stream_stats`, so the channel-menu UI can display it. Live MPEG-TS / HLS streams almost never expose container-level `bit_rate`, so the plugin computes the average from `packets[].size / packets[].duration_time` for the video stream. Rounded to the nearest whole kbps before write (v1.26.1220052+). Probes that capture fewer than 30 video packets (≈1s of 30fps video) leave `video_bitrate` unset rather than persist a noisy average — short samples were producing wildly inflated values (observed: 22924 kbps from 2 packets) that polluted the channel-menu display (v1.26.1221035+). The default `ffprobe_analysis_duration` was bumped from 5 s → 8 s in v1.26.1221101 to give slow-start streams enough room to clear the 30-packet trust gate; verified runs jumped from 97% to 100% bitrate coverage on alive streams with median packet count rising from 200–400 → 662 (default-only change, existing deployments keep their saved value). The default `ffprobe_flags` was changed to `-show_streams,-show_packets,-loglevel error` in v1.26.1211342 — passing both `-show_frames` and `-show_packets` makes ffprobe emit a combined `packets_and_frames` array instead of separate `packets[]`, which silently breaks the bitrate calc. If you've customized `ffprobe_flags`, do **not** include `-show_frames`.
+- **Window-Aware Retry Pass:** When a windowed run closes mid-list, the parallel/sequential retry passes now also bail on `_past_window_end()` so transient-error retries cannot overshoot the window boundary (v1.26.1212238+; previously observed up to 14 minutes of overrun).
+- **Adaptive Rate-Limit Guard:** Detects upstream HTTP 429 responses, classifies them as **Skipped (Rate Limited)** instead of Dead so destructive actions never act on a throttled stream, and applies an exponentially-doubling cooldown when 429s spike (v1.26.1181025+). The cooldown counter is shared across the whole container — Dispatcharr's multiple worker processes can no longer reset it independently (v1.26.1181126+).
+- **Single-Scheduler Election:** Dispatcharr runs ~9 separate Python processes; a file-based PID lock at `/data/iptv_checker_scheduler.pid` ensures exactly one of them hosts the cron scheduler. Prior versions could fire each cron N times in parallel (v1.26.1181126+). Module-reload duplicate-thread protection added in v1.26.1191257 (Django/uwsgi could re-import the plugin module within the elected process and spawn additional scheduler threads, defeating the PID lock). Cross-worker UI-restart protection added in v1.26.1220951: any UI button click landed in whichever uwsgi worker the load balancer picked, and `update_schedule_action` / `Plugin.run()` previously called `_start_background_scheduler` directly without checking the PID lock — so non-owner workers spawned rogue scheduler threads (observed: `'59 23 * * *'` fired twice 27 ms apart on 2026-05-02). Non-owners now write a `/data/iptv_checker_scheduler_reload.flag` file that the owner's scheduler loop polls every 30 s; the owner re-reads settings via `_fresh_settings` and swaps its cron expressions in place.
 
 ## Requirements
 
@@ -124,13 +130,15 @@ To update the plugin:
 | FFprobe Path | string | `/usr/local/bin/ffprobe` | Full path to the ffprobe executable |
 | FFprobe Analysis Flags | string | `-show_streams,-show_frames,...` | Comma-separated FFprobe flags |
 | FFprobe Analysis Duration | number | 5 | Seconds of stream to analyze |
+| Streamlink-Only Hosts | string | `youtube.com, youtu.be, twitch.tv, kick.com` | Comma-separated host suffixes ffprobe cannot validate (served via Streamlink). Streams matching these hosts are marked **Skipped** instead of **Dead**, so rename/move/delete actions leave them alone. Blank falls back to defaults. |
 
 ### Parallel Checking
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | Enable Parallel Checking | boolean | true | Check multiple streams simultaneously |
-| Number of Parallel Workers | number | 2 | How many streams to check at once |
+| Number of Parallel Workers | number | 2 | How many streams to check at once. **Keep below your provider's concurrent-connection limit.** |
+| Per-Stream Cooldown (seconds) | number | 2 | Each worker waits this long after finishing a check before picking up the next. Prevents provider rate-limiting / slot-reuse errors. Retry passes wait 3× this value. |
 
 ### Webhook
 
@@ -142,8 +150,12 @@ To update the plugin:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| Scheduled Check Times | string | *(empty)* | Cron expression (e.g., `0 4 * * *` for daily at 4 AM) |
+| Scheduled Check Times | string | *(empty)* | Cron expression (e.g., `0 4 * * *` for daily at 4 AM). When **Use Windowed Schedule** is on, this becomes the window **start** trigger. |
 | Scheduler Timezone | select | `America/Chicago` | Timezone for the scheduler |
+| Use Windowed Schedule | boolean | false | When on, each cron-fire opens a run window. The check runs until the configured end-of-window, then halts cleanly between streams. The next time the window opens, the run **resumes** from where it left off — already-checked streams are skipped. |
+| Window End Mode | select | `duration` | `duration` = run for N hours; `time` = run until a specific HH:MM (wraps past midnight if earlier than the start). |
+| Window Duration (hours) | number | 4 | Used when Window End Mode = duration. Decimals allowed (e.g. 3.5). |
+| Window End Time | string | `04:00` | Used when Window End Mode = time. 24-hour format in the Scheduler Timezone above. |
 | Export CSV for Scheduled Checks | boolean | false | Auto-export results to CSV after scheduled checks |
 | Rename Dead Channels | boolean | false | Auto-rename dead channels after scheduled checks |
 | Rename Low Framerate Channels | boolean | false | Auto-rename slow channels after scheduled checks |
@@ -220,7 +232,7 @@ To update the plugin:
 - **Load Group(s):** Load channels from specified groups (async for large lists)
 - **Start Stream Check:** Begin checking all loaded streams in background thread
 - **View Check Progress:** View current progress and ETA of the running check
-- **Cancel Stream Check:** Stop the currently running stream check
+- **Cancel Stream Check:** Stop the currently running stream check (confirmation dialog; queued and in-flight streams abort, already-probed results are kept)
 - **View Last Results:** View summary of the last completed stream check
 
 ### Channel Management
@@ -252,6 +264,28 @@ Use shell-style wildcards in the Group(s) to Check field:
 - **Post-Check Automation:** Chain any combination of rename, move, delete, export, and webhook actions
 - **Conflict Prevention:** Scheduler queues jobs if a manual check is already running
 
+#### Windowed Schedules with Resume
+
+For overnight or off-peak runs, enable **Use Windowed Schedule**. The cron expression becomes the window **start**; the check halts cleanly when the window closes and resumes from the same place the next time the window opens.
+
+**Example — Sun–Thu, 00:00 → 04:00 CST:**
+
+| Setting | Value |
+|---|---|
+| Scheduled Check Times | `0 0 * * 0-4` |
+| Scheduler Timezone | `America/Chicago` |
+| Use Windowed Schedule | ✅ on |
+| Window End Mode | `duration` |
+| Window Duration (hours) | `4` |
+
+What happens:
+
+- The window opens at midnight Sun–Thu and runs for 4 hours.
+- Per-stream progress is persisted to `/data/iptv_checker_pending_resume.json`.
+- If the window closes before the channel list is finished, post-check actions (rename / move / delete / webhook) are **deferred** to the window that completes the list.
+- If the container restarts mid-window, the original window end is preserved and the check resumes immediately rather than waiting for the next cron fire.
+- Click **Reset Window Progress** to wipe pending state and start fresh on the next window.
+
 ### Metadata Synchronization
 - **Database Sync:** Automatically updates Dispatcharr with technical stream details from FFprobe analysis
 - **Synced Fields:** Video/Audio Codecs, Resolution, Bitrates, Sample Rates, Audio Channels, Stream Types
@@ -261,6 +295,15 @@ Use shell-style wildcards in the Group(s) to Check field:
 - Provides server recovery time between retry attempts
 - Retry queue processes every 4 streams to balance throughput and recovery
 - Multiple retry attempts per stream based on configured retry count
+- **Retry-aware ETA:** `View Check Progress` keeps the percentage and ETA honest through retry passes — it no longer snaps to 100% at the end of the first pass.
+
+### Provider Concurrency Limits
+Most IPTV providers cap concurrent connections per account (often 1–4). Two settings let you stay under the cap while still running checks in parallel:
+
+- **Number of Parallel Workers** — keep this **below** your account's cap. For a 4-stream account, 2 workers leaves headroom for viewing while a check runs.
+- **Per-Stream Cooldown** — 2 s by default. Each worker waits this long after finishing before picking up the next stream, so the upstream slot has time to release. Retry passes wait `3×` this value.
+
+If you see a lot of "Server Error" or "Stream Unreachable" results that turn alive on retry, raise the cooldown or drop the worker count.
 
 ### Auto-Delete Dead Channels
 - Permanently deletes channels with dead streams from the database
@@ -287,10 +330,12 @@ docker restart dispatcharr
 - Restart Dispatcharr container
 
 **Scheduler Not Running:**
+- The scheduler starts automatically on container boot — no UI action needed
 - Verify `pytz` is installed in the container
 - Check cron syntax (5 fields required: minute hour day month weekday)
 - Use **Check Scheduler Status** to verify state
 - Check logs: `docker logs dispatcharr | grep -i scheduler`
+- Confirm scheduler started on boot: `docker logs dispatcharr | grep "Background scheduler thread started"`
 
 **Stream Check Failures:**
 - Increase connection timeout and/or probe timeout for slow streams
@@ -312,6 +357,10 @@ docker restart dispatcharr
 - **Settings:** `/data/iptv_checker_settings.json`
 - **CSV Exports:** `/data/exports/iptv_checker_results_YYYYMMDD_HHMMSS.csv`
 
+## Versioning
+
+This plugin uses calver `1.26.{DDD}{HHMM}` (UTC day-of-year + UTC hour-minute), matching the Lineuparr / Channel-Mapparr / EPG-Janitor cohort. Releases prior to `1.26.1081815` used semver (`0.X.Y`). See the [release notes](https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin/releases) for full changelogs.
+
 ## Contributing
 
 When reporting issues:
@@ -320,3 +369,44 @@ When reporting issues:
 3. Test with small channel groups first
 4. Document specific error messages and error types
 5. Note current progress from **View Last Results**
+
+Pull requests welcome. To submit changes:
+
+### To this repo (PiratesIRC/Dispatcharr-IPTV-Checker-Plugin)
+
+1. Bump version: `python3 bump_version.py` (auto-stamps with current UTC day-of-year + HHMM).
+2. Commit, push, tag, and release:
+
+```bash
+git tag <version> && git push origin <version>
+gh release create <version> --title "v<version>" --notes "..."
+gh release upload <version> iptv_checker.zip
+```
+
+### To the upstream marketplace (Dispatcharr/Plugins)
+
+Updates also need to be PR'd to `Dispatcharr/Plugins` so the plugin updates in users' Dispatcharr UIs. The repo's GitHub Actions validator enforces strict rules — failing any blocks the merge:
+
+| Check | Requirement |
+|-------|-------------|
+| PR title | Must match `[iptv-checker]: <description>`. The `validate-title` job fails on any other format. Most common trip-up. |
+| Version bump | `plugin.json` version must be greater than the version on upstream `main` for any code/asset change. Metadata-only edits are exempt. |
+| Required `plugin.json` fields | `name`, `version`, `description`, `author`, `license` (SPDX). |
+| Authorship | PR author's GitHub username must appear in `author` or `maintainers`, or the `close-unauthorized` job auto-closes the PR. |
+| Folder name | `plugins/iptv-checker/` (lowercase-kebab) — note this differs from the `iptv_checker/` snake_case used inside this repo's zip. |
+
+Workflow:
+
+```bash
+# In your fork of Dispatcharr/Plugins:
+git fetch upstream && git checkout main && git merge upstream/main --ff-only && git push origin main
+git checkout -b iptv-checker-v<version>
+cp <this-repo>/plugin.{py,json} plugins/iptv-checker/
+git commit -am "[iptv-checker]: ..."
+git push -u origin iptv-checker-v<version>
+gh pr create --repo Dispatcharr/Plugins --base main \
+    --title "[iptv-checker]: Bump to v<version> — <summary>" \
+    --body "..."
+```
+
+On merge, upstream automation builds the zip + checksums and updates `manifest.json` on the `releases` branch — do not touch that branch manually.

--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.1221101",
+  "version": "1.26.1362003",
   "description": "A Dispatcharr Plugin that goes through a playlist to check IPTV channels",
   "author": "PiratesIRC",
   "logo": "logo.png",

--- a/plugins/iptv-checker/plugin.py
+++ b/plugins/iptv-checker/plugin.py
@@ -33,12 +33,20 @@ except ImportError:
     PYTZ_AVAILABLE = False
     # Will log warning later when scheduler is attempted to be used
 
-# Django/Dispatcharr imports for metadata updates
+# Django/Dispatcharr imports for metadata updates.
+# Dispatcharr's dev branch renamed apps.proxy.ts_proxy -> apps.proxy.live_proxy.
+# Prefer the new path, fall back to the legacy one so the plugin works on both
+# current-release and next-release Dispatcharr. The ChannelService API
+# (_update_stream_stats_in_db(stream_id, **stats)) is unchanged across the rename.
 try:
-    from apps.proxy.ts_proxy.services.channel_service import ChannelService
+    from apps.proxy.live_proxy.services.channel_service import ChannelService
     DISPATCHARR_INTEGRATION_AVAILABLE = True
 except ImportError:
-    DISPATCHARR_INTEGRATION_AVAILABLE = False
+    try:
+        from apps.proxy.ts_proxy.services.channel_service import ChannelService
+        DISPATCHARR_INTEGRATION_AVAILABLE = True
+    except ImportError:
+        DISPATCHARR_INTEGRATION_AVAILABLE = False
 
 # Setup logging with plugin name for Dispatcharr's logging system
 class PluginNameFilter(logging.Filter):
@@ -57,6 +65,12 @@ _scheduler_stop_event = threading.Event()
 _scheduler_pending_run = False  # Flag to queue a run if check already in progress
 _scheduler_init_lock = threading.Lock()  # Serialize concurrent _init_scheduler calls
 _scheduler_initialized = False  # Set True after the first Plugin instance bootstraps the scheduler
+# Re-entrant: makes the stop->create->assign-global sequence in
+# _start_background_scheduler atomic against a concurrent start from another
+# thread (e.g. _init_scheduler racing the run()/update-schedule path). RLock so
+# _start_background_scheduler can call _stop_background_scheduler while holding
+# it. Distinct from _scheduler_init_lock to avoid a deadlock with _init_scheduler.
+_scheduler_lifecycle_lock = threading.RLock()
 # _RATE_LIMIT_GUARD is initialized eagerly below the RateLimitGuard class
 # definition so all Plugin instances share one guard counter.
 
@@ -223,12 +237,52 @@ class RateLimitGuard:
 _RATE_LIMIT_GUARD = RateLimitGuard()
 
 
+_CONTAINER_BOOT_TOKEN = None
+
+
+def _container_boot_token():
+    """A token that is stable within one container lifetime but changes on every
+    container (re)start. Used to detect a scheduler lock file left behind on the
+    persistent /data volume by a previous container — after a restart the OS
+    recycles low PID numbers, so the old holder PID frequently collides with a
+    live, unrelated process and os.kill(pid, 0) succeeds, wedging the election.
+
+    Composed of the host kernel boot_id (changes on host reboot) and PID 1's
+    starttime in clock ticks (changes on every container start, since PID 1 is
+    the container entrypoint). Either component alone is insufficient: boot_id
+    is unchanged by a container restart, and starttime can recur across a host
+    reboot. Cached after first computation. Returns "" if nothing readable, in
+    which case callers fall back to the legacy dead-PID check only.
+    """
+    global _CONTAINER_BOOT_TOKEN
+    if _CONTAINER_BOOT_TOKEN is not None:
+        return _CONTAINER_BOOT_TOKEN
+    boot_id = ""
+    try:
+        with open('/proc/sys/kernel/random/boot_id', 'r') as f:
+            boot_id = f.read().strip()
+    except OSError:
+        pass
+    pid1_start = ""
+    try:
+        with open('/proc/1/stat', 'r') as f:
+            # Field 22 (1-indexed) is starttime. The comm field (2) may contain
+            # spaces/parens, so split on the final ')' first.
+            stat = f.read()
+            after = stat[stat.rfind(')') + 1:].split()
+            pid1_start = after[19]  # 22nd field overall -> index 19 after comm
+    except (OSError, IndexError):
+        pass
+    _CONTAINER_BOOT_TOKEN = f"{boot_id}:{pid1_start}" if (boot_id or pid1_start) else ""
+    return _CONTAINER_BOOT_TOKEN
+
+
 class Plugin:
     """Dispatcharr IPTV Checker Plugin"""
     
     # Explicitly set the plugin key
     key = "iptv_checker"
-    version = "1.26.1221101"
+    version = "1.26.1362003"
 
     # Fields and actions are defined in plugin.json (single source of truth)
     def __init__(self):
@@ -303,32 +357,43 @@ class Plugin:
         """
         lock_path = PluginConfig.SCHEDULER_LOCK_FILE
         my_pid = os.getpid()
+        my_token = _container_boot_token()
 
         if os.path.exists(lock_path):
             try:
                 with open(lock_path, 'r') as f:
-                    holder_pid = int(f.read().strip() or '0')
+                    raw = f.read().splitlines()
+                holder_pid = int((raw[0].strip() if raw else '') or '0')
+                holder_token = raw[1].strip() if len(raw) > 1 else ''
                 if holder_pid and holder_pid != my_pid:
-                    try:
-                        os.kill(holder_pid, 0)
-                        LOGGER.info(f"Scheduler already owned by PID {holder_pid}; this process ({my_pid}) will skip scheduler bootstrap.")
-                        return False
-                    except ProcessLookupError:
-                        LOGGER.info(f"Stale scheduler lock for dead PID {holder_pid}; reclaiming as PID {my_pid}.")
-                    except PermissionError:
-                        # Holder is alive but owned by another user (shouldn't
-                        # happen in this container). Treat as held.
-                        LOGGER.info(f"Scheduler lock held by PID {holder_pid} (different uid); skipping.")
-                        return False
-                    # Other OSError (EINTR, transient FS errors): skip rather
-                    # than risk stealing a live lock.
+                    # A lock written by a previous container instance: after a
+                    # restart the recycled PID often collides with a live
+                    # unrelated process, so os.kill() can't be trusted. The
+                    # boot token is the authoritative staleness signal.
+                    if my_token and holder_token and holder_token != my_token:
+                        LOGGER.info(f"Stale scheduler lock from a previous container (PID {holder_pid}, token mismatch); reclaiming as PID {my_pid}.")
+                    else:
+                        try:
+                            os.kill(holder_pid, 0)
+                            LOGGER.info(f"Scheduler already owned by PID {holder_pid}; this process ({my_pid}) will skip scheduler bootstrap.")
+                            return False
+                        except ProcessLookupError:
+                            LOGGER.info(f"Stale scheduler lock for dead PID {holder_pid}; reclaiming as PID {my_pid}.")
+                        except PermissionError:
+                            # Holder is alive but owned by another user (shouldn't
+                            # happen in this container). Treat as held.
+                            LOGGER.info(f"Scheduler lock held by PID {holder_pid} (different uid); skipping.")
+                            return False
+                        # Other OSError (EINTR, transient FS errors): skip rather
+                        # than risk stealing a live lock.
             except (ValueError, OSError):
                 pass
 
         tmp = f"{lock_path}.{my_pid}.tmp"
         try:
             with open(tmp, 'w') as f:
-                f.write(str(my_pid))
+                # Line 1: PID. Line 2: container boot token (staleness signal).
+                f.write(f"{my_pid}\n{my_token}")
                 f.flush()
                 os.fsync(f.fileno())
             os.rename(tmp, lock_path)
@@ -342,7 +407,7 @@ class Plugin:
 
         try:
             with open(lock_path, 'r') as f:
-                won = int(f.read().strip() or '0') == my_pid
+                won = int((f.readline().strip() or '0')) == my_pid
         except (ValueError, OSError):
             won = False
         if won:
@@ -359,7 +424,7 @@ class Plugin:
         """
         try:
             with open(PluginConfig.SCHEDULER_LOCK_FILE, 'r') as f:
-                return int(f.read().strip() or '0') == os.getpid()
+                return int((f.readline().strip() or '0')) == os.getpid()
         except (OSError, ValueError):
             return False
 
@@ -501,9 +566,34 @@ class Plugin:
         saved_fp = pending.get('settings_fingerprint') or {}
         if saved_fp != self._settings_fingerprint(settings):
             logger.warning(
-                f"⏰ WINDOW RESUME: settings changed since last window — continuing with saved channel list. "
+                f"⏰ WINDOW RESUME: settings changed since last window — discarding stale "
+                f"pending state and starting a fresh load with current settings. "
                 f"saved={saved_fp} current={self._settings_fingerprint(settings)}"
             )
+            self._clear_pending_resume()
+            return False
+
+        # A pending file whose window has already elapsed is dead state (e.g.
+        # left behind by a closed window — see _maybe_resume_after_restart).
+        # Resuming it would scan a stale list against the wrong window; discard.
+        saved_end_iso = pending.get('window_end_iso')
+        if saved_end_iso:
+            try:
+                saved_end = datetime.fromisoformat(saved_end_iso)
+                saved_tz = pytz.timezone(pending.get('tz') or PluginConfig.DEFAULT_TIMEZONE)
+                if saved_end.tzinfo is None:
+                    saved_end = saved_tz.localize(saved_end)
+                if datetime.now(saved_tz) >= saved_end:
+                    logger.warning(
+                        "⏰ WINDOW RESUME: saved window already elapsed — discarding "
+                        "stale pending state and starting a fresh load"
+                    )
+                    self._clear_pending_resume()
+                    return False
+            except Exception as e:
+                logger.warning(f"⏰ WINDOW RESUME: could not parse saved window end ({e}); discarding stale pending state")
+                self._clear_pending_resume()
+                return False
 
         loaded = self._load_json_file(self.loaded_channels_file) or []
         if not loaded:
@@ -596,7 +686,8 @@ class Plugin:
             return
         now = datetime.now(tz)
         if now >= end:
-            LOGGER.info("⏰ WINDOW: pending state exists but window already closed — leaving for next scheduled fire")
+            LOGGER.info("⏰ WINDOW: pending state exists but its window already closed — discarding dead pending state")
+            self._clear_pending_resume()
             return
         LOGGER.info(f"⏰ WINDOW: pending state detected (ends {end.isoformat()}); resuming check after restart")
         # Set the guard BEFORE spawning so the scheduler_loop's first tick
@@ -805,9 +896,6 @@ class Plugin:
             LOGGER.error("Scheduler requires pytz library but it is not installed")
             return
         
-        # Stop any existing scheduler first
-        self._stop_background_scheduler()
-        
         # Get and validate schedule configuration
         scheduled_times_str = settings.get("scheduled_times", "")
         if not scheduled_times_str:
@@ -838,6 +926,14 @@ class Plugin:
 
             while not _scheduler_stop_event.is_set():
                 try:
+                    # Self-evict if superseded: a newer _start_background_scheduler
+                    # may have replaced the global without _stop_background_scheduler
+                    # having joined this thread. Belt-and-suspenders alongside the
+                    # lifecycle lock so an orphaned loop can never double-fire.
+                    if _bg_scheduler_thread is not threading.current_thread():
+                        LOGGER.info("Scheduler loop superseded by a newer thread — exiting orphaned loop")
+                        return
+
                     # Reload schedule from DB if a non-owner worker requested it
                     # (UI "Update Schedule" handled in a different uwsgi process).
                     if os.path.exists(PluginConfig.SCHEDULER_RELOAD_FLAG):
@@ -916,27 +1012,36 @@ class Plugin:
             
             LOGGER.info("Scheduler stopped")
         
-        # Start the scheduler thread
-        _bg_scheduler_thread = threading.Thread(
-            target=scheduler_loop,
-            name="iptv-checker-scheduler",
-            daemon=True
-        )
-        _bg_scheduler_thread.start()
-        LOGGER.info("Background scheduler thread started")
+        # Atomically stop any existing scheduler and install this one. Holding
+        # _scheduler_lifecycle_lock across stop+create+assign prevents a
+        # concurrent start (e.g. _init_scheduler racing the run()/update-schedule
+        # path) from leaving two live scheduler_loop threads — each with its own
+        # last_run, which caused duplicate cron fires.
+        with _scheduler_lifecycle_lock:
+            self._stop_background_scheduler()
+            _bg_scheduler_thread = threading.Thread(
+                target=scheduler_loop,
+                name="iptv-checker-scheduler",
+                daemon=True
+            )
+            _bg_scheduler_thread.start()
+            LOGGER.info("Background scheduler thread started")
     
     def _stop_background_scheduler(self):
         """Cleanly stop the background scheduler thread."""
         global _bg_scheduler_thread, _scheduler_pending_run
-        
-        if _bg_scheduler_thread and _bg_scheduler_thread.is_alive():
-            LOGGER.info("Stopping scheduler thread...")
-            _scheduler_stop_event.set()
-            _bg_scheduler_thread.join(timeout=PluginConfig.SCHEDULER_STOP_TIMEOUT)
-            _scheduler_stop_event.clear()
-            _scheduler_pending_run = False
-            _bg_scheduler_thread = None
-            LOGGER.info("Scheduler thread stopped")
+
+        # Re-entrant: _start_background_scheduler calls this while already
+        # holding _scheduler_lifecycle_lock; an external stop serializes here.
+        with _scheduler_lifecycle_lock:
+            if _bg_scheduler_thread and _bg_scheduler_thread.is_alive():
+                LOGGER.info("Stopping scheduler thread...")
+                _scheduler_stop_event.set()
+                _bg_scheduler_thread.join(timeout=PluginConfig.SCHEDULER_STOP_TIMEOUT)
+                _scheduler_stop_event.clear()
+                _scheduler_pending_run = False
+                _bg_scheduler_thread = None
+                LOGGER.info("Scheduler thread stopped")
     
     def _execute_scheduled_check(self, settings, preserved_window_end=None, preserved_window_tz=None):
         """Execute the scheduled stream check (Load Groups + Start Check).
@@ -2270,6 +2375,16 @@ class Plugin:
         suffixes_to_add = {s.strip() for s in suffixes_to_add_str.split(',')}
         logger.info(f"DEBUG: Configured suffixes to add: {suffixes_to_add}")
 
+        # Recognized format tags that may already be appended to a channel name.
+        # Always includes the standard set so a previously-applied tag is stripped
+        # even if the user later narrows video_format_suffixes (issue #18).
+        known_format_tags = {s for s in suffixes_to_add if s} | {'uhd', 'fhd', 'hd', 'sd', 'unknown'}
+        # Matches one or more trailing " [TAG]" groups (case-insensitive).
+        trailing_tag_re = re.compile(
+            r'(?:\s*\[(?:' + '|'.join(re.escape(t) for t in known_format_tags) + r')\])+\s*$',
+            re.IGNORECASE,
+        )
+
         results = self._load_json_file(self.results_file)
         if results is None:
             return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first."}
@@ -2316,15 +2431,18 @@ class Plugin:
                     continue
 
                 suffix = f" [{fmt.upper()}]"
+                # Strip any previously-applied format tag(s) before re-appending so
+                # quality changes replace the suffix instead of stacking (issue #18).
+                base_name = trailing_tag_re.sub('', current_name).rstrip()
+                new_name = base_name + suffix
                 logger.debug(f"DEBUG:   - Current name: '{current_name}'")
-                logger.debug(f"DEBUG:   - Will add suffix: '{suffix}'")
-                logger.debug(f"DEBUG:   - Already ends with suffix? {current_name.endswith(suffix)}")
+                logger.debug(f"DEBUG:   - Base name (tags stripped): '{base_name}'")
+                logger.debug(f"DEBUG:   - Will set suffix: '{suffix}'")
 
-                if current_name.endswith(suffix):
-                    logger.debug(f"DEBUG:   - Skipped: already has suffix '{suffix}'")
+                if new_name == current_name:
+                    logger.debug(f"DEBUG:   - Skipped: already has correct suffix '{suffix}'")
                     skipped_already_has_suffix += 1
                 else:
-                    new_name = current_name + suffix
                     logger.info(f"DEBUG:   ✓ Adding to payload: '{current_name}' -> '{new_name}'")
                     payload.append({'id': cid, 'name': new_name})
 
@@ -3261,7 +3379,11 @@ class Plugin:
                 # Dead stream - completely clear stream_stats by setting to empty dict
                 logger.debug(f"Clearing metadata for dead stream {stream_id}")
                 try:
-                    from apps.proxy.ts_proxy.models import Stream as ProxyStream
+                    # The Stream model carrying stream_stats lives in
+                    # apps.channels.models (it never lived under apps.proxy.*);
+                    # the old apps.proxy.ts_proxy.models path always ImportError'd
+                    # and silently disabled this dead-stream cleanup path.
+                    from apps.channels.models import Stream as ProxyStream
                     stream = ProxyStream.objects.filter(id=stream_id).first()
                     if stream:
                         stream.stream_stats = {}  # Clear all stats


### PR DESCRIPTION
Update **IPTV Checker** to **v1.26.1362003**.

### Changes
- **Dispatcharr `ts_proxy` → `live_proxy` compatibility.** `ChannelService` import tries the new `live_proxy` path first and falls back to legacy `ts_proxy`, so the plugin works on both the current release and the upcoming proxy-refactor release. Dead-stream `Stream` import corrected to `apps.channels.models`.
- **Scheduler reliability.** Cross-process lock now carries a container boot token so a stale lock from a previous container is reclaimed instead of trusting a recycled PID (fixed the scheduler wedging permanently after a container restart). Eliminated a duplicate-cron-fire race (re-entrant lifecycle lock + loop self-eviction) and a stale-resume scope hijack (pending state discarded on settings drift / elapsed window).
- **Fixes #18 behaviour** (video format suffixes now replace instead of stacking).

All changes QA-reviewed; scheduler fixes verified working in production. Only `plugins/iptv-checker/` is touched.