### PR TITLE
[epgeditarr]: Update to v0.2.05 — XMLTV source type fix, sport sort order, XML sanitizer

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.04",
+  "version": "0.2.05",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## EPGeditARR v0.2.05

### Bug fixes
- **Critical: fresh install XMLTV source type bug** — v0.2.04 created the `EPGeditARR: SiriusXM` EPG source as `standard` type instead of `xmltv`. Dispatcharr cannot parse a `standard`-type source from a URL, so the SiriusXM Fill EPG action would silently fail to load any program data on a first-time install. Required manual API intervention to correct the source type. v0.2.05 creates it correctly as `xmltv` and auto-migrates any existing wrong-type sources on the next Fill run.
- **Utah Hockey Club** team name corrected in sport sort order (was incorrectly stored as 'Utah Mammoth', which is their AHL affiliate)

> **Note for maintainers:** Please consider removing or flagging v0.2.04 from the registry. The XMLTV source type bug means any user who installed v0.2.04 on a fresh Dispatcharr instance (no prior SiriusXM EPG source) would get broken Fill EPG with no actionable error — it requires a manual API PATCH to fix. v0.2.05 auto-remediates this on the next Fill run.

### Improvements
- XMLTV character sanitization — strips XML 1.0-invalid control characters before parsing and at write time; retries download once on parse failure for CDN resilience
- Sport team sort order now mirrors official SiriusXM app lineup using real app-stream channel numbers (NFL 800-831, MLB 840-869, NBA 880-909, NHL 920-951)
- Phase 1 iterparse memory fix — programme elements cleared immediately during channel-only pass, reducing peak memory significantly on large XMLTV files
