### PR TITLE
[repo]: Add targeted force-rebuild, yank-plugin-version workflow, and version removal process

### DIFF
--- a/.github/ISSUE_TEMPLATE/version-removal-request.yml
+++ b/.github/ISSUE_TEMPLATE/version-removal-request.yml
@@ -1,0 +1,50 @@
+name: Version Removal Request
+description: Request that a specific published version of a plugin be removed from the registry.
+labels: ["Rollback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request that a specific version be yanked from the registry. A maintainer will review and run the yank workflow on your behalf.
+
+        Only plugin authors and listed maintainers may request removal of their own plugin versions. Maintainers with write access to this repository can request removal of any version.
+
+  - type: input
+    id: plugin
+    attributes:
+      label: Plugin slug
+      description: The folder name of the plugin (e.g. `dispatcharr-exporter`).
+      placeholder: my-plugin
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version to remove
+      description: The exact version string as it appears in `plugin.json` (e.g. `1.2.3`).
+      placeholder: "1.2.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: reason
+    attributes:
+      label: Reason for removal
+      options:
+        - Critical bug
+        - Security vulnerability
+        - Mistaken publish (wrong version, wrong files)
+        - License correction
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Describe what is wrong with this version and why it should be removed.
+      placeholder: Briefly explain the issue.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,6 +28,7 @@
 - [ ] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
 - [ ] My GitHub username is in `author` or `maintainers`
 - [ ] `license` is a valid [OSI-approved SPDX identifier](https://spdx.org/licenses/) (e.g. `MIT`, `Apache-2.0`)
+- [ ] I have the right to distribute this plugin under the license specified and understand that once a version is published its license cannot be changed retroactively
 - [ ] I have tested the plugin against a running Dispatcharr instance
 
 **If this is an update to an existing plugin:**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,6 @@
 - [ ] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
 - [ ] My GitHub username is in `author` or `maintainers`
 - [ ] `license` is a valid [OSI-approved SPDX identifier](https://spdx.org/licenses/) (e.g. `MIT`, `Apache-2.0`)
-- [ ] I have the right to distribute this plugin under the license specified and understand that once a version is published its license cannot be changed retroactively
 - [ ] I have tested the plugin against a running Dispatcharr instance
 
 **If this is an update to an existing plugin:**

--- a/.github/scripts/publish/run.sh
+++ b/.github/scripts/publish/run.sh
@@ -56,7 +56,20 @@ fi
 
 # Checkout or create releases branch
 echo "Setting up $RELEASES_BRANCH branch..."
-if [[ "${FORCE_REBUILD:-false}" == "true" ]]; then
+if [[ "${FORCE_REBUILD:-false}" == "true" && -n "${FORCE_REBUILD_PLUGIN:-}" ]]; then
+  # Targeted rebuild: keep existing releases branch, clear only the named plugin's zips dir.
+  # build-zips.sh will rebuild it since the zip is gone; all other plugins are untouched.
+  if git ls-remote --exit-code --heads origin $RELEASES_BRANCH >/dev/null 2>&1; then
+    git checkout $RELEASES_BRANCH
+    git pull origin $RELEASES_BRANCH || true
+  else
+    git checkout --orphan $RELEASES_BRANCH
+    git rm -rf . 2>/dev/null || true
+    git commit --allow-empty -m "Initialize $RELEASES_BRANCH branch"
+  fi
+  echo "Targeted force rebuild: clearing zips/$FORCE_REBUILD_PLUGIN/"
+  rm -rf "zips/$FORCE_REBUILD_PLUGIN"
+elif [[ "${FORCE_REBUILD:-false}" == "true" ]]; then
   echo "Force rebuild requested - resetting $RELEASES_BRANCH to a new orphan commit."
   git checkout --orphan $RELEASES_BRANCH
   git rm -rf . 2>/dev/null || true

--- a/.github/scripts/publish/yank-version.sh
+++ b/.github/scripts/publish/yank-version.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+set -e
+
+# yank-version.sh
+# Removes a specific version of a plugin from the releases branch and regenerates
+# manifests and READMEs. If the yanked version is the current latest, the previous
+# version is promoted to latest. If it is the only version, the plugin is fully
+# removed. A rollback PR is opened against the source branch when the latest (or
+# only) version is yanked.
+#
+# Environment variables required:
+#   GITHUB_REPOSITORY - Full repository name (owner/repo)
+#   GITHUB_TOKEN      - GitHub token with write access and PR creation permission
+#   YANK_PLUGIN       - Plugin slug (e.g. dispatcharr-exporter)
+#   YANK_VERSION      - Version to remove (e.g. 3.0.1)
+#   SOURCE_BRANCH     - Source branch to fetch plugin metadata from (e.g. main)
+
+: "${GITHUB_REPOSITORY:?}" "${GITHUB_TOKEN:?}" "${YANK_PLUGIN:?}" "${YANK_VERSION:?}" "${SOURCE_BRANCH:?}" "${YANK_ISSUE:?}"
+
+RELEASES_BRANCH="releases"
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+
+export SOURCE_BRANCH RELEASES_BRANCH GITHUB_REPOSITORY
+
+echo "Yanking $YANK_PLUGIN v$YANK_VERSION from $RELEASES_BRANCH (issue #$YANK_ISSUE)"
+
+# --- Validate issue ---
+ISSUE_STATE=$(gh api "repos/$GITHUB_REPOSITORY/issues/$YANK_ISSUE" --jq '.state' 2>/dev/null || true)
+if [[ -z "$ISSUE_STATE" ]]; then
+  echo "::error::Issue #$YANK_ISSUE not found in $GITHUB_REPOSITORY."
+  exit 1
+fi
+if [[ "$ISSUE_STATE" != "open" ]]; then
+  echo "::error::Issue #$YANK_ISSUE is already $ISSUE_STATE. Only open issues can authorize a yank."
+  exit 1
+fi
+echo "  Issue #$YANK_ISSUE is open - proceeding."
+
+WORK_DIR=$(mktemp -d)
+BUILD_META_DIR=$(mktemp -d)
+export BUILD_META_DIR
+trap 'rm -rf "$WORK_DIR" "$BUILD_META_DIR"' EXIT
+
+echo "Cloning repository..."
+git clone --no-checkout "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$WORK_DIR/repo"
+cd "$WORK_DIR/repo"
+
+# Configure git identity
+if [[ -n "${APP_SLUG:-}" ]]; then
+  BOT_USER_ID=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq '.id' 2>/dev/null || echo "")
+  git config user.name "${APP_SLUG}[bot]"
+  if [[ -n "$BOT_USER_ID" ]]; then
+    git config user.email "${BOT_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
+  else
+    git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+  fi
+else
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+fi
+
+# Checkout releases branch
+if git ls-remote --exit-code --heads origin $RELEASES_BRANCH >/dev/null 2>&1; then
+  git checkout $RELEASES_BRANCH
+  git pull origin $RELEASES_BRANCH || true
+else
+  echo "::error::Releases branch does not exist."
+  exit 1
+fi
+
+ZIP_DIR="zips/$YANK_PLUGIN"
+TARGET_ZIP="$ZIP_DIR/${YANK_PLUGIN}-${YANK_VERSION}.zip"
+PLUGIN_MANIFEST="$ZIP_DIR/manifest.json"
+
+# --- Validate ---
+if [[ ! -f "$TARGET_ZIP" ]]; then
+  echo "::error::$TARGET_ZIP not found on the releases branch. Nothing to yank."
+  exit 1
+fi
+
+# Count existing versioned ZIPs (excluding -latest)
+REMAINING=$(ls -1 "$ZIP_DIR/${YANK_PLUGIN}"-*.zip 2>/dev/null | grep -v '\-latest\.zip' | grep -v "/${YANK_PLUGIN}-${YANK_VERSION}\.zip" || true)
+REMAINING_COUNT=$(echo "$REMAINING" | grep -c . || true)
+
+# Determine if we are yanking the current latest
+CURRENT_LATEST=""
+if [[ -f "$PLUGIN_MANIFEST" ]]; then
+  CURRENT_LATEST=$(jq -r '.manifest.latest.version // ""' "$PLUGIN_MANIFEST" 2>/dev/null || true)
+fi
+IS_LATEST=false
+[[ "$YANK_VERSION" == "$CURRENT_LATEST" ]] && IS_LATEST=true
+
+IS_LAST_VERSION=false
+[[ "$REMAINING_COUNT" -eq 0 ]] && IS_LAST_VERSION=true
+
+echo "  Current latest : ${CURRENT_LATEST:-unknown}"
+echo "  Is latest      : $IS_LATEST"
+echo "  Remaining ZIPs : $REMAINING_COUNT"
+echo "  Is last version: $IS_LAST_VERSION"
+
+# --- Fetch source branch + plugins dir (needed by manifest + readme scripts) ---
+git fetch origin "$SOURCE_BRANCH"
+git checkout "origin/$SOURCE_BRANCH" -- plugins
+
+# Determine source_type before deleting anything
+SOURCE_TYPE=$(jq -r '.source_type // "local"' "plugins/$YANK_PLUGIN/plugin.json" 2>/dev/null || echo "local")
+
+# --- Perform the yank ---
+if $IS_LAST_VERSION; then
+  echo "Last version - removing entire zips/$YANK_PLUGIN/ directory."
+  rm -rf "$ZIP_DIR"
+else
+  echo "Removing $TARGET_ZIP"
+  rm "$TARGET_ZIP"
+
+  if $IS_LATEST; then
+    NEW_LATEST_ZIP=$(ls -1 "$ZIP_DIR/${YANK_PLUGIN}"-*.zip 2>/dev/null | grep -v '\-latest\.zip' | sort -t- -k2 -V -r | head -1 || true)
+    if [[ -z "$NEW_LATEST_ZIP" ]]; then
+      echo "::error::Could not find a replacement version to promote to latest."
+      exit 1
+    fi
+    NEW_LATEST_VERSION=$(basename "$NEW_LATEST_ZIP" | sed "s/${YANK_PLUGIN}-\(.*\)\.zip/\1/")
+    echo "Promoting $NEW_LATEST_VERSION to latest"
+    cp "$NEW_LATEST_ZIP" "$ZIP_DIR/${YANK_PLUGIN}-latest.zip"
+  fi
+fi
+
+# --- Regenerate manifests and READMEs ---
+rm -f manifest.json README.md
+
+echo ""
+echo "=== Regenerating manifests ==="
+bash "$SCRIPT_DIR/generate-manifest.sh"
+
+echo ""
+echo "=== Regenerating per-plugin READMEs ==="
+bash "$SCRIPT_DIR/plugin-readmes.sh"
+
+echo ""
+echo "=== Regenerating releases README ==="
+bash "$SCRIPT_DIR/releases-readme.sh"
+
+# --- Commit and push ---
+echo ""
+echo "=== Committing ==="
+rm -rf plugins
+git rm -rf --cached plugins 2>/dev/null || true
+
+git add zips manifest.json README.md
+
+if git diff --cached --quiet; then
+  echo "No changes to commit - was this version already absent?"
+else
+  git commit -m "Yank ${YANK_PLUGIN} v${YANK_VERSION}
+
+Refs #${YANK_ISSUE}
+[skip ci]"
+  RELEASES_COMMIT=$(git rev-parse --short HEAD)
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" $RELEASES_BRANCH
+  echo "Successfully yanked ${YANK_PLUGIN} v${YANK_VERSION} from ${RELEASES_BRANCH}"
+fi
+
+ROLLBACK_PR_URL=""
+
+# --- Open rollback PR if we yanked the latest (or only) version ---
+if $IS_LATEST; then
+  echo ""
+  echo "=== Opening rollback PR ==="
+
+  REPO_OWNER=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f1)
+  REPO_NAME=$(echo "$GITHUB_REPOSITORY" | cut -d'/' -f2)
+  ROLLBACK_BRANCH="yank/${YANK_PLUGIN}-${YANK_VERSION}"
+
+  # Start rollback branch from source branch tip
+  git fetch origin "$SOURCE_BRANCH"
+  git checkout -b "$ROLLBACK_BRANCH" "origin/$SOURCE_BRANCH"
+
+  if $IS_LAST_VERSION; then
+    # Remove the plugin from source entirely
+    git rm -rf "plugins/$YANK_PLUGIN"
+    PR_TITLE="[${YANK_PLUGIN}]: Remove plugin (all versions yanked)"
+    PR_BODY="## Plugin Removed
+
+All published versions of \`${YANK_PLUGIN}\` have been yanked from the releases branch.
+
+This PR removes the plugin from the source branch to prevent it from being republished on the next run.
+
+**Yanked version:** \`${YANK_VERSION}\`
+**Authorized by:** #${YANK_ISSUE}
+
+Closes #${YANK_ISSUE}"
+  else
+    # Roll back plugin source to the new-latest version
+    if [[ "$SOURCE_TYPE" == "local" ]]; then
+      # Find the most recent commit where plugin.json had the target version
+      RESTORE_COMMIT=$(git log --all --format="%H" -- "plugins/$YANK_PLUGIN/plugin.json" | while IFS= read -r sha; do
+        v=$(git show "${sha}:plugins/${YANK_PLUGIN}/plugin.json" 2>/dev/null | jq -r '.version // ""' 2>/dev/null || true)
+        if [[ "$v" == "$NEW_LATEST_VERSION" ]]; then
+          echo "$sha"
+          break
+        fi
+      done)
+
+      if [[ -n "$RESTORE_COMMIT" ]]; then
+        echo "Restoring plugins/$YANK_PLUGIN/ from commit $RESTORE_COMMIT"
+        git checkout "$RESTORE_COMMIT" -- "plugins/$YANK_PLUGIN/"
+        SOURCE_NOTE="Plugin source files restored from commit \`${RESTORE_COMMIT:0:7}\` (the last commit where \`${YANK_PLUGIN}\` was at \`${NEW_LATEST_VERSION}\`)."
+      else
+        echo "::warning::Could not find a commit for $YANK_PLUGIN v$NEW_LATEST_VERSION - falling back to version field update only."
+        jq --arg v "$NEW_LATEST_VERSION" '.version = $v' "plugins/$YANK_PLUGIN/plugin.json" > /tmp/plugin.json.tmp
+        mv /tmp/plugin.json.tmp "plugins/$YANK_PLUGIN/plugin.json"
+        SOURCE_NOTE="⚠️ **Could not restore source files** - no commit found for \`${NEW_LATEST_VERSION}\` (history may have been squashed). Only the \`version\` field was updated. Please review the source files manually before merging."
+      fi
+    else
+      # External plugin: only the version field needs to change
+      jq --arg v "$NEW_LATEST_VERSION" '.version = $v' "plugins/$YANK_PLUGIN/plugin.json" > /tmp/plugin.json.tmp
+      mv /tmp/plugin.json.tmp "plugins/$YANK_PLUGIN/plugin.json"
+      SOURCE_NOTE="Version field in \`plugin.json\` updated to \`${NEW_LATEST_VERSION}\`. The ZIP will be re-fetched from the external source URL on the next publish run."
+    fi
+
+    git add "plugins/$YANK_PLUGIN/"
+    PR_TITLE="[${YANK_PLUGIN}]: Roll back to v${NEW_LATEST_VERSION} (yank of v${YANK_VERSION})"
+    PR_BODY="## Version Rollback
+
+\`${YANK_PLUGIN}\` \`${YANK_VERSION}\` has been yanked from the releases branch. This PR rolls the source back to \`${NEW_LATEST_VERSION}\` so the yanked version is not republished on the next run.
+
+**Yanked version:** \`${YANK_VERSION}\`
+**New latest:** \`${NEW_LATEST_VERSION}\`
+**Authorized by:** #${YANK_ISSUE}
+
+${SOURCE_NOTE}
+
+Closes #${YANK_ISSUE}"
+  fi
+
+  git commit -m "$PR_TITLE"
+  git push "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$ROLLBACK_BRANCH"
+
+  # Ensure the Rollback label exists
+  gh label create "Rollback" \
+    --color "E11D48" \
+    --description "Version rollback opened by the yank workflow" \
+    --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+
+  ROLLBACK_PR_URL=$(gh pr create \
+    --repo "$GITHUB_REPOSITORY" \
+    --base "$SOURCE_BRANCH" \
+    --head "$ROLLBACK_BRANCH" \
+    --title "$PR_TITLE" \
+    --label "Rollback" \
+    --body "$PR_BODY")
+
+  echo "Rollback PR opened: $ROLLBACK_BRANCH -> $SOURCE_BRANCH ($ROLLBACK_PR_URL)"
+fi
+
+# --- Comment on the issue; close directly only if no rollback PR is pending ---
+if $IS_LATEST; then
+  # Issue will be auto-closed when the rollback PR is merged (via Closes #N in PR body).
+  # Leave a comment pointing to the PR so the requester can track progress.
+  gh issue comment "$YANK_ISSUE" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body "\`${YANK_PLUGIN}\` v\`${YANK_VERSION}\` has been removed from the releases branch (commit \`${RELEASES_COMMIT:-unknown}\`).
+
+A rollback PR has been opened to update the source branch: ${ROLLBACK_PR_URL:-"(see workflow run for link)"}
+
+This issue will close automatically when that PR is merged."
+else
+  # No rollback PR - close the issue directly.
+  gh issue comment "$YANK_ISSUE" \
+    --repo "$GITHUB_REPOSITORY" \
+    --body "\`${YANK_PLUGIN}\` v\`${YANK_VERSION}\` has been removed from the releases branch (commit \`${RELEASES_COMMIT:-unknown}\`).
+
+This was not the latest version so no source branch changes are needed."
+
+  gh issue close "$YANK_ISSUE" \
+    --repo "$GITHUB_REPOSITORY" \
+    --reason "completed"
+fi

--- a/.github/scripts/validate/detect-changes.sh
+++ b/.github/scripts/validate/detect-changes.sh
@@ -18,9 +18,10 @@ set -e
 
 PR_AUTHOR=$1
 BASE_REF=$2
+HEAD_REF=${3:-}
 
 if [[ -z "$PR_AUTHOR" || -z "$BASE_REF" ]]; then
-  echo "Usage: $0 <pr_author> <base_ref>"
+  echo "Usage: $0 <pr_author> <base_ref> [head_ref]"
   exit 1
 fi
 
@@ -39,6 +40,24 @@ has_write_access() {
 }
 
 MERGE_BASE=$(git merge-base "origin/${BASE_REF}" HEAD)
+
+# --- Bot-authored yank rollback PRs bypass plugin validation ---
+# The yank workflow opens PRs on branches named yank/* using the bot identity.
+# These PRs intentionally roll back (or remove) plugin versions, so the normal
+# version-bump and format checks do not apply.
+if [[ "$PR_AUTHOR" == *"[bot]" && "$HEAD_REF" == yank/* ]]; then
+  echo "Bot-authored yank rollback PR detected ($PR_AUTHOR, $HEAD_REF) - skipping plugin validation."
+  echo "matrix=[]"               >> "$GITHUB_OUTPUT"
+  echo "plugin_count=0"          >> "$GITHUB_OUTPUT"
+  echo "close_pr=false"          >> "$GITHUB_OUTPUT"
+  echo "close_reason="           >> "$GITHUB_OUTPUT"
+  echo "skip_validation=true"    >> "$GITHUB_OUTPUT"
+  echo "outside_violation=false" >> "$GITHUB_OUTPUT"
+  echo "pub_key_changed=false"   >> "$GITHUB_OUTPUT"
+  echo "has_new_plugin=false"    >> "$GITHUB_OUTPUT"
+  echo "has_updated_plugin=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
 
 # --- Protection check: only plugins/ may be modified by non-maintainers ---
 OUTSIDE_CHANGES=$(git diff --name-only "$MERGE_BASE" HEAD | grep -v '^plugins/' || true)

--- a/.github/scripts/validate/validate.sh
+++ b/.github/scripts/validate/validate.sh
@@ -328,12 +328,20 @@ has_permission="false"
 
       if $metadata_only_change && [[ -n "$changed_fields" ]]; then
         TABLE_ROWS+=("| Version bump | ✅ | \`$OLD_VERSION\` (unchanged - metadata-only update) |")
-      elif $metadata_only_change && [[ -z "$changed_fields" ]]; then
-        # Nothing changed at all - still require a bump so PRs aren't no-ops
-        TABLE_ROWS+=("| Version bump | ❌ | No changes detected - nothing to publish |")
-        failed=1
       else
-        TABLE_ROWS+=("| Version bump | ❌ | \`$VERSION\` must be greater than current \`$OLD_VERSION\` |")
+        # Any non-metadata plugin.json change or other file change requires a version bump.
+        # If plugin.json is identical, check whether other files in the directory changed
+        # so we can give a more accurate error message.
+        _other_changed=""
+        if [[ -z "$changed_fields" ]]; then
+          _other_changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" -- "$PLUGIN_DIR" \
+            | grep -v "^${PLUGIN_JSON}$" | head -1 || true)
+        fi
+        if [[ -z "$changed_fields" && -z "$_other_changed" ]]; then
+          TABLE_ROWS+=("| Version bump | ❌ | No changes detected - nothing to publish |")
+        else
+          TABLE_ROWS+=("| Version bump | ❌ | \`$VERSION\` must be greater than current \`$OLD_VERSION\` |")
+        fi
         failed=1
       fi
     fi

--- a/.github/workflows/publish-plugins.yml
+++ b/.github/workflows/publish-plugins.yml
@@ -23,12 +23,17 @@ on:
   workflow_dispatch:
     inputs:
       force_rebuild:
-        description: 'Wipe and recreate the releases branch from scratch. WARNING: purges all version history - only the latest version of each plugin will be retained.'
+        description: 'Check this to clear and rebuild plugin ZIPs from scratch. Scope is controlled by force_rebuild_plugin below. Requires CONFIRM in force_rebuild_confirm.'
         type: boolean
         default: false
         required: false
+      force_rebuild_plugin:
+        description: 'Optional: plugin slug to target (e.g. dispatcharr-exporter). Only that plugin is cleared and rebuilt - all others are untouched. Leave blank to wipe and rebuild the entire releases branch (WARNING: purges all version history).'
+        type: string
+        default: ''
+        required: false
       force_rebuild_confirm:
-        description: 'Type CONFIRM to proceed with force rebuild (required when force_rebuild is true)'
+        description: 'Required when force_rebuild is checked: type CONFIRM to proceed. Leave blank at all other times.'
         type: string
         default: ''
         required: false
@@ -86,6 +91,7 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           FORCE_REBUILD: ${{ inputs.force_rebuild }}
           FORCE_REBUILD_CONFIRM: ${{ inputs.force_rebuild_confirm }}
+          FORCE_REBUILD_PLUGIN: ${{ inputs.force_rebuild_plugin }}
         run: |
           set -o pipefail
           if [[ "${FORCE_REBUILD}" == "true" && "${FORCE_REBUILD_CONFIRM}" != "CONFIRM" ]]; then

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -170,7 +170,8 @@ jobs:
           chmod +x .github/scripts/validate/*.sh
           .github/scripts/validate/detect-changes.sh \
             "${{ github.event.pull_request.user.login }}" \
-            "${{ github.event.pull_request.base.ref }}"
+            "${{ github.event.pull_request.base.ref }}" \
+            "${{ github.event.pull_request.head.ref }}"
 
       - name: Check author and plugin blacklists
         id: blacklist
@@ -313,7 +314,7 @@ jobs:
   # --------------------------------------------------------------------------
   validate-title:
     needs: [detect-changes]
-    if: github.event.pull_request.draft == false && needs.detect-changes.result == 'success' && needs.detect-changes.outputs.close_pr == 'false'
+    if: github.event.pull_request.draft == false && needs.detect-changes.result == 'success' && needs.detect-changes.outputs.close_pr == 'false' && needs.detect-changes.outputs.skip_validation != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:

--- a/.github/workflows/yank-plugin-version.yml
+++ b/.github/workflows/yank-plugin-version.yml
@@ -1,0 +1,95 @@
+name: Yank Plugin Version
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: 'Plugin slug to yank a version from (e.g. dispatcharr-exporter)'
+        type: string
+        required: true
+      version:
+        description: 'Version to remove (e.g. 3.0.1)'
+        type: string
+        required: true
+      issue_number:
+        description: 'Issue number of the Version Removal Request that authorized this yank (e.g. 42). The issue will be cited in the commit and rollback PR, then closed.'
+        type: string
+        required: true
+
+jobs:
+  yank:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Load app ID from config
+        id: config
+        env:
+          GH_APP_ID: ${{ vars.GH_APP_ID }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+        run: |
+          if [[ -n "${GH_APP_ID:-}" && -n "${GH_APP_PRIVATE_KEY:-}" ]]; then
+            echo "app_id=${GH_APP_ID}" >> "$GITHUB_OUTPUT"
+            echo "use_app=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_app=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate GitHub App token
+        if: steps.config.outputs.use_app == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ steps.config.outputs.app_id }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Log fallback to actions token
+        if: steps.config.outputs.use_app != 'true'
+        run: |
+          printf '## ⚠️ GitHub App token not available\n\nGH_APP_ID or GH_APP_PRIVATE_KEY not configured. Falling back to `GITHUB_TOKEN` (github-actions[bot] identity).\n' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Make scripts executable
+        run: chmod +x .github/scripts/publish/*.sh
+
+      - name: Yank plugin version
+        env:
+          GITHUB_TOKEN: ${{ steps.config.outputs.use_app == 'true' && steps.app-token.outputs.token || github.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          YANK_PLUGIN: ${{ inputs.plugin }}
+          YANK_VERSION: ${{ inputs.version }}
+          YANK_ISSUE: ${{ inputs.issue_number }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
+        run: |
+          set -o pipefail
+          .github/scripts/publish/yank-version.sh 2>&1 | tee yank.log
+
+      - name: Generate job summary
+        if: always()
+        run: |
+          echo "## Yank Result" >> $GITHUB_STEP_SUMMARY
+          if [ -f yank.log ]; then
+            if grep -q "Successfully yanked" yank.log; then
+              echo "✅ Yank completed successfully" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "❌ Yank failed - see logs for details." >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            tail -20 yank.log >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,4 +218,17 @@ All other fields - including `name`, `author`, `license`, `source_url`, `source_
 
 All plugins must be distributed under an [OSI-approved open source license](https://opensource.org/licenses). The `license` field is required in `plugin.json` and must be a valid [SPDX identifier](https://spdx.org/licenses/).
 
-By submitting a PR you confirm that you have the rights to distribute the plugin under the license you specify. This is binding for the version being published. Once a version is live, its license cannot be changed retroactively. Users who downloaded that version hold rights under those terms permanently. To change the license going forward, bump the version. The old version stays under its original license.
+By submitting a PR you confirm that you have the rights to distribute the plugin under the license you specify. This is binding for the version being published. Users who downloaded a version hold rights under its license permanently - those rights are not affected if the version is later removed from the registry. To change the license going forward, bump the version. The old version stays under its original license.
+
+## Version Removal
+
+Plugin authors and maintainers can request that a specific version be removed from the registry. Reasons might include a critical bug, a security issue, a mistaken publish, or a license correction.
+
+To request a removal, [open an issue](../../issues/new/choose) using the **Version Removal Request** template. A maintainer will run the yank workflow on your behalf.
+
+What happens when a version is yanked:
+
+- The versioned ZIP and its manifest entry are removed from the releases branch.
+- If it was the latest version, the previous version is automatically promoted to latest and a PR is opened against the source branch to roll back `plugin.json` to match.
+- If it was the only version, the plugin is fully removed from the registry and a PR is opened to remove its source folder.
+- Users who already downloaded the version are unaffected.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,10 @@ Version increments are enforced by the validation workflow. You cannot submit a 
 
 All other fields - including `name`, `author`, `license`, `source_url`, `source_type`, and any code changes - require a version bump.
 
+> **Changing the license?** A version bump is required because the license you publish under is binding for that release. Users who installed the previous version hold rights under the old license and those cannot be revoked. The new version carries the new license going forward.
+
 ## Licensing
 
 All plugins must be distributed under an [OSI-approved open source license](https://opensource.org/licenses). The `license` field is required in `plugin.json` and must be a valid [SPDX identifier](https://spdx.org/licenses/).
+
+By submitting a PR you confirm that you have the rights to distribute the plugin under the license you specify. This is binding for the version being published. Once a version is live, its license cannot be changed retroactively. Users who downloaded that version hold rights under those terms permanently. To change the license going forward, bump the version. The old version stays under its original license.


### PR DESCRIPTION
Adds two new maintenance workflows and supporting documentation.

**Targeted force-rebuild**: `force_rebuild` now accepts an optional plugin slug. When set, only that plugin's zips directory is cleared and rebuilt - all other plugins and their version history are untouched. Full branch wipe remains the default when no slug is provided.

**Yank plugin version**: New workflow to remove a specific version from the releases branch. If the yanked version is the latest, the previous version is promoted and a rollback PR is opened against the source branch. If it is the only version, the plugin is removed entirely. The workflow requires an open issue number, comments on it with the result, and closes it (or lets the rollback PR close it via `Closes #N`).

**Validation**: Bot-authored PRs on `yank/*` branches skip plugin validation so rollback PRs pass without triggering the version-bump check.

**Version removal request**: New issue template and CONTRIBUTING.md section documenting the removal process.
