### PR TITLE
[epgeditarr] Bump version to v0.2.01

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.1.7",
+  "version": "0.2.01",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and sorts SiriusXM channels into official lineup order with automatic seasonal channel handling.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## EPGeditARR v0.2.01

### Changes

- **SiriusXM Fill EPG** now incorporates sports intelligence with automatic failover -- sports channels get smart Upcoming/LIVE/Post-game blocks; all other channels get repeating fill with real SiriusXM descriptions; if the live sports schedule is unavailable, falls back to repeating fill for all channels automatically
- Expanded community XMLTV logo coverage from 270 to ~460 channels (team/college logos matched from logos directory)
- Community XMLTV feed renamed from `siriusxm_sports_epg.xml` to `siriusxm_epg.xml`

### Release

https://github.com/jstevenscl/epgeditarr/releases/tag/v0.2.01