### PR TITLE
[event-channel-managarr] v1.26.1401103 - fix WrongDayOfWeek for cross-TZ viewers

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.1362004",
+  "version": "1.26.1401103",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/plugins/event-channel-managarr/plugin.py
+++ b/plugins/event-channel-managarr/plugin.py
@@ -41,7 +41,7 @@ _scheduler_lock = threading.Lock()  # Prevent concurrent scheduler starts
 class PluginConfig:
     """Centralized configuration constants for Event Channel Managarr."""
 
-    PLUGIN_VERSION = "1.26.1362004"
+    PLUGIN_VERSION = "1.26.1401103"
 
     # Default timezone for scheduling
     DEFAULT_TIMEZONE = "America/Chicago"
@@ -1177,15 +1177,15 @@ class Plugin:
             meridiem = meridiem.upper()
             if meridiem == "AM":
                 return 0 if hour == 12 else hour
-            # PM
-            return hour if hour == 12 else hour + 12
+            else:
+                return hour if hour == 12 else hour + 12
 
         # Pattern 0: start:YYYY-MM-DD HH:MM:SS[ AM/PM] or stop:YYYY-MM-DD HH:MM:SS[ AM/PM]
         for prefix in ["start:", "stop:"]:
-            pattern0 = re.search(rf'{prefix}(\d{{4}})-(\d{{2}})-(\d{{2}})\s+(\d{{1,2}}):(\d{{2}}):(\d{{2}})\s*([AaPp][Mm])?', channel_name)
+            pattern0 = re.search(rf'{prefix}(\d{{4}})-(\d{{2}})-(\d{{2}})\s+(\d{{1,2}}):(\d{{2}}):(\d{{2}})\s*(?P<ap>[AaPp][Mm])?', channel_name)
             if pattern0:
                 year, month, day, hour, minute, second = map(int, pattern0.groups()[:6])
-                hour = _apply_meridiem(hour, pattern0.group(7))
+                hour = _apply_meridiem(hour, pattern0.group("ap"))
                 try:
                     extracted_date = datetime(year, month, day, hour, minute, second)
                     logger.debug(f"Extracted datetime {extracted_date} from pattern {prefix}YYYY-MM-DD HH:MM:SS[ AM/PM] in '{channel_name}'")
@@ -1194,10 +1194,10 @@ class Plugin:
                     pass
 
         # Pattern 0a: (YYYY-MM-DD HH:MM:SS[ AM/PM]) in parentheses
-        pattern0a = re.search(r'\((\d{4})-(\d{2})-(\d{2})\s+(\d{1,2}):(\d{2}):(\d{2})\s*([AaPp][Mm])?\)', channel_name)
+        pattern0a = re.search(r'\((\d{4})-(\d{2})-(\d{2})\s+(\d{1,2}):(\d{2}):(\d{2})\s*(?P<ap>[AaPp][Mm])?\)', channel_name)
         if pattern0a:
             year, month, day, hour, minute, second = map(int, pattern0a.groups()[:6])
-            hour = _apply_meridiem(hour, pattern0a.group(7))
+            hour = _apply_meridiem(hour, pattern0a.group("ap"))
             try:
                 extracted_date = datetime(year, month, day, hour, minute, second)
                 logger.debug(f"Extracted datetime {extracted_date} from pattern (YYYY-MM-DD HH:MM:SS[ AM/PM]) in '{channel_name}'")
@@ -1331,13 +1331,24 @@ class Plugin:
             now_in_tz = datetime.now(local_tz)
             today_day = now_in_tz.weekday()
 
+            # ±1 day tolerance: a channel named for a US/EU day can roll over the
+            # viewer's local calendar (e.g. "Monday Night Football" is Tuesday in
+            # Australia). Earth's TZ span is UTC-12..UTC+14, so the named day will
+            # always be within ±1 of the viewer's day for any live event.
+            allowed_days = {(today_day - 1) % 7, today_day, (today_day + 1) % 7}
+
             day_names = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
             extracted_day_name = day_names[extracted_day]
             today_day_name = day_names[today_day]
 
-            if extracted_day != today_day:
+            if extracted_day not in allowed_days:
                 return True, f"[WrongDayOfWeek] Channel is for {extracted_day_name}, but today is {today_day_name}"
 
+            if extracted_day != today_day:
+                logger.debug(
+                    f"[WrongDayOfWeek] allowing '{channel_name}': named day {extracted_day_name} "
+                    f"is within ±1 of today ({today_day_name}) in {tz_str} — cross-TZ rollover tolerance"
+                )
             return False, None
 
         elif rule_name == "NoEventPattern":


### PR DESCRIPTION
## Summary

- `[WrongDayOfWeek]` rule now tolerates ±1 day to fix false-positive hides for cross-timezone viewers
- Bumps event-channel-managarr to **v1.26.1401103**

## The bug

The rule extracted a day name from the channel string (e.g. "Monday Night Football") and compared it against **today in the viewer's local timezone**. Channel names encode the *source-TZ* day (US for MNF/TNF/SNF, EU for European sports). A viewer in Australia (GMT+10) seeing a US channel (GMT-4) experiences a 14h gap — the calendar days disagree and the rule false-positive hides every cross-TZ live event. Switching the user's TZ to the source TZ only fixes one source.

## The fix

±1 day tolerance: accept the channel if `extracted_day` equals yesterday, today, or tomorrow in the viewer's TZ. Earth's TZ span is UTC-12..UTC+14, so any live event's source-day is always within ±1 of the viewer's local day. Zero-config; covers AU↔US↔EU simultaneously. 4 of 7 days still trigger the rule, so it remains a useful filter against stale stub channels.

Also adds a `DEBUG`-level log entry when the tolerance lets a channel through, for support diagnosis.

## Test plan

- [x] Verified modulo math wraps correctly at Sun→Mon (`{6,0,1}`) and Sat→Sun (`{5,6,0}`) boundaries
- [x] Confirmed rule still meaningful (4 of 7 weekdays still hide)
- [x] DST-safe: uses `datetime.now(tz_aware).weekday()`
- [x] Plugin version sync between `plugin.py` and `plugin.json` (1.26.1401103)
- [x] Deployed to a live Dispatcharr container and verified the new logic is present
- [ ] User to verify on Australian-TZ install that previously-hidden US live channels are now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)