### PR TITLE
[epgeditarr]: Update to v0.2.07 — fix XMLTV parse false-retry and add 504 timeout warning

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.06",
+  "version": "0.2.07",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- **Fix SiriusXM Fill EPG "unclosed token" failure** — The XML sanity check truncated the XMLTV to 512 bytes, which always raised `ParseError: unclosed token` on valid files (expected — the slice cuts mid-element). This incorrectly triggered a retry that also failed. The fix allows `unclosed token` through and only retries on errors indicating a genuinely garbage response (e.g. HTML 404). The retry path now applies the same guard so a successful retry on valid XML no longer falsely reports failure.
- **504 Gateway Timeout warning** — Fill EPG downloads ~200 MB and can take 60–90+ seconds. Reverse proxies (nginx, Traefik, Caddy) often drop the browser connection before the response arrives. The action description and README now explain that the backend keeps running and users should check Show Status to confirm completion.
- **CI fix** — `scripts/cache_logos.py` no longer crashes when `_workshop/sxm_logos_raw.json` is absent in CI environments.

## Release

https://github.com/jstevenscl/epgeditarr/releases/tag/v0.2.07