### PR TITLE
[iptv-checker]: Update to v1.26.1421301

### DIFF
--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.1362003",
+  "version": "1.26.1421301",
   "description": "A Dispatcharr Plugin that goes through a playlist to check IPTV channels",
   "author": "PiratesIRC",
   "logo": "logo.png",

--- a/plugins/iptv-checker/plugin.py
+++ b/plugins/iptv-checker/plugin.py
@@ -282,7 +282,7 @@ class Plugin:
     
     # Explicitly set the plugin key
     key = "iptv_checker"
-    version = "1.26.1362003"
+    version = "1.26.1421301"
 
     # Fields and actions are defined in plugin.json (single source of truth)
     def __init__(self):
@@ -1237,13 +1237,13 @@ class Plugin:
                         current_parts += [0] * (max_len - len(current_parts))
 
                         if latest_parts > current_parts:
-                            message = f"🔔 Update Available: v{latest_version} is available (current: v{self.version})"
+                            message = f"🔔 Update Available: v{latest_clean} is available (current: v{current_clean})"
                         else:
                             message = f"✅ Version Status: You are up to date (v{self.version})"
                     except (ValueError, AttributeError):
                         # Fallback to string comparison if version parsing fails
-                        if latest_version != self.version:
-                            message = f"🔔 Update Available: v{latest_version} is available (current: v{self.version})"
+                        if latest_clean != current_clean:
+                            message = f"🔔 Update Available: v{latest_clean} is available (current: v{current_clean})"
                         else:
                             message = f"✅ Version Status: You are up to date (v{self.version})"
 


### PR DESCRIPTION
Updates **iptv-checker** to **v1.26.1421301**.

### Change
Fixes a cosmetic bug in the plugin's version-check message: the *Update Available* log line / UI toast rendered the latest version with a doubled `v` prefix (e.g. `vv1.26.1362003`) because the message interpolated `v{latest_version}` while `latest_version` already carried the GitHub release tag's own `v`. Both the parsed and fallback branches now use the already-stripped version values.

Display-only change — no effect on stream checking, scheduling, or Dispatcharr integration.

Diff is limited to `plugins/iptv-checker/` (plugin.json + plugin.py).

Source release: https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin/releases/tag/v1.26.1421301