### PR TITLE
[event-channel-managarr] Bump version to 1.26.1362004

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.1291442",
+  "version": "1.26.1362004",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/plugins/event-channel-managarr/plugin.py
+++ b/plugins/event-channel-managarr/plugin.py
@@ -41,7 +41,7 @@ _scheduler_lock = threading.Lock()  # Prevent concurrent scheduler starts
 class PluginConfig:
     """Centralized configuration constants for Event Channel Managarr."""
 
-    PLUGIN_VERSION = "1.26.1291442"
+    PLUGIN_VERSION = "1.26.1362004"
 
     # Default timezone for scheduling
     DEFAULT_TIMEZONE = "America/Chicago"
@@ -1170,25 +1170,37 @@ class Plugin:
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
         date_format = (settings or {}).get("date_format", "Auto")
 
-        # Pattern 0: start:YYYY-MM-DD HH:MM:SS or stop:YYYY-MM-DD HH:MM:SS
+        def _apply_meridiem(hour, meridiem):
+            """Convert a 12-hour clock hour to 24-hour given an optional AM/PM token."""
+            if not meridiem:
+                return hour
+            meridiem = meridiem.upper()
+            if meridiem == "AM":
+                return 0 if hour == 12 else hour
+            # PM
+            return hour if hour == 12 else hour + 12
+
+        # Pattern 0: start:YYYY-MM-DD HH:MM:SS[ AM/PM] or stop:YYYY-MM-DD HH:MM:SS[ AM/PM]
         for prefix in ["start:", "stop:"]:
-            pattern0 = re.search(rf'{prefix}(\d{{4}})-(\d{{2}})-(\d{{2}})\s+(\d{{2}}):(\d{{2}}):(\d{{2}})', channel_name)
+            pattern0 = re.search(rf'{prefix}(\d{{4}})-(\d{{2}})-(\d{{2}})\s+(\d{{1,2}}):(\d{{2}}):(\d{{2}})\s*([AaPp][Mm])?', channel_name)
             if pattern0:
-                year, month, day, hour, minute, second = map(int, pattern0.groups())
+                year, month, day, hour, minute, second = map(int, pattern0.groups()[:6])
+                hour = _apply_meridiem(hour, pattern0.group(7))
                 try:
                     extracted_date = datetime(year, month, day, hour, minute, second)
-                    logger.debug(f"Extracted datetime {extracted_date} from pattern {prefix}YYYY-MM-DD HH:MM:SS in '{channel_name}'")
+                    logger.debug(f"Extracted datetime {extracted_date} from pattern {prefix}YYYY-MM-DD HH:MM:SS[ AM/PM] in '{channel_name}'")
                     return extracted_date
                 except ValueError:
                     pass
 
-        # Pattern 0a: (YYYY-MM-DD HH:MM:SS) in parentheses
-        pattern0a = re.search(r'\((\d{4})-(\d{2})-(\d{2})\s+(\d{2}):(\d{2}):(\d{2})\)', channel_name)
+        # Pattern 0a: (YYYY-MM-DD HH:MM:SS[ AM/PM]) in parentheses
+        pattern0a = re.search(r'\((\d{4})-(\d{2})-(\d{2})\s+(\d{1,2}):(\d{2}):(\d{2})\s*([AaPp][Mm])?\)', channel_name)
         if pattern0a:
-            year, month, day, hour, minute, second = map(int, pattern0a.groups())
+            year, month, day, hour, minute, second = map(int, pattern0a.groups()[:6])
+            hour = _apply_meridiem(hour, pattern0a.group(7))
             try:
                 extracted_date = datetime(year, month, day, hour, minute, second)
-                logger.debug(f"Extracted datetime {extracted_date} from pattern (YYYY-MM-DD HH:MM:SS) in '{channel_name}'")
+                logger.debug(f"Extracted datetime {extracted_date} from pattern (YYYY-MM-DD HH:MM:SS[ AM/PM]) in '{channel_name}'")
                 return extracted_date
             except ValueError:
                 pass


### PR DESCRIPTION
## About this submission

Bug-fix release for the **event-channel-managarr** plugin (v1.26.1291442 → v1.26.1362004). Supersedes #72 (that branch accidentally carried unrelated `iptv-checker` changes inherited from the fork's main; this branch is rebased cleanly on `upstream/main` and touches only `plugins/event-channel-managarr/`).

Fixes an auto date-detection gap reported in [issue #19](https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/issues/19). Channel names containing a parenthesized ISO datetime with a 12-hour clock and an `AM`/`PM` suffix — e.g. `Arizona Diamondbacks @ Chicago Cubs (2026-05-01 02:20:00 PM)` — were not being date-detected. `_extract_date_from_channel_name` Pattern 0 / Pattern 0a required the closing `)` immediately after `HH:MM:SS`, so the trailing ` AM`/` PM` broke the match. With no date extracted, the `[FutureDate]` / `[PastDate]` hide rules silently skipped the channel and upcoming events kept showing.

Changes (scoped to `plugin.py` Pattern 0/0a and a new `_apply_meridiem()` helper):

- Optional `AM`/`PM` token added; 1–2 digit hours allowed.
- 12-hour → 24-hour conversion: 12 AM → 00:00, 12 PM → 12:00, other PM hours +12.
- Legacy 24-hour names without a meridiem are unchanged (no regression).

No new settings or dependencies. Smoke-tested against the reporter's exact examples plus 12 AM / 12 PM / no-meridiem edge cases, and reviewed by a code-review pass (no blockers).

Source release & full notes: https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/tag/v1.26.1362004