### PR TITLE
[epgeditarr]: Update to v0.2.06 — Rebrowser CSV channel source, alias normalization, unmatched log

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.05",
+  "version": "0.2.06",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Switches channel cache from SiriusXM edge-gateway API (broken by passkey auth) to [rebrowser/siriusxm-dataset](https://github.com/rebrowser/siriusxm-dataset) public CSV — no credentials required
- `channel_aliases.json` expanded with ~25 Rebrowser name variants to maintain match rates; curly-quote normalization; channel number deduplication
- Unmatched channel names are now logged persistently in plugin settings (visible in Status action) for alias review
- Code cleanup: stale runtime alias table cleared, XML regex moved to module level

## Release

https://github.com/jstevenscl/epgeditarr/releases/tag/v0.2.06