### PR TITLE
[epgeditarr]: Update to v0.2.04 — fix Docker OOM from memory pressure on multi-source EPG setups

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.03",
+  "version": "0.2.04",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
Bumps EPGeditARR to v0.2.04.

## Changes

**Fix: Docker OOM crashes from memory pressure in multi-source EPG setups**

Two root causes fixed:

1. **Signal handler running Fill EPG N times per refresh cycle** — The EPG refresh signal fired `_action_sxm_fill_epg` once per EPG source. With 4+ sources refreshing simultaneously, this spawned N parallel fill runs each allocating 200–300 MB, causing OOM and Docker daemon crashes. Fixed with a 4-hour cooldown so the fill runs at most once per cooldown window.

2. **`ET.fromstring` building full 246k-programme XML DOM in memory** — Replaced with `ET.iterparse` + `elem.clear()` streaming. Peak XML memory drops from ~200 MB to ~5 MB and is released when the function exits.

Stress tested: 4 consecutive Fill & Sort runs on a live instance after clean Docker restart — uWSGI memory stayed flat throughout.

Release: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.2.04
