### PR TITLE
[epg-janitor] Update to 1.26.1420824 — adaptive execution, matcher accuracy, wildcard settings

### DIFF
--- a/plugins/epg-janitor/AU_channels.json
+++ b/plugins/epg-janitor/AU_channels.json
@@ -1,7 +1,7 @@
 {
   "country_code": "AU",
   "country_name": "Australia",
-  "version": "2025-11-10",
+  "version": "2026-05-17",
   "channels": [
     {
       "channel_name": "ABC TV",
@@ -251,6 +251,636 @@
     {
       "channel_name": "BBC Earth",
       "category": "Documentary",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky News",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky News HD",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky News Weather",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky News Extra",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky News UK",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fox News Channel",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNN International",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "MS NOW",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "NBC News NOW",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNBC",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bloomberg Television",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Al Jazeera English",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CGTN",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "NHK World",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "GB News",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fox Sports 503",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fox Sports 505",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fox Sports 506",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fox Sports More+",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "ESPN2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Main Event",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Main Event UFC",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky Racing 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky Racing 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky Thoroughbred Central",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fox Sports Ultra HD",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies 4K Ultra HD",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Premiere",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Hits",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Family",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Action",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Comedy",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Romance",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Drama",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movies Greats",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "British Cinema",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Aussie Classics",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "PULP",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "More Movies",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "DreamWorks",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Foxtel One",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC UKTV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "FOX8",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Showcase",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Classics",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "British",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Universal TV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Foxtel Pop Up",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "More Drama",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "More British",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "More Classics",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "BoxSets",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Aurora Community Channel",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Real Life",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "TLC",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "LifeStyle Home",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "More Lifestyle",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fashion TV",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Comedy",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Seinfeld",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "More Comedy",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "DocPlay Channel",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Real History",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Trace Sport Stars",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nature Time",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "HauntTV",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Love Pets",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "More Docos",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Animal Planet",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Discovery Turbo",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "CGTN Documentary",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Crime",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "Real Crime",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "Investigation Discovery",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "GOOD.",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Daystar",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "SBN",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Trending",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Kids Music",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Club",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Retro",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "CMC",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Max",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Australian Played",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Vevo Pop",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Vevo 2K",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Vevo '90s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Vevo '70s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Vevo Retro Rock",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Vevo Country",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Good Vibes",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Triple M 70s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Oldskool 80s Hits",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Triple M 90s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Triple M 2000s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Almost Acoustic",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Rock 'n' Road Trip",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Triple M Classic Rock",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Indie & Alt",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "60s Hits",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Blender Beats",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Triple M 80s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Almost Acoustic Pop",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Easy Hits",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Deep Calm",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "RnB Chill",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Chill Pop Hits",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Oldskool 90s Hits",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Top 30",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "90s Soft Pop",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "RnB Fridays Radio",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Dance Hits",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "2010s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Triple M Country",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Country Classics",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC World Service",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "SBS Radio 1",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "SBS Radio 2",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "SBS Chill",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Easy 97.2",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Rai Radio 1",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "TVSN",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "Antenna Pacific",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Rai Italia",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Outdoor Channel",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "LifeStyle Food",
+      "category": "Food & Travel",
       "type": "National"
     }
   ]

--- a/plugins/epg-janitor/CA_channels.json
+++ b/plugins/epg-janitor/CA_channels.json
@@ -1,7 +1,7 @@
 {
   "country_code": "CA",
   "country_name": "Canada",
-  "version": "2025-12-08",
+  "version": "2026-05-17",
   "channels": [
     {
       "channel_name": "1 Plus 1 International",
@@ -16222,6 +16222,541 @@
       "channel_name": "Évasion HD",
       "category": "Canada",
       "type": "Regional"
+    },
+    {
+      "channel_name": "BBC World News",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bloomberg TV Canada",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "BNN",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CCTV News",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNBC",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNNI",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "FOX News",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "MSNBC",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Weather Network",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "ESPN Classic Sports",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fight Network",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FNTSY Sports Network",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "MLB Extra Innings",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NBA League Pass",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NFL Network",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NFL Sunday Ticket",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NHL Centre Ice",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "radX",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TSN1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TSN2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TSN3",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TSN4",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TSN5",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "WWE Network",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sportsnet Flames",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sportsnet Oilers",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sportsnet Pacific/West",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sportsnet Vancouver Hockey",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Action",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "CraveTV On Demand",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "FXX",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "HBO Canada",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Hollywood Suite 70",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Hollywood Suite 80",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Hollywood Suite 90",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Hollywood Suite 00",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "IFC",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sundance Channel",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Super Channel 1",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Super Channel 2",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Super Channel 3",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Super Channel 4",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "TMN 1",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "TMN Encore 1",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Turner Classic Movies",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "W Movies",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "BabyTV",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC Kids",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cartoon Network",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "CHRGD",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney Channel",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney Junior",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney XD",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Family Channel",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Family Jr",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nickelodeon",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Teletoon",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "A&E",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "ABC Spark",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "AMC",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC Canada",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bravo",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cosmopolitan TV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "DejaView",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "E!",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Fashion Television Channel",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "G4",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Lifetime",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "One",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "OWN",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Showcase",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Space",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Spike TV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "VICELAND",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "DIY Network",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "HGTV",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Comedy Gold",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Peachtree TV",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Comedy Network",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Animal Planet",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Book TV",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Discovery Science",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Discovery Velocity",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Documentary",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "H2",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "National Geographic Channel",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nat Geo Wild",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Crime+ Investigation",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "EWTN",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Hope TV",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Miracle Channel",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Salt + Light",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "BET",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "CMT",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "HIFI",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "MTV2",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "MuchLoud",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "MuchMusic",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Much Retro",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "MuchVibe",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Stingray Music",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Shopping Channel",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "Telelatino",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Univision",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "OLN",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "World Fishing Network",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "Travel + Escape",
+      "category": "Food & Travel",
+      "type": "National"
     }
   ]
 }

--- a/plugins/epg-janitor/ES_channels.json
+++ b/plugins/epg-janitor/ES_channels.json
@@ -1,7 +1,7 @@
 {
   "country_code": "ES",
   "country_name": "Spain",
-  "version": "2025-12-08",
+  "version": "2026-05-17",
   "channels": [
     {
       "channel_name": "#Vamos",
@@ -2732,6 +2732,621 @@
       "channel_name": "À Punt internacional",
       "category": "Spain",
       "type": "Regional"
+    },
+    {
+      "channel_name": "La 1",
+      "category": "Generalistas",
+      "type": "National"
+    },
+    {
+      "channel_name": "La 2",
+      "category": "Generalistas",
+      "type": "National"
+    },
+    {
+      "channel_name": "Antena 3",
+      "category": "Generalistas",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cuatro",
+      "category": "Generalistas",
+      "type": "National"
+    },
+    {
+      "channel_name": "Telecinco",
+      "category": "Generalistas",
+      "type": "National"
+    },
+    {
+      "channel_name": "La Sexta",
+      "category": "Generalistas",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movistar Plus",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movistar Vamos",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Estrenos",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Hits",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Originales",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Documentales",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Clásicos",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Acción",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Comedia",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Drama",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Indie",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Cine Español",
+      "category": "Movistar+",
+      "type": "National"
+    },
+    {
+      "channel_name": "ETB 1",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "ETB 2",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "TeleBilbao",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal Sur Andalucía",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "TVG Europa",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "7TV Sevilla",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "Aragón TV",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "7TV",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "ETBon 1",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "ETBon 2",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "Betevé",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "Esport 3",
+      "category": "Autonómicos",
+      "type": "National"
+    },
+    {
+      "channel_name": "AMC Western",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC Top Gear",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "BeMad",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "Calle 13",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cosmo",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "Syfy",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "SundanceTV",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "STAR TVE",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "AMC Living",
+      "category": "Cine y Series",
+      "type": "National"
+    },
+    {
+      "channel_name": "Veo 7",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Trece",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Energy",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "FDF",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Neox",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Divinity",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nova",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Mega",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Ten",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Squirrel",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Squirrel 2",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bom Cine",
+      "category": "Entretenimiento",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Vamos",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "Primera Federación",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "DAZN MotoGP",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ LaLiga",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "DAZN LaLiga",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "LaLiga TV Hypermotion",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ LaLiga 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "DAZN LaLiga 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "LaLiga TV Hypermotion 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Liga de Campeones",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Liga de Campeones 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Liga de Campeones 3",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Deportes",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Deportes 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Deportes 3",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Vamos 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Vamos 3",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Golf",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Golf 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "GOL",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "Caza y Pesca TV",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "Iberalia TV",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "El Garage TV",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "Rally TV",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "UBEAT",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "DAZN Baloncesto",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "DAZN Baloncesto 2",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "DAZN Baloncesto 3",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "CazaVision",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "UCL",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "ONETORO",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "TYC SPORT",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ LaLiga 3",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ LaLiga 4",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ LaLiga 5",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "LaLiga TV Hypermotion 3",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Deportes 4",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Deportes 5",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Deportes 6",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "M+ Deportes 7",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "UFC Fight HD",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal Fútbol Replay",
+      "category": "Deportes",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nat Geo Wild",
+      "category": "Documentales",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC History",
+      "category": "Documentales",
+      "type": "National"
+    },
+    {
+      "channel_name": "Discovery",
+      "category": "Documentales",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal Odisea",
+      "category": "Documentales",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC Food",
+      "category": "Documentales",
+      "type": "National"
+    },
+    {
+      "channel_name": "DKiss",
+      "category": "Documentales",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nick Jr",
+      "category": "Infantil",
+      "type": "National"
+    },
+    {
+      "channel_name": "DreamWorks",
+      "category": "Infantil",
+      "type": "National"
+    },
+    {
+      "channel_name": "Boing",
+      "category": "Infantil",
+      "type": "National"
+    },
+    {
+      "channel_name": "Clan",
+      "category": "Infantil",
+      "type": "National"
+    },
+    {
+      "channel_name": "SX3",
+      "category": "Infantil",
+      "type": "National"
+    },
+    {
+      "channel_name": "Stingray Classica",
+      "category": "Música",
+      "type": "National"
+    },
+    {
+      "channel_name": "24 Horas",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "BBC World",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNN Int",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "Al Jazeera English",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "France 24",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "1 + 1 International",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNBC Europa",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV5 Monde",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bloomberg",
+      "category": "Noticias",
+      "type": "National"
+    },
+    {
+      "channel_name": "CGTN Documentary",
+      "category": "Internacional",
+      "type": "National"
+    },
+    {
+      "channel_name": "Arirang TV",
+      "category": "Internacional",
+      "type": "National"
+    },
+    {
+      "channel_name": "EWTN",
+      "category": "Internacional",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cubavisión",
+      "category": "Internacional",
+      "type": "National"
+    },
+    {
+      "channel_name": "Daystar TV",
+      "category": "Internacional",
+      "type": "National"
+    },
+    {
+      "channel_name": "Alquiler 1",
+      "category": "Eventos",
+      "type": "National"
+    },
+    {
+      "channel_name": "Alquiler 2",
+      "category": "Eventos",
+      "type": "National"
+    },
+    {
+      "channel_name": "Alquiler 3",
+      "category": "Eventos",
+      "type": "National"
+    },
+    {
+      "channel_name": "Alquiler 4",
+      "category": "Eventos",
+      "type": "National"
     }
   ]
 }

--- a/plugins/epg-janitor/README.md
+++ b/plugins/epg-janitor/README.md
@@ -13,6 +13,7 @@ Dispatcharr v0.20.0 or newer. Python 3.13+ (bundled). No external dependencies.
 
 - **Auto-Match EPG** — weighted structural scoring (callsign 50 / state 30 / city 20 / network 10) + Lineuparr-style 4-stage fuzzy pipeline (alias → exact → substring → token-sort), takes the higher score. Identical-name matches score 100.
 - **Scan & Heal** — find channels whose current EPG has no program data and walk ranked candidates for a working replacement (respects fallback source allowlist).
+- **EPG source selection & priority** — pick eligible sources by name or `*`/`?` wildcard (case-insensitive); only enabled sources are used, and score ties resolve by each source's Dispatcharr `priority` (higher wins).
 - **~200 built-in aliases** (FS1/FS2, CSPAN variants, rebrands like EPIX→MGM+, MSNBC→MS NOW, getTV→GREATTV, DIY→Magnolia, Hallmark Movies & Mysteries→Hallmark Mystery, Justice Network→True Crime Network). User-extendable via a JSON `custom_aliases` setting.
 - **Regional differentiation** (East/West/Pacific, Pacific ≡ West) — lineup channels with regional markers only match compatible EPG feeds, even when `ignore_regional_tags=true`.
 - **Per-category normalization toggles** — quality (`[HD]`, `[4K]`), regional (East/West/Pacific), geographic (`US:`, `[CA]`), misc (`(A)`, `(CX)`) stripped independently.

--- a/plugins/epg-janitor/UK_channels.json
+++ b/plugins/epg-janitor/UK_channels.json
@@ -1,7 +1,7 @@
 {
   "country_code": "UK",
   "country_name": "United Kingdom",
-  "version": "2025-12-08",
+  "version": "2026-05-17",
   "channels": [
     {
       "channel_name": "1-2-3.tv",
@@ -9272,6 +9272,231 @@
       "channel_name": "ZenLIFE by Stingray",
       "category": "United Kingdom",
       "type": "Regional"
+    },
+    {
+      "channel_name": "Arirang TV",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bloomberg",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "DM News",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "NDTV World",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "NHK World",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "NTD",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "DAZN PPV",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "LFCTV",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "MUTV",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky Sports +",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky Sports Tennis",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TNT Sports Box Office",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TNT Sports Ultimate (UHD)",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney+ Cinema",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "GREAT! Romance",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sky Cinema SciFi/Horror",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Boomerang",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cúla4",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney Jr HD",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "RTÉ KIDSjr",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "5 USA",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "5ACTION",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "5STAR",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "GTC Punjabi",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "More4",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Really",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Comedy Central Xtra",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Discovery",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nat Geo Wild",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Crime+Investigation",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "EWTN Catholic",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "GOD Channel",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "LoveWorld",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Revelation",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "SonLife",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Word Network",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Clubland TV",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "NOW 90s and 00s",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "Direct Store TV",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "Gemporia",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "High Street TV 1",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "MustHaveIdeas",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "TJC",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "HUM Masala",
+      "category": "Food & Travel",
+      "type": "National"
+    },
+    {
+      "channel_name": "Travelxp",
+      "category": "Food & Travel",
+      "type": "National"
     }
   ]
 }

--- a/plugins/epg-janitor/US_channels.json
+++ b/plugins/epg-janitor/US_channels.json
@@ -1,7 +1,7 @@
 {
   "country_code": "US",
   "country_name": "United States",
-  "version": "2025-12-08",
+  "version": "2026-05-17",
   "channels": [
     {
       "channel_name": "3ABN",
@@ -158107,6 +158107,861 @@
       "channel_name": "SportsNet Pittsburgh- Alternate 2 HD",
       "category": "United States",
       "type": "Regional"
+    },
+    {
+      "channel_name": "Bloomberg",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "HLN Headline News Network",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Eleven Sports",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "ESPN U",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NESN National+",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sportsnet New York National",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "YES National",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Action Max",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Five Star Max",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "More Max",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Movie Max",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Outer Max",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Thriller Max",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nick 2",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "HBCU GO",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "OWN: Oprah Winfrey Network",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "StellarTV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "UP",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "E! Entertainment Television",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "History Channel",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Crime & Investigation Network",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "JusticeCentral.TV",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "Law & Crime Network",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "PTL TV",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "The SonLife Broadcasting Network",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Word",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Three Angels Broadcasting",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "QVC 2",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "QVC 3",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "Antena 3",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "MAX Latino",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Univision tINovelas",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "MAV TV",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "MyDestination TV",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "Pursuit",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "CCTV News",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "NASA",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Russia Today",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Weather Channel",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "beIN SPORT",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bases Loaded / Buzzer Beater / Goal Line",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NBCSN",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV Games Network",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Regional Sports Networks (market-based)",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Big 10 Network",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "EPIX 1",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Showtime (E)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Showtime (W)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Showtime Beyond",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ (E)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ (W)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ Encore (E)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ Encore (W)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Movie Channel (E)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Movie Channel (W)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Movie Channel Xtra (E)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "BabyFirstTV",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cartoon Network (E)",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cartoon Network (W)",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney Channel (E)",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney Channel (W)",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nick/Nick at Nite (E)",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nick/Nick at Nite (W)",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "LAFF TV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Uplifting Entertainment",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "BUZZ",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "DIY",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "EVINE Live",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Justice Network",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "Hillsong Channel",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Shepherd's Chapel Network",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Impact Network",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Three Angels Broadcasting Network",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Victory",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "DISH Music Channels",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "SiriusXM Music Channels (Hopper/Wally/Joey)",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "SiriusXM Music Channels (all other receivers)",
+      "category": "Music",
+      "type": "National"
+    },
+    {
+      "channel_name": "BeautyIQ",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sale",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "CCTV-E",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "NBC Universo",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Univision Deportes",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Univision East",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Univision West",
+      "category": "Spanish",
+      "type": "National"
+    },
+    {
+      "channel_name": "Great American Country",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "In Country Television",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "RECTV",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "Ride TV",
+      "category": "Outdoors",
+      "type": "National"
+    },
+    {
+      "channel_name": "ABC Localish",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNNi",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "News Mix",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "All Women's Sports",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Big 12",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "DIRECTV 4K Live 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "DIRECTV 4K Live 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "DraftKings",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "League Sports Mix",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NBA FAST Channel",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Players TV",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sports Illustrated",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Sports Mix",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Tennis Channel 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TNA",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Chicago Sports Network",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Cincinnati",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Detroit",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Florida",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Midwest",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports North",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Ohio",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Oklahoma",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports SoCal",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports South",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Southeast",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Southwest",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Sun",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports West",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "FanDuel Sports Wisconsin",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "MASN",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NBA New Orleans Pelicans",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NESN",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "NHL Network Alternate",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "SNY",
+      "category": "Regional Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cinemax East",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Family Movie Classics (FMC)",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "HBO Comedy East HD",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "HBO Drama HD East",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "HBO Hits HD East",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Paramount+ with SHOWTIME EAST",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "SHOWTIME 2 East",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "ShortsTV",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ Cinema East HD",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ Comedy East HD",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ Edge East HD",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ ENCORE East",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ ENCORE West",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "STARZ In Black East HD",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Tribeca Festival+",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "BabyFirst HD",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Cartoon Network East",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney Channel East",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Kids Mix",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "LooLooKids",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nickelodeon East",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "CleoTV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "EBONY TV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Heroes & Icons (H&I)",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "ION East HD",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Pop TV",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV One (HD only)",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "TheGrio",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "All Reality WeTV",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Dance Moms by Lifetime",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Love After Lockup",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "OWN",
+      "category": "Reality & Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "Always Funny",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Comedy TV",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Family Feud (Steve Harvey)",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "The Price is Right: Drew Carey",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Three Stooges",
+      "category": "Comedy",
+      "type": "National"
+    },
+    {
+      "channel_name": "Bob Ross",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Discovery",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Earth Touch",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "HISTORY Channel, The",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Mythbusters",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "National Geographic Channel",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "Torque by History",
+      "category": "Discovery",
+      "type": "National"
+    },
+    {
+      "channel_name": "I (Almost) Got Away With It",
+      "category": "Crime",
+      "type": "National"
+    },
+    {
+      "channel_name": "Dove TV",
+      "category": "Faith",
+      "type": "National"
+    },
+    {
+      "channel_name": "Jewelry TV",
+      "category": "Shopping",
+      "type": "National"
+    },
+    {
+      "channel_name": "Univision (Este)",
+      "category": "Spanish",
+      "type": "National"
     }
   ]
 }

--- a/plugins/epg-janitor/aliases.py
+++ b/plugins/epg-janitor/aliases.py
@@ -240,4 +240,11 @@ CHANNEL_ALIASES = {
     "Discovery Turbo": ["Disc.Turbo", "Disc.Turbo+1", "UK: DISCOVERY TURBO", "DISCOVERY TURBO"],
     "Discovery Science": ["Disc.Science", "Disc.Sci+1", "Discovery Science", "UK: DISCOVERY SCIENCE"],
     "Crime+Investigation": ["Crime+Inv HD", "Crime+Inv+1", "Crime + Investigation", "Crime+Investigation"],
+
+    # --- AU: Brand-rename / network-prefix gaps (lineup name → XMLTV name) ---
+    "SBS Food": ["Food Network (SBSAU)", "Food Network"],
+    "Movies Romance": ["Foxtel Movies Romance", "Foxtel Movies Romance HD"],
+    "Movies Greats": ["Foxtel Movies Greats", "Foxtel Movies Greats HD"],
+    "Action Movies": ["Foxtel Movies Action", "Foxtel Movies Action HD", "Action Hollywood Movies"],
+    "Antenna TV Pacific": ["Antenna Pacific"],
 }

--- a/plugins/epg-janitor/fuzzy_matcher.py
+++ b/plugins/epg-janitor/fuzzy_matcher.py
@@ -25,7 +25,7 @@ import logging
 import unicodedata
 from glob import glob
 
-__version__ = "1.0.0"
+__version__ = "1.26.1420824"
 
 LOGGER = logging.getLogger("plugins.epg_janitor.fuzzy_matcher")
 if not LOGGER.handlers:
@@ -114,6 +114,8 @@ class FuzzyMatcher:
         self._norm_cache = {}  # raw_name -> normalized_lower
         self._norm_nospace_cache = {}  # raw_name -> normalized_nospace
         self._processed_cache = {}  # raw_name -> processed_for_matching
+        self._callsign_cache = {}  # raw_name -> (callsign|None, is_high_confidence)
+        # (legacy extract_callsign callers also populate this; safe — extraction is pure)
         # Legacy EPG-Janitor state used by restored methods below
         self.broadcast_channels = []
         self.premium_channels = []
@@ -134,6 +136,7 @@ class FuzzyMatcher:
         self._norm_cache.clear()
         self._norm_nospace_cache.clear()
         self._processed_cache.clear()
+        self._callsign_cache.clear()
 
         for name in names:
             norm = self.normalize_name(name, user_ignored_tags)
@@ -319,15 +322,34 @@ class FuzzyMatcher:
     # Words that match the callsign regex shape but are never US broadcast
     # callsigns. WWE/WWF/WCW added to stop wrestling show names from being
     # extracted as false-positive callsigns (e.g., "PPV 14 | WWE NXT").
+    # A US callsign (K/W + 2-4 letters) is shape-identical to many common
+    # English words, so the loose Priority-4 pattern mis-extracts them — e.g.
+    # the word "with" in "Bizarre Foods with Andrew Zimmern" becomes callsign
+    # "WITH". Regex alone cannot tell "WITH" from "WABC"; frequent K/W-initial
+    # words are denied explicitly so they never extract as a callsign.
     _CALLSIGN_DENYLIST = frozenset({
-        'WEST', 'EAST', 'KIDS', 'WOMEN', 'WILD', 'WORLD',
-        'WWE', 'WWF', 'WCW',
+        'WWE', 'WWF', 'WCW', 'EAST',
+        'WAR', 'WARS', 'WARM', 'WASH', 'WATCH', 'WAVE', 'WAVES', 'WAY', 'WAYS',
+        'WEB', 'WEEK', 'WELL', 'WENT', 'WERE', 'WEST', 'WHAT', 'WHEN', 'WHERE',
+        'WHICH', 'WHILE', 'WHITE', 'WHO', 'WHY', 'WIDE', 'WIFE', 'WILD', 'WILL',
+        'WIND', 'WINE', 'WING', 'WINGS', 'WINS', 'WIRE', 'WISE', 'WISH', 'WITH',
+        'WOLF', 'WOMAN', 'WOMEN', 'WOOD', 'WORD', 'WORDS', 'WORK', 'WORKS',
+        'WORLD', 'WORM', 'WORN', 'WRAP',
+        'KEEN', 'KEEP', 'KEPT', 'KEY', 'KEYS', 'KICK', 'KID', 'KIDS', 'KILL',
+        'KIND', 'KING', 'KINGS', 'KISS', 'KITE', 'KNEE', 'KNEW', 'KNOW', 'KNOWN',
     })
 
-    def extract_callsign(self, channel_name):
+    def _compute_callsign_with_confidence(self, channel_name):
         """
-        Extract US TV callsign from channel name with priority order.
-        Returns None if common false positives appear alone.
+        Extract US TV callsign with a confidence flag.
+
+        Returns (callsign, is_high_confidence). High confidence =
+        Priorities 1-3 (parenthesized / suffixed-paren / end-of-name).
+        Priority 4 (any loose word) is low confidence. (None, False)
+        when nothing extractable.
+
+        Channel name is pre-processed to strip common provider prefixes
+        (leading "D<digits>-" and "US"/"USA" prefixes) before matching.
         """
         # Remove common prefixes
         channel_name = re.sub(r'^D\d+-', '', channel_name)
@@ -338,29 +360,52 @@ class FuzzyMatcher:
         if paren_match:
             callsign = paren_match.group(1).upper()
             if callsign not in self._CALLSIGN_DENYLIST:
-                return callsign
+                return callsign, True
 
         # Priority 2: Callsigns with suffix in parentheses
         paren_suffix_match = re.search(r'\(([KW][A-Z]{2,4}-(?:TV|CD|LP|DT|LD))\)', channel_name, re.IGNORECASE)
         if paren_suffix_match:
-            callsign = paren_suffix_match.group(1).upper()
-            return callsign
+            return paren_suffix_match.group(1).upper(), True
 
         # Priority 3: Callsigns at the end
         end_match = re.search(r'\b([KW][A-Z]{2,4}(?:-(?:TV|CD|LP|DT|LD))?)\s*(?:\.[a-z]+)?\s*$', channel_name, re.IGNORECASE)
         if end_match:
             callsign = end_match.group(1).upper()
             if callsign not in self._CALLSIGN_DENYLIST:
-                return callsign
+                return callsign, True
 
-        # Priority 4: Any word matching callsign pattern
+        # Priority 4: Any word matching callsign pattern (low confidence)
         word_match = re.search(r'\b([KW][A-Z]{2,4}(?:-(?:TV|CD|LP|DT|LD))?)\b', channel_name, re.IGNORECASE)
         if word_match:
             callsign = word_match.group(1).upper()
             if callsign not in self._CALLSIGN_DENYLIST:
-                return callsign
+                return callsign, False
 
-        return None
+        return None, False
+
+    def _extract_callsign_with_confidence(self, channel_name):
+        """
+        Cached wrapper around _compute_callsign_with_confidence.
+
+        Extraction is pure in channel_name, so results are memoized — the
+        anchor calls this once per (channel, stream) pair over a fixed
+        stream list, which is otherwise massively redundant. Cache is
+        cleared by precompute_normalizations (mirrors the norm caches).
+        """
+        cached = self._callsign_cache.get(channel_name)
+        if cached is not None:
+            return cached
+        result = self._compute_callsign_with_confidence(channel_name)
+        self._callsign_cache[channel_name] = result
+        return result
+
+    def extract_callsign(self, channel_name):
+        """
+        Extract US TV callsign from channel name with priority order.
+        Returns None if common false positives appear alone.
+        """
+        callsign, _ = self._extract_callsign_with_confidence(channel_name)
+        return callsign
 
     def normalize_callsign(self, callsign):
         """Remove suffix from callsign for display."""
@@ -865,7 +910,12 @@ class FuzzyMatcher:
             effective_threshold = self._length_scaled_threshold(self.match_threshold, best_alias_len)
 
             if score >= effective_threshold and score < 100:
-                need_majority = score < 90
+                # Short strings need the stricter majority-overlap guard even
+                # at high scores: a 90 score on a 5-char alias is just one
+                # Levenshtein substitution ("ME TV" -> "WE tv"), a different
+                # channel — and the basic guard passes vacuously when every
+                # token is shorter than min_token_len.
+                need_majority = score < 90 or best_alias_len <= 8
                 if not self._has_token_overlap(best_alias_norm, candidate_lower, require_majority=need_majority):
                     continue
 
@@ -998,6 +1048,12 @@ class FuzzyMatcher:
         if user_ignored_tags is None:
             user_ignored_tags = []
 
+        # Callsign anchor (asymmetric): floor on any-confidence equality;
+        # hard-reject only on high-confidence disagreement.
+        query_callsign, query_cs_hc = self._extract_callsign_with_confidence(lineup_name or "")
+        query_callsign_norm = self.normalize_callsign(query_callsign) if query_callsign else None
+        callsign_anchored = set()  # candidate names exempt from region filter
+
         all_matches = {}  # stream_name -> (score, match_type)
 
         # Stage 0: Alias matching
@@ -1068,13 +1124,32 @@ class FuzzyMatcher:
                     boost = self._channel_number_boost(candidate, channel_number)
                     all_matches[candidate] = (min(score + boost, 100), mtype)
 
+        # Callsign anchor: a shared callsign rescues an otherwise-unmatched
+        # stream; a disagreeing one hard-rejects a false positive. BOTH the
+        # floor and the reject require BOTH callsigns to be high-confidence
+        # (parenthesized or end-of-name). A loose mid-name word that merely
+        # has callsign shape (e.g. "WITH") is not a reliable callsign and
+        # must not floor a score at 95 or reject a candidate.
+        if query_callsign_norm and query_cs_hc:
+            for candidate in candidate_names:
+                cand_cs, cand_hc = self._extract_callsign_with_confidence(candidate)
+                if not cand_cs or not cand_hc:
+                    continue
+                if self.normalize_callsign(cand_cs) == query_callsign_norm:
+                    existing = all_matches.get(candidate)
+                    if existing is None or existing[0] < 95:
+                        all_matches[candidate] = (95, "callsign")
+                    callsign_anchored.add(candidate)
+                else:
+                    # High-confidence disagreement -> hard reject.
+                    all_matches.pop(candidate, None)
+
         # Filter out wrong-region matches (East vs West vs Pacific)
         # Detect regional markers from the ORIGINAL lineup name (the normalized
         # form may have stripped them). When present, the lineup is explicitly
         # signaling a zoned feed and we filter candidates to compatible regions
         # regardless of ignore_regional_tags. The toggle only controls whether
         # regionless queries reject Pacific/West candidates.
-        query_lower = (normalized_query or "").lower()
         original_lower = (lineup_name or "").lower()
         # Detect (e)/(w)/(p) abbreviations in the original name
         _has_abbrev_east = bool(re.search(r'\(\s*e\s*\)', original_lower))
@@ -1089,6 +1164,9 @@ class FuzzyMatcher:
             # Filter candidates to compatible regions.
             filtered = {}
             for stream_name, (score, mtype) in all_matches.items():
+                if stream_name in callsign_anchored:
+                    filtered[stream_name] = (score, mtype)
+                    continue
                 sn_lower = stream_name.lower()
                 stream_has_east = "east" in sn_lower
                 stream_has_west = "west" in sn_lower and "western" not in sn_lower
@@ -1124,6 +1202,9 @@ class FuzzyMatcher:
             # Prefer regionless EPG entries, reject Pacific/West for regionless queries.
             filtered = {}
             for stream_name, (score, mtype) in all_matches.items():
+                if stream_name in callsign_anchored:
+                    filtered[stream_name] = (score, mtype)
+                    continue
                 sn_lower = stream_name.lower()
                 stream_has_pacific = "pacific" in sn_lower
                 stream_has_west = "west" in sn_lower and "western" not in sn_lower

--- a/plugins/epg-janitor/plugin.json
+++ b/plugins/epg-janitor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPG Janitor",
-  "version": "1.26.1021352",
+  "version": "1.26.1420824",
   "description": "Scans for channels with EPG assignments but no program data. Auto-matches EPG to channels using intelligent fuzzy matching with aliases, removes EPG from hidden channels, and manages EPG assignments.",
   "author": "PiratesIRC",
   "maintainers": ["PiratesIRC"],
@@ -10,6 +10,7 @@
   "discord_thread": "https://discord.com/channels/1340492560220684331/1420051973994053848",
   "min_dispatcharr_version": "v0.20.0",
   "fields": [
+    {"id": "_section_quickstart", "label": "Quick Start", "type": "info", "description": "New here? Typical workflow — 1) ✅ Validate  2) 🔍 Scan Missing finds channels whose EPG has no program data  3) 👁️ Preview Auto-Match, then 🎯 Apply Auto-Match to assign EPG  4) 🧹 Preview Heal, then 🧹 Apply Heal to repair stale assignments. Every action that changes data has a Preview — run it first. Long jobs keep running in the background — click 📊 Status / Results to watch them."},
     {"id": "_section_scope", "label": "Scope", "type": "info", "description": "Limit which channels and EPG sources this plugin touches."},
     {"id": "channel_profile_name", "label": "Channel Profile Names", "type": "text", "default": "",
      "placeholder": "e.g. All, Favorites",
@@ -65,16 +66,16 @@
   ],
   "actions": [
     {"id": "validate_settings", "label": "Validate Settings", "button_label": "✅ Validate", "description": "Validate all plugin settings and database connectivity", "button_variant": "outline", "button_color": "blue"},
-    {"id": "get_summary", "label": "View Last Results", "button_label": "📊 View Results", "description": "Display summary of the last EPG scan results", "button_variant": "outline", "button_color": "blue"},
     {"id": "scan_missing_epg", "label": "Scan for Missing Program Data", "button_label": "🔍 Scan Missing", "description": "Find channels with EPG assignments but no program data", "button_variant": "outline", "button_color": "blue"},
-    {"id": "preview_auto_match", "label": "Preview Auto-Match (Dry Run)", "button_label": "👁️ Preview Auto-Match", "description": "Preview intelligent EPG auto-matching with program data validation", "button_variant": "outline", "button_color": "cyan"},
-    {"id": "scan_and_heal_dry_run", "label": "Scan & Heal (Dry Run)", "button_label": "🧹 Heal Preview", "description": "Find broken EPG assignments and search for working replacements (preview only)", "button_variant": "outline", "button_color": "cyan"},
+    {"id": "get_summary", "label": "Status / Last Results", "button_label": "📊 Status / Results", "description": "Watch a running job's progress, or show the last scan's summary", "button_variant": "outline", "button_color": "blue"},
     {"id": "export_results", "label": "Export Results to CSV", "button_label": "📄 Export CSV", "description": "Export the last scan results to a CSV file", "button_variant": "outline", "button_color": "cyan"},
+    {"id": "preview_auto_match", "label": "Preview Auto-Match (Dry Run)", "button_label": "👁️ Preview Auto-Match", "description": "Preview intelligent EPG auto-matching with program data validation", "button_variant": "outline", "button_color": "cyan"},
     {"id": "apply_auto_match", "label": "Apply Auto-Match EPG Assignments", "button_label": "🎯 Apply Auto-Match", "description": "Automatically match and assign EPG to channels using intelligent weighted scoring", "button_variant": "filled", "button_color": "green", "confirm": {"message": "This will assign EPG data to matched channels. Continue?"}},
+    {"id": "scan_and_heal_dry_run", "label": "Scan & Heal (Dry Run)", "button_label": "🧹 Preview Heal", "description": "Find broken EPG assignments and search for working replacements (preview only)", "button_variant": "outline", "button_color": "cyan"},
     {"id": "scan_and_heal_apply", "label": "Scan & Heal (Apply Changes)", "button_label": "🧹 Apply Heal", "description": "Automatically find and fix broken EPG assignments", "button_variant": "filled", "button_color": "green", "confirm": {"message": "This will replace broken EPG assignments with working ones. Continue?"}},
     {"id": "add_bad_epg_suffix", "label": "Add Bad EPG Suffix to Channels", "button_label": "🏷️ Suffix Bad EPG", "description": "Add suffix to channels with missing EPG program data", "button_variant": "filled", "button_color": "orange", "confirm": {"message": "This will rename channels that have missing EPG program data. Continue?"}},
-    {"id": "remove_epg_from_hidden", "label": "Remove EPG from Hidden Channels", "button_label": "👁️‍🗨️ Strip Hidden EPG", "description": "Remove all EPG data from channels hidden in the selected profile", "button_variant": "filled", "button_color": "orange", "confirm": {"message": "This will remove EPG assignments from every channel hidden in the selected profile. Continue?"}},
     {"id": "remove_epg_assignments", "label": "Remove EPG Assignments (Missing Program Data)", "button_label": "❌ Remove Bad EPG", "description": "Remove EPG assignments from channels with missing program data", "button_variant": "filled", "button_color": "red", "confirm": {"message": "This will permanently remove EPG assignments from channels with missing program data. Are you sure?"}},
+    {"id": "remove_epg_from_hidden", "label": "Remove EPG from Hidden Channels", "button_label": "🙈 Strip Hidden EPG", "description": "Remove all EPG data from channels hidden in the selected profile", "button_variant": "filled", "button_color": "orange", "confirm": {"message": "This will remove EPG assignments from every channel hidden in the selected profile. Continue?"}},
     {"id": "remove_epg_by_regex", "label": "Remove EPG Assignments matching REGEX", "button_label": "❌ Remove by REGEX", "description": "Remove EPG from channels matching REGEX pattern within groups", "button_variant": "filled", "button_color": "red", "confirm": {"message": "This will permanently remove EPG assignments from channels matching the REGEX pattern. Are you sure?"}},
     {"id": "remove_all_epg_from_groups", "label": "Remove ALL EPG Assignments from Groups", "button_label": "❌ Remove All in Groups", "description": "Remove EPG from all channels in specified groups", "button_variant": "filled", "button_color": "red", "confirm": {"message": "This will permanently remove EPG from EVERY channel in the specified groups. This cannot be undone. Are you sure?"}},
     {"id": "clear_csv_exports", "label": "Clear CSV Exports", "button_label": "🗑️ Clear Exports", "description": "Delete all CSV export files created by this plugin", "button_variant": "outline", "button_color": "red", "confirm": {"message": "Delete all EPG Janitor CSV exports?"}}

--- a/plugins/epg-janitor/plugin.py
+++ b/plugins/epg-janitor/plugin.py
@@ -10,9 +10,8 @@ import csv
 import os
 import re
 import time
-import urllib.request
-import urllib.error
-from datetime import datetime, timedelta
+import threading
+from datetime import datetime, timedelta, timezone as dt_timezone
 from django.utils import timezone
 from django.db import transaction
 from glob import glob
@@ -25,6 +24,8 @@ from core.utils import send_websocket_update
 # Import fuzzy matcher module
 from .fuzzy_matcher import FuzzyMatcher
 from .aliases import CHANNEL_ALIASES
+from . import wildcard_match
+from . import progress_status
 
 # Setup logging
 LOGGER = logging.getLogger("plugins.epg_janitor")
@@ -37,11 +38,13 @@ class Plugin:
     """Dispatcharr EPG Janitor Plugin"""
 
     name = "EPG Janitor"
-    version = "1.26.1021352"
+    version = "1.26.1420824"
     description = "Scan for channels with EPG assignments but no program data. Auto-match EPG to channels using OTA and regular channel data."
 
     # Settings rendered by UI
     _base_fields = [
+        {"id": "_section_quickstart", "label": "Quick Start", "type": "info",
+         "description": "New here? Typical workflow — 1) ✅ Validate  2) 🔍 Scan Missing finds channels whose EPG has no program data  3) 👁️ Preview Auto-Match, then 🎯 Apply Auto-Match to assign EPG  4) 🧹 Preview Heal, then 🧹 Apply Heal to repair stale assignments. Every action that changes data has a Preview — run it first. Long jobs keep running in the background — click 📊 Status / Results to watch them."},
         {"id": "_section_scope", "label": "Scope", "type": "info",
          "description": "Limit which channels and EPG sources this plugin touches."},
         {"id": "channel_profile_name", "label": "Channel Profile Names", "type": "text", "default": "",
@@ -49,13 +52,13 @@ class Plugin:
          "help_text": "Comma-separated profile names. Actions like 'Remove EPG from Hidden Channels' use the first profile."},
         {"id": "selected_groups", "label": "Channel Groups", "type": "text", "default": "",
          "placeholder": "e.g. DTV: All, DISH: All",
-         "help_text": "Only process channels in these groups. Leave empty to include all groups."},
+         "help_text": "Only process channels in these groups. Leave empty to include all groups. Supports * and ? wildcards (e.g. US*, *Sports*); wildcard matches are case-insensitive."},
         {"id": "ignore_groups", "label": "Ignore Groups", "type": "text", "default": "",
          "placeholder": "e.g. PPV Live Events, 24/7 Streams",
-         "help_text": "Exclude channels in these groups. Applied after 'Channel Groups' filter."},
+         "help_text": "Exclude channels in these groups. Applied after 'Channel Groups' filter. Supports * and ? wildcards (e.g. PPV*); wildcard matches are case-insensitive."},
         {"id": "epg_sources_to_match", "label": "EPG Sources to Match", "type": "text", "default": "",
          "placeholder": "leave empty for all sources",
-         "help_text": "Comma-separated EPG source names. Leave empty to match against every configured EPG source."},
+         "help_text": "Comma-separated EPG source names to use (a filter, not a priority list). Leave empty for all active sources. Supports * and ? wildcards (e.g. *EPG*); wildcard matches are case-insensitive. Match priority follows each source's Dispatcharr priority (higher number wins); disabled EPG sources are skipped."},
         {"id": "check_hours", "label": "Hours to Check Ahead", "type": "number", "default": 12,
          "help_text": "Window (in hours) used to validate that a matched EPG actually has program data."},
         {"id": "_section_automatch", "label": "Auto-Match", "type": "info",
@@ -63,7 +66,7 @@ class Plugin:
         {"id": "automatch_confidence_threshold", "label": "Auto-Match Confidence Threshold", "type": "number", "default": 95,
          "help_text": "0-100. Matches below this score are rejected. 95 is strict; lower values accept more matches at higher false-positive risk."},
         {"id": "allow_epg_without_programs", "label": "Allow EPG Without Program Data", "type": "boolean", "default": False,
-         "help_text": "When ON, auto-match accepts EPG entries even if they carry no current program schedule. Usually OFF."},
+         "help_text": "When ON, auto-match accepts EPG entries even if they carry no current program schedule. Usually OFF, but turn ON for the first auto-match against a freshly added EPG source: Dispatcharr only imports program data for EPG channels already mapped to a Dispatcharr channel, so a brand-new source starts with zero programs and every match would be rejected. After the first auto-match assigns EPG IDs, refresh the EPG source to backfill program data, then you can turn this OFF again."},
         {"id": "_section_heal", "label": "Scan & Heal", "type": "info",
          "description": "Detect channels whose existing EPG assignment has gone stale (no program data) and replace with a working EPG."},
         {"id": "heal_fallback_sources", "label": "Heal Fallback EPG Sources", "type": "text", "default": "",
@@ -75,7 +78,7 @@ class Plugin:
          "description": "Actions that alter channel metadata or strip EPG assignments."},
         {"id": "epg_regex_to_remove", "label": "EPG Name REGEX to Remove", "type": "string", "default": "",
          "placeholder": "e.g. ^XYZ_\\d+$",
-         "help_text": "Python regex. Channels whose current EPG name matches get their EPG removed by 'Remove EPG Assignments matching REGEX'."},
+         "help_text": "Python regex. Channels whose current EPG name matches get their EPG removed by '❌ Remove by REGEX'."},
         {"id": "bad_epg_suffix", "label": "Bad EPG Suffix", "type": "string", "default": " [BadEPG]",
          "help_text": "Suffix appended to channel names by 'Add Bad EPG Suffix to Channels'. Leading space matters."},
         {"id": "remove_epg_with_suffix", "label": "Also Remove EPG When Adding Suffix", "type": "boolean", "default": False,
@@ -100,16 +103,16 @@ class Plugin:
     # Actions for Dispatcharr UI
     actions = [
         {"id": "validate_settings", "label": "Validate Settings", "button_label": "✅ Validate", "description": "Validate all plugin settings and database connectivity", "button_variant": "outline", "button_color": "blue"},
-        {"id": "get_summary", "label": "View Last Results", "button_label": "📊 View Results", "description": "Display summary of the last EPG scan results", "button_variant": "outline", "button_color": "blue"},
         {"id": "scan_missing_epg", "label": "Scan for Missing Program Data", "button_label": "🔍 Scan Missing", "description": "Find channels with EPG assignments but no program data", "button_variant": "outline", "button_color": "blue"},
-        {"id": "preview_auto_match", "label": "Preview Auto-Match (Dry Run)", "button_label": "👁️ Preview Auto-Match", "description": "Preview intelligent EPG auto-matching with program data validation", "button_variant": "outline", "button_color": "cyan"},
-        {"id": "scan_and_heal_dry_run", "label": "Scan & Heal (Dry Run)", "button_label": "🧹 Heal Preview", "description": "Find broken EPG assignments and search for working replacements (preview only)", "button_variant": "outline", "button_color": "cyan"},
+        {"id": "get_summary", "label": "Status / Last Results", "button_label": "📊 Status / Results", "description": "Watch a running job's progress, or show the last scan's summary", "button_variant": "outline", "button_color": "blue"},
         {"id": "export_results", "label": "Export Results to CSV", "button_label": "📄 Export CSV", "description": "Export the last scan results to a CSV file", "button_variant": "outline", "button_color": "cyan"},
+        {"id": "preview_auto_match", "label": "Preview Auto-Match (Dry Run)", "button_label": "👁️ Preview Auto-Match", "description": "Preview intelligent EPG auto-matching with program data validation", "button_variant": "outline", "button_color": "cyan"},
         {"id": "apply_auto_match", "label": "Apply Auto-Match EPG Assignments", "button_label": "🎯 Apply Auto-Match", "description": "Automatically match and assign EPG to channels using intelligent weighted scoring", "button_variant": "filled", "button_color": "green", "confirm": {"message": "This will assign EPG data to matched channels. Continue?"}},
+        {"id": "scan_and_heal_dry_run", "label": "Scan & Heal (Dry Run)", "button_label": "🧹 Preview Heal", "description": "Find broken EPG assignments and search for working replacements (preview only)", "button_variant": "outline", "button_color": "cyan"},
         {"id": "scan_and_heal_apply", "label": "Scan & Heal (Apply Changes)", "button_label": "🧹 Apply Heal", "description": "Automatically find and fix broken EPG assignments", "button_variant": "filled", "button_color": "green", "confirm": {"message": "This will replace broken EPG assignments with working ones. Continue?"}},
         {"id": "add_bad_epg_suffix", "label": "Add Bad EPG Suffix to Channels", "button_label": "🏷️ Suffix Bad EPG", "description": "Add suffix to channels with missing EPG program data", "button_variant": "filled", "button_color": "orange", "confirm": {"message": "This will rename channels that have missing EPG program data. Continue?"}},
-        {"id": "remove_epg_from_hidden", "label": "Remove EPG from Hidden Channels", "button_label": "👁️‍🗨️ Strip Hidden EPG", "description": "Remove all EPG data from channels hidden in the selected profile", "button_variant": "filled", "button_color": "orange", "confirm": {"message": "This will remove EPG assignments from every channel hidden in the selected profile. Continue?"}},
         {"id": "remove_epg_assignments", "label": "Remove EPG Assignments (Missing Program Data)", "button_label": "❌ Remove Bad EPG", "description": "Remove EPG assignments from channels with missing program data", "button_variant": "filled", "button_color": "red", "confirm": {"message": "This will permanently remove EPG assignments from channels with missing program data. Are you sure?"}},
+        {"id": "remove_epg_from_hidden", "label": "Remove EPG from Hidden Channels", "button_label": "🙈 Strip Hidden EPG", "description": "Remove all EPG data from channels hidden in the selected profile", "button_variant": "filled", "button_color": "orange", "confirm": {"message": "This will remove EPG assignments from every channel hidden in the selected profile. Continue?"}},
         {"id": "remove_epg_by_regex", "label": "Remove EPG Assignments matching REGEX", "button_label": "❌ Remove by REGEX", "description": "Remove EPG from channels matching REGEX pattern within groups", "button_variant": "filled", "button_color": "red", "confirm": {"message": "This will permanently remove EPG assignments from channels matching the REGEX pattern. Are you sure?"}},
         {"id": "remove_all_epg_from_groups", "label": "Remove ALL EPG Assignments from Groups", "button_label": "❌ Remove All in Groups", "description": "Remove EPG from all channels in specified groups", "button_variant": "filled", "button_color": "red", "confirm": {"message": "This will permanently remove EPG from EVERY channel in the specified groups. This cannot be undone. Are you sure?"}},
         {"id": "clear_csv_exports", "label": "Clear CSV Exports", "button_label": "🗑️ Clear Exports", "description": "Delete all CSV export files created by this plugin", "button_variant": "outline", "button_color": "red", "confirm": {"message": "Delete all EPG Janitor CSV exports?"}},
@@ -118,40 +121,10 @@ class Plugin:
     @property
     def fields(self):
         """Dynamically generate settings fields including channel database selection."""
-        # Check for version updates (with caching)
-        version_info = {'message': f"Current version: {self.version}", 'status': 'unknown'}
-        try:
-            version_info = self._check_version_update()
-        except Exception as e:
-            LOGGER.debug(f"{PLUGIN_NAME}: Error checking version update: {e}")
 
         # Start with empty list
         fields_list = []
 
-        # Add version status field first
-        if version_info['status'] == 'current':
-            status_icon = "✅"
-            status_text = f"You are up to date (v{self.version})"
-        elif version_info['status'] == 'outdated':
-            # Extract the latest version from the message
-            status_icon = "⚠️"
-            # version_info['message'] is like "v0.6c (update available: v0.7)"
-            if 'update available:' in version_info['message']:
-                latest = version_info['message'].split('update available:')[1].strip().rstrip(')')
-                status_text = f"Update available: {latest} (current: v{self.version})"
-            else:
-                status_text = f"Update available (current: v{self.version})"
-        else:
-            status_icon = "ℹ️"
-            status_text = f"Version check unavailable (v{self.version})"
-
-        version_field = {
-            "id": "plugin_version_status",
-            "label": "📦 Plugin Version Status",
-            "type": "info",
-            "help_text": f"{status_icon} {status_text}"
-        }
-        fields_list.append(version_field)
 
         # Add dynamic channel database boolean fields
         try:
@@ -196,22 +169,32 @@ class Plugin:
             }
             fields_list.append(error_db_field)
 
-        # Add all base fields
-        base_fields_copy = []
-        for field in self._base_fields:
-            field_copy = field.copy()
-            base_fields_copy.append(field_copy)
-
-        fields_list.extend(base_fields_copy)
+        # Add all base fields (shallow-copied so callers can't mutate the class list)
+        fields_list.extend(field.copy() for field in self._base_fields)
 
         return fields_list
 
     def __init__(self):
         self.results_file = "/data/epg_janitor_results.json"
         self.automatch_preview_file = "/data/epg_automatch_preview.csv"
-        self.version_check_cache_file = "/data/epg_janitor_version_check.json"
         self.last_results = []
         self.scan_progress = {"current": 0, "total": 0, "status": "idle", "start_time": None}
+        self._progress_path = "/data/epg_janitor_progress.json"
+        self._scan_lock = threading.Lock()
+        # True while a scan is running in its background thread. This
+        # in-process flag plus the persisted progress file form the
+        # single-flight guard (see _run_scan_adaptive / _scan_busy).
+        self._sync_scan_active = False
+        # Stale-normalize: a freshly loaded process can't have a live run.
+        try:
+            progress_status.save_progress_atomic(
+                self._progress_path,
+                progress_status.normalize_stale_progress(
+                    progress_status.load_progress(self._progress_path)
+                ),
+            )
+        except OSError:
+            pass
         self.pending_status_message = None
         self.completion_message = None
 
@@ -251,14 +234,13 @@ class Plugin:
                     version = data.get('version')
 
                     # If country_name is missing, use filename as fallback
-                    if country_name:
-                        if version:
-                            label = f"{country_code} - {country_name} (v{version})"
-                        else:
-                            label = f"{country_code} - {country_name}"
-                    else:
+                    if not country_name:
                         # Fallback: show filename when metadata is missing
                         label = f"{filename}"
+                    elif version:
+                        label = f"{country_code} - {country_name} (v{version})"
+                    else:
+                        label = f"{country_code} - {country_name}"
 
                 databases.append({
                     'id': country_code,
@@ -269,215 +251,6 @@ class Plugin:
                 LOGGER.warning(f"Error reading channel database {channel_file}: {e}")
 
         return databases
-
-    def _get_latest_version(self, owner, repo):
-        """
-        Fetches the latest release tag name from GitHub using only Python's standard library.
-
-        Args:
-            owner (str): GitHub repository owner
-            repo (str): GitHub repository name
-
-        Returns:
-            str: Latest version tag or None if error
-        """
-        url = f"https://api.github.com/repos/{owner}/{repo}/releases/latest"
-
-        # Add a user-agent to avoid potential 403 Forbidden errors
-        headers = {
-            'User-Agent': 'Dispatcharr-Plugin-Version-Checker'
-        }
-
-        try:
-            # Create a request object with headers
-            req = urllib.request.Request(url, headers=headers)
-
-            # Make the request and open the URL with a 10 second timeout
-            with urllib.request.urlopen(req, timeout=10) as response:
-                # Read the response and decode it as UTF-8
-                data = response.read().decode('utf-8')
-
-                # Parse the JSON string
-                json_data = json.loads(data)
-
-                # Get the tag name
-                latest_version = json_data.get("tag_name")
-
-                if latest_version:
-                    LOGGER.info(f"{PLUGIN_NAME}: Successfully fetched latest version: {latest_version}")
-                    return latest_version
-                else:
-                    LOGGER.warning(f"{PLUGIN_NAME}: GitHub API response missing tag_name")
-                    return None
-
-        except urllib.error.HTTPError as http_err:
-            if http_err.code == 404:
-                LOGGER.warning(f"{PLUGIN_NAME}: GitHub repo not found or has no releases: https://github.com/{owner}/{repo}")
-                return None
-            else:
-                LOGGER.warning(f"{PLUGIN_NAME}: HTTP error {http_err.code} checking version at {url}")
-                return None
-        except urllib.error.URLError as url_err:
-            LOGGER.warning(f"{PLUGIN_NAME}: Network error checking version: {str(url_err)}")
-            return None
-        except Exception as e:
-            # Catch other errors like timeouts
-            LOGGER.warning(f"{PLUGIN_NAME}: Error checking version from {url}: {str(e)}")
-            return None
-
-    def _load_version_check_cache(self):
-        """
-        Load version check cache from file.
-        Returns: cache dict or None
-        """
-        try:
-            if os.path.exists(self.version_check_cache_file):
-                with open(self.version_check_cache_file, 'r') as f:
-                    return json.load(f)
-        except Exception as e:
-            LOGGER.warning(f"{PLUGIN_NAME}: Error loading version check cache: {e}")
-        return None
-
-    def _save_version_check_cache(self, cache_data):
-        """
-        Save version check cache to file.
-        """
-        try:
-            os.makedirs(os.path.dirname(self.version_check_cache_file), exist_ok=True)
-            with open(self.version_check_cache_file, 'w') as f:
-                json.dump(cache_data, f)
-        except Exception as e:
-            LOGGER.warning(f"{PLUGIN_NAME}: Error saving version check cache: {e}")
-
-    def _should_check_version(self):
-        """
-        Determines if we should check for a new version.
-        Checks once per day for successful checks, or every 2 hours for errors.
-        Returns: (should_check: bool, cached_info: dict or None)
-        """
-        cache = self._load_version_check_cache()
-
-        if not cache:
-            return True, None
-
-        try:
-            last_check_timestamp = cache.get("timestamp")
-            last_plugin_version = cache.get("plugin_version")
-            cached_info = cache.get("version_info")
-
-            # If plugin version changed, check again
-            if last_plugin_version != self.version:
-                LOGGER.info(f"{PLUGIN_NAME}: Plugin version changed, checking for updates...")
-                return True, None
-
-            current_time = time.time()
-            hours_passed = (current_time - last_check_timestamp) / 3600
-
-            # If last check was an error, retry after 2 hours instead of 24
-            if cached_info and cached_info.get('status') == 'error':
-                if hours_passed >= 2:
-                    LOGGER.info(f"{PLUGIN_NAME}: Previous version check failed, retrying...")
-                    return True, None
-                else:
-                    LOGGER.debug(f"{PLUGIN_NAME}: Using cached error status (retry in {2 - hours_passed:.1f} hours)")
-                    return False, cached_info
-
-            # For successful checks, wait 24 hours
-            if hours_passed >= 24:
-                LOGGER.info(f"{PLUGIN_NAME}: 24 hours passed, checking for updates...")
-                return True, None
-
-            # Use cached info
-            LOGGER.debug(f"{PLUGIN_NAME}: Using cached version info (refresh in {24 - hours_passed:.1f} hours)")
-            return False, cached_info
-
-        except Exception as e:
-            LOGGER.warning(f"{PLUGIN_NAME}: Error parsing version check cache: {e}")
-            return True, None
-
-    def _check_version_update(self):
-        """
-        Checks version against GitHub and returns version info dict.
-        Saves the result to cache file.
-        Returns: dict with 'message' and 'status' keys
-        """
-        # Check if we should perform a version check
-        should_check, cached_info = self._should_check_version()
-
-        if not should_check and cached_info:
-            return cached_info
-
-        # Perform version check
-        latest_version = self._get_latest_version("PiratesIRC", "Dispatcharr-EPG-Janitor-Plugin")
-
-        current_time = time.time()
-
-        if latest_version is None:
-            version_info = {
-                'message': f"v{self.version} (update check failed)",
-                'status': 'error'
-            }
-            cache_data = {
-                "timestamp": current_time,
-                "plugin_version": self.version,
-                "latest_version": None,
-                "version_info": version_info
-            }
-            self._save_version_check_cache(cache_data)
-            return version_info
-
-        # Remove 'v' prefix if present for comparison
-        current_clean = self.version.lstrip('v')
-        latest_clean = latest_version.lstrip('v')
-
-        if current_clean == latest_clean:
-            version_info = {
-                'message': f"v{self.version} (up to date)",
-                'status': 'current'
-            }
-        else:
-            # Try to compare versions to see if update is newer
-            try:
-                # Parse version numbers, removing any letter suffixes (e.g., "0.6c" -> "0.6")
-                def parse_version(v):
-                    """Parse version string to list of integers, stripping letter suffixes"""
-                    parts = []
-                    for part in v.split('.'):
-                        # Extract numeric part only (e.g., "6c" -> "6")
-                        numeric = ''.join(filter(str.isdigit, part))
-                        if numeric:
-                            parts.append(int(numeric))
-                    return parts
-
-                current_parts = parse_version(current_clean)
-                latest_parts = parse_version(latest_clean)
-
-                if latest_parts > current_parts:
-                    version_info = {
-                        'message': f"v{self.version} (update available: {latest_version})",
-                        'status': 'outdated'
-                    }
-                else:
-                    version_info = {
-                        'message': f"v{self.version} (up to date)",
-                        'status': 'current'
-                    }
-            except Exception as e:
-                # If version comparison fails, just show both versions
-                LOGGER.debug(f"{PLUGIN_NAME}: Version comparison failed: {e}")
-                version_info = {
-                    'message': f"v{self.version} (latest: {latest_version})",
-                    'status': 'unknown'
-                }
-
-        cache_data = {
-            "timestamp": current_time,
-            "plugin_version": self.version,
-            "latest_version": latest_version,
-            "version_info": version_info
-        }
-        self._save_version_check_cache(cache_data)
-        return version_info
 
     def _get_bool_setting(self, settings, key, default=False):
         """
@@ -513,75 +286,81 @@ class Plugin:
         # Fallback to default for None or other types
         return default
 
+    @staticmethod
+    def _order_by_priority(epg_list, source_info, active_ids):
+        """Keep only entries from active sources, then stable-sort by source
+        priority descending (higher Dispatcharr priority wins). source_info maps
+        source id -> {'priority': int, 'is_active': bool, ...}. active_ids is the
+        set of source ids with is_active True. list.sort is stable, so entries
+        within the same priority keep their prior relative order."""
+        active = [e for e in epg_list if e.get('epg_source') in active_ids]
+        active.sort(
+            key=lambda e: source_info.get(e.get('epg_source'), {}).get('priority', 0),
+            reverse=True,
+        )
+        return active
+
+    @staticmethod
+    def _priority_order_log(epg_list, source_info):
+        """Human-readable 'Name (priority)' list, high->low, deduplicated, for
+        the source ids actually present in epg_list."""
+        present = {e.get('epg_source') for e in epg_list}
+        rows = [source_info[sid] for sid in present if sid in source_info]
+        rows.sort(key=lambda s: s.get('priority', 0), reverse=True)
+        return ', '.join(f"{s.get('name', '?')} ({s.get('priority', 0)})" for s in rows)
+
     def _get_filtered_epg_data(self, settings, logger):
-        """Fetch and filter EPG data based on settings with validation and prioritization"""
+        """Fetch EPG data, restrict to active sources, order by Dispatcharr
+        source priority (higher wins). 'epg_sources_to_match' is a name/glob
+        filter only; its list order no longer sets priority."""
         try:
-            # Fetch all EPG data via ORM
             all_epg_data = list(EPGData.objects.all().values('id', 'name', 'epg_source'))
             logger.info(f"{PLUGIN_NAME}: Fetched {len(all_epg_data)} EPG data entries")
 
-            # Filter by EPG sources if specified
+            # Build source info (id -> {id,name,priority,is_active}) and active set.
+            try:
+                epg_sources = self._get_epg_sources(logger)
+            except Exception as source_error:
+                logger.warning(f"{PLUGIN_NAME}: Error fetching EPG sources, proceeding without source filtering or priority: {source_error}")
+                return all_epg_data
+            if not epg_sources:
+                logger.warning(f"{PLUGIN_NAME}: No EPG sources found, proceeding with all EPG data (no priority/active filter)")
+                return all_epg_data
+
+            source_info = {s['id']: s for s in epg_sources}
+            active_ids = {sid for sid, s in source_info.items() if s.get('is_active', True)}
+
             epg_sources_str = settings.get("epg_sources_to_match", "").strip()
             if epg_sources_str:
-                try:
-                    # Get EPG source names to IDs mapping
-                    logger.info(f"{PLUGIN_NAME}: Fetching EPG sources for filtering...")
-                    epg_sources = self._get_epg_sources(logger)
+                # Name/glob filter selects WHICH sources (order here is irrelevant).
+                source_names_input = [s.strip() for s in re.split(r'[,\n]+', epg_sources_str) if s.strip()]
+                available_sources = {src.get('name', '').strip(): src['id'] for src in epg_sources if src.get('name')}
 
-                    if not epg_sources:
-                        logger.warning(f"{PLUGIN_NAME}: No EPG sources found, skipping source filtering")
-                        return all_epg_data
+                matched_sources, invalid_sources = wildcard_match.expand_patterns(
+                    source_names_input, list(available_sources), ci_plain=True)
+                valid_source_ids = {available_sources[n] for n in matched_sources}
 
-                    # Parse user-entered source names (maintain order for prioritization)
-                    source_names_input = [s.strip() for s in re.split(r'[,\n]+', epg_sources_str) if s.strip()]
+                if invalid_sources:
+                    logger.warning(f"{PLUGIN_NAME}: ⚠️ Invalid EPG source name(s): {', '.join(invalid_sources)}")
+                    logger.info(f"{PLUGIN_NAME}: Available EPG sources: {', '.join(sorted(available_sources.keys()))}")
 
-                    # Get available source names from API
-                    available_sources = {src.get('name', '').strip(): src['id'] for src in epg_sources if src.get('name')}
-                    available_sources_upper = {name.upper(): (name, src_id) for name, src_id in available_sources.items()}
+                if valid_source_ids:
+                    candidate = [epg for epg in all_epg_data if epg.get('epg_source') in valid_source_ids]
+                else:
+                    logger.warning(f"{PLUGIN_NAME}: No valid EPG sources found in: {epg_sources_str}")
+                    logger.info(f"{PLUGIN_NAME}: Proceeding with all EPG data")
+                    candidate = all_epg_data
+            else:
+                candidate = all_epg_data
 
-                    # Validate and match source names (case-insensitive)
-                    valid_source_ids = []
-                    valid_source_names = []
-                    invalid_sources = []
-
-                    for input_name in source_names_input:
-                        input_name_upper = input_name.upper()
-                        if input_name_upper in available_sources_upper:
-                            actual_name, src_id = available_sources_upper[input_name_upper]
-                            valid_source_ids.append(src_id)
-                            valid_source_names.append(actual_name)
-                        else:
-                            invalid_sources.append(input_name)
-
-                    # Log validation results
-                    if invalid_sources:
-                        logger.warning(f"{PLUGIN_NAME}: ⚠️ Invalid EPG source name(s): {', '.join(invalid_sources)}")
-                        logger.info(f"{PLUGIN_NAME}: Available EPG sources: {', '.join(sorted(available_sources.keys()))}")
-
-                    if valid_source_ids:
-                        # Filter EPG data by valid source IDs
-                        filtered_data = [epg for epg in all_epg_data if epg.get('epg_source') in valid_source_ids]
-
-                        # Prioritize by user-specified order
-                        # Create a priority map based on the order of valid source IDs
-                        source_priority = {src_id: idx for idx, src_id in enumerate(valid_source_ids)}
-
-                        # Sort filtered data by source priority (lower index = higher priority)
-                        filtered_data.sort(key=lambda epg: source_priority.get(epg.get('epg_source'), 999))
-
-                        logger.info(f"{PLUGIN_NAME}: ✓ Filtered to {len(filtered_data)} EPG entries from {len(valid_source_ids)} source(s)")
-                        logger.info(f"{PLUGIN_NAME}: Priority order: {', '.join(valid_source_names)}")
-                        return filtered_data
-                    else:
-                        logger.warning(f"{PLUGIN_NAME}: No valid EPG sources found in: {epg_sources_str}")
-                        logger.info(f"{PLUGIN_NAME}: Proceeding with all EPG data")
-                        return all_epg_data
-
-                except Exception as source_error:
-                    logger.warning(f"{PLUGIN_NAME}: Error fetching EPG sources, proceeding without source filtering: {source_error}")
-                    return all_epg_data
-
-            return all_epg_data
+            before = len(candidate)
+            ordered = self._order_by_priority(candidate, source_info, active_ids)
+            excluded = before - len(ordered)
+            logger.info(f"{PLUGIN_NAME}: ✓ {len(ordered)} EPG entries from active source(s)")
+            logger.info(f"{PLUGIN_NAME}: Priority order (Dispatcharr): {self._priority_order_log(ordered, source_info)}")
+            if excluded:
+                logger.info(f"{PLUGIN_NAME}: Excluded {excluded} EPG entr{'y' if excluded == 1 else 'ies'} from inactive EPG source(s)")
+            return ordered
 
         except Exception as e:
             logger.error(f"{PLUGIN_NAME}: Error fetching EPG data: {e}")
@@ -685,6 +464,8 @@ class Plugin:
 
             # Initialize progress
             self.scan_progress = {"current": 0, "total": total_channels, "status": "running", "start_time": time.time()}
+            self._automatch_action_id = "preview_auto_match" if dry_run else "apply_auto_match"
+            self._publish_progress("running", action=self._automatch_action_id, current=0, total=total_channels)
 
             match_results = []
             matched_count = 0
@@ -715,18 +496,14 @@ class Plugin:
                 logger.warning(f"{PLUGIN_NAME}: precompute_normalizations failed, continuing without cache", exc_info=True)
 
             # Pre-extract EPG callsigns/locations once (big perf win).
-            epg_attr_cache = {}
-            for e in epg_data_list:
-                name = e.get('name', '')
-                if name:
-                    epg_attr_cache[name] = (
-                        self.fuzzy_matcher.extract_callsign(name),
-                        self._extract_location(name),
-                    )
+            epg_attr_cache = self._build_epg_attr_cache(epg_data_list)
 
             # Process each channel
             for i, channel in enumerate(channels):
                 self.scan_progress["current"] = i + 1
+                if time.time() - getattr(self, "_last_progress_flush", 0) >= 2:
+                    self._publish_progress("running", action=self._automatch_action_id,
+                                           current=i + 1, total=total_channels)
                 progress_pct = int((i + 1) / total_channels * 100)
 
                 # Log progress every 10 channels or at completion
@@ -801,16 +578,24 @@ class Plugin:
             
             # Mark scan as complete
             self.scan_progress['status'] = 'idle'
-            
+
             # Calculate different types of matches
             callsigns_extracted = sum(1 for r in match_results if r['extracted_callsign'] != 'N/A')
             epg_found = sum(1 for r in match_results if r['epg_data_id'] is not None)
             validated_matches = sum(1 for r in match_results if r['has_program_data'] == 'Yes')
 
             logger.info(f"{PLUGIN_NAME}: Auto-match completed: {callsigns_extracted} callsigns extracted, {validated_matches} validated EPG matches (with program data) out of {total_channels} channels")
+            self._publish_progress(
+                "done", action=self._automatch_action_id,
+                current=self.scan_progress.get("current", 0),
+                total=self.scan_progress.get("total", 0),
+                summary={"mode": "applied" if not dry_run else "preview",
+                         "matched": validated_matches,
+                         "total": total_channels,
+                         "callsigns": callsigns_extracted})
 
             # Export results to CSV
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=dt_timezone.utc).strftime("%Y%m%d_%H%M%S")
             csv_filename = f"epg_janitor_automatch_{'preview' if dry_run else 'applied'}_{timestamp}.csv"
             csv_filepath = os.path.join("/data/exports", csv_filename)
             os.makedirs("/data/exports", exist_ok=True)
@@ -892,12 +677,12 @@ class Plugin:
                     max_score = max(fuzzy_scores)
                     message_parts.append("")
                     message_parts.append(f"💡 0 channels meet {automatch_confidence_threshold}% threshold (highest fuzzy match: {max_score}%)")
-                    message_parts.append(f"Review the CSV and consider lowering 'Auto-Match: Apply Confidence Threshold' to {max(50, int(max_score) - 5)}%")
+                    message_parts.append(f"Lower 'Auto-Match Confidence Threshold' to ~{max(50, int(max_score) - 5)}% and retry.")
 
             if dry_run:
                 if not (validated_matches == 0 and has_fuzzy_matches):
                     message_parts.append("")
-                message_parts.append("ℹ️ Use 'Apply Auto-Match EPG Assignments' to apply these matches.")
+                message_parts.append("ℹ️ Click '🎯 Apply Auto-Match' to apply these matches.")
             else:
                 if not (validated_matches == 0 and has_fuzzy_matches):
                     message_parts.append("")
@@ -915,8 +700,26 @@ class Plugin:
             
         except Exception as e:
             self.scan_progress['status'] = 'idle'
+            self._publish_progress("done", action=getattr(self, "_automatch_action_id", "preview_auto_match"),
+                                   current=self.scan_progress.get("current", 0),
+                                   total=self.scan_progress.get("total", 0))
             logger.error(f"{PLUGIN_NAME}: Error during auto-match: {str(e)}")
             return {"status": "error", "message": f"Error during auto-match: {str(e)}"}
+
+    def _build_epg_attr_cache(self, epg_data_list):
+        """Pre-extract EPG callsigns/locations once (big perf win).
+
+        Returns a dict mapping EPG name -> (callsign, location).
+        """
+        epg_attr_cache = {}
+        for e in epg_data_list:
+            name = e.get('name', '')
+            if name:
+                epg_attr_cache[name] = (
+                    self.fuzzy_matcher.extract_callsign(name),
+                    self._extract_location(name),
+                )
+        return epg_attr_cache
 
     def _extract_location(self, channel_name):
         """
@@ -1351,6 +1154,8 @@ class Plugin:
 
             # Initialize progress tracking
             self.scan_progress = {"current": 0, "total": total_channels, "status": "running", "start_time": time.time()}
+            self._heal_action_id = "scan_and_heal_dry_run" if dry_run else "scan_and_heal_apply"
+            self._publish_progress("running", action=self._heal_action_id, current=0, total=total_channels)
 
             broken_channels = []
 
@@ -1364,6 +1169,9 @@ class Plugin:
             # Find channels with no program data
             for i, channel in enumerate(channels_with_epg):
                 self.scan_progress["current"] = i + 1
+                if time.time() - getattr(self, "_last_progress_flush", 0) >= 2:
+                    self._publish_progress("running", action=self._heal_action_id,
+                                           current=i + 1, total=total_channels)
 
                 has_programs = channel.epg_data_id in epg_ids_with_programs
 
@@ -1373,6 +1181,9 @@ class Plugin:
             # If no channels are found based on filters
             if total_channels == 0:
                 self.scan_progress['status'] = 'idle'
+                self._publish_progress("done", action=getattr(self, "_heal_action_id", "scan_and_heal_dry_run"),
+                                       current=self.scan_progress.get("current", 0),
+                                       total=self.scan_progress.get("total", 0))
                 return {
                     "status": "success",
                     "message": "No channels have EPG assignments in the selected groups/profiles. Check your filter settings or assign EPGs to channels first.",
@@ -1383,6 +1194,9 @@ class Plugin:
 
             if not broken_channels:
                 self.scan_progress['status'] = 'idle'
+                self._publish_progress("done", action=getattr(self, "_heal_action_id", "scan_and_heal_dry_run"),
+                                       current=self.scan_progress.get("current", 0),
+                                       total=self.scan_progress.get("total", 0))
                 return {
                     "status": "success",
                     "message": f"No broken EPG assignments found! All {total_channels} channels have program data.",
@@ -1409,6 +1223,9 @@ class Plugin:
 
             if not all_epg_data:
                 self.scan_progress['status'] = 'idle'
+                self._publish_progress("done", action=getattr(self, "_heal_action_id", "scan_and_heal_dry_run"),
+                                       current=self.scan_progress.get("current", 0),
+                                       total=self.scan_progress.get("total", 0))
                 return {
                     "status": "error",
                     "message": "No EPG data available to search for replacements. Check your EPG sources."
@@ -1436,14 +1253,7 @@ class Plugin:
                 logger.warning(f"{PLUGIN_NAME}: precompute_normalizations failed, continuing without cache", exc_info=True)
 
             # Pre-extract EPG callsigns/locations once (big perf win).
-            epg_attr_cache = {}
-            for e in all_epg_data:
-                name = e.get('name', '')
-                if name:
-                    epg_attr_cache[name] = (
-                        self.fuzzy_matcher.extract_callsign(name),
-                        self._extract_location(name),
-                    )
+            epg_attr_cache = self._build_epg_attr_cache(all_epg_data)
 
             for i, channel in enumerate(broken_channels):
                 self.scan_progress["current"] = total_channels + i + 1
@@ -1542,7 +1352,7 @@ class Plugin:
             # STEP 6: Generate CSV report and summary
             logger.info(f"{PLUGIN_NAME}: Step 5/6: Generating report...")
 
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=dt_timezone.utc).strftime("%Y%m%d_%H%M%S")
             csv_filename = f"epg_janitor_heal_results_{timestamp}.csv"
             csv_filepath = os.path.join("/data/exports", csv_filename)
             os.makedirs("/data/exports", exist_ok=True)
@@ -1581,6 +1391,14 @@ class Plugin:
 
             # Mark scan as complete
             self.scan_progress['status'] = 'idle'
+            self._publish_progress(
+                "done", action=getattr(self, "_heal_action_id", "scan_and_heal_dry_run"),
+                current=self.scan_progress.get("current", 0),
+                total=self.scan_progress.get("total", 0),
+                summary={"mode": "applied" if not dry_run else "preview",
+                         "healed": high_confidence_replacements if not dry_run else 0,
+                         "candidates": replacements_found,
+                         "broken": len(broken_channels)})
 
             # Build summary message
             mode_text = "Dry Run" if dry_run else "Applied"
@@ -1605,11 +1423,11 @@ class Plugin:
                 message_parts.append(f"• Would apply (confidence ≥{confidence_threshold}%): {high_conf}")
 
             message_parts.append("")
-            message_parts.append(f"Results exported to: {csv_filepath}")
+            message_parts.append(f"CSV: {csv_filepath}")
 
             if dry_run:
                 message_parts.append("")
-                message_parts.append("Use '🚀 Scan & Heal (Apply Changes)' to apply these fixes.")
+                message_parts.append("Click '🧹 Apply Heal' to apply these fixes.")
             else:
                 message_parts.append("")
                 message_parts.append("GUI refresh triggered - changes should be visible shortly.")
@@ -1628,10 +1446,22 @@ class Plugin:
 
         except Exception as e:
             self.scan_progress['status'] = 'idle'
+            self._publish_progress("done", action=getattr(self, "_heal_action_id", "scan_and_heal_dry_run"),
+                                   current=self.scan_progress.get("current", 0),
+                                   total=self.scan_progress.get("total", 0))
             logger.error(f"{PLUGIN_NAME}: Error during Scan & Heal: {str(e)}")
             import traceback
             logger.error(f"{PLUGIN_NAME}: Traceback: {traceback.format_exc()}")
             return {"status": "error", "message": f"Error during Scan & Heal: {str(e)}"}
+
+    @staticmethod
+    def _filter_phrase(items, lead, noun, parens=False):
+        """Notification-safe filter description: names joined when there are
+        few, a bare count when many — keeps messages within the UI's char cap.
+        e.g. ' in groups: A, B' or ' in 5 groups'."""
+        body = (f"{lead} {noun}: {', '.join(items)}" if len(items) <= 3
+                else f"{lead} {len(items)} {noun}")
+        return f" ({body})" if parens else f" {body}"
 
     def _validate_and_filter_groups(self, settings, logger, channels_query):
         """Validate group settings and filter channels accordingly"""
@@ -1715,7 +1545,7 @@ class Plugin:
                 if len(found_profiles) == 1:
                     profile_filter_info = f" in profile '{found_profiles[0]}'"
                 else:
-                    profile_filter_info = f" in profiles: {', '.join(found_profiles)}"
+                    profile_filter_info = self._filter_phrase(found_profiles, "in", "profiles")
 
             except ValueError as e:
                 # Re-raise ValueError for proper error handling
@@ -1730,30 +1560,38 @@ class Plugin:
         if selected_groups_str:
             selected_groups = [g.strip() for g in re.split(r'[,\n]+', selected_groups_str) if g.strip()]
             if group_name_to_id:
-                valid_group_ids = [group_name_to_id[name] for name in selected_groups if name in group_name_to_id]
+                matched_groups, _ = wildcard_match.expand_patterns(
+                    selected_groups, list(group_name_to_id), ci_plain=False)
+                valid_group_ids = [group_name_to_id[name] for name in matched_groups]
                 if not valid_group_ids:
                     raise ValueError(f"None of the specified groups were found: {', '.join(selected_groups)}")
                 channels_query = channels_query.filter(channel_group_id__in=valid_group_ids)
+                resolved = matched_groups
             else:
                 channels_query = channels_query.filter(channel_group__name__in=selected_groups)
-            
-            logger.info(f"{PLUGIN_NAME}: Filtering to groups: {', '.join(selected_groups)}")
-            group_filter_info = f" in groups: {', '.join(selected_groups)}"
+                resolved = selected_groups
+
+            logger.info(f"{PLUGIN_NAME}: Filtering to groups: {', '.join(resolved)}")
+            group_filter_info = self._filter_phrase(resolved, "in", "groups")
         
         # Handle ignore groups (exclude these)
         elif ignore_groups_str:
             ignore_groups = [g.strip() for g in re.split(r'[,\n]+', ignore_groups_str) if g.strip()]
             if group_name_to_id:
-                ignore_group_ids = [group_name_to_id[name] for name in ignore_groups if name in group_name_to_id]
+                matched_ignore, _ = wildcard_match.expand_patterns(
+                    ignore_groups, list(group_name_to_id), ci_plain=False)
+                ignore_group_ids = [group_name_to_id[name] for name in matched_ignore]
                 if ignore_group_ids:
                     channels_query = channels_query.exclude(channel_group_id__in=ignore_group_ids)
                 else:
                     logger.warning(f"{PLUGIN_NAME}: None of the ignore groups were found: {', '.join(ignore_groups)}")
+                resolved = matched_ignore or ignore_groups
             else:
                 channels_query = channels_query.exclude(channel_group__name__in=ignore_groups)
-            
-            logger.info(f"{PLUGIN_NAME}: Ignoring groups: {', '.join(ignore_groups)}")
-            group_filter_info = f" (ignoring: {', '.join(ignore_groups)})"
+                resolved = ignore_groups
+
+            logger.info(f"{PLUGIN_NAME}: Ignoring groups: {', '.join(resolved)}")
+            group_filter_info = self._filter_phrase(resolved, "ignoring", "groups", parens=True)
         
         # Combine filter info messages
         combined_filter_info = profile_filter_info + group_filter_info
@@ -1762,7 +1600,7 @@ class Plugin:
 
     def _get_epg_sources(self, logger):
         """Fetch all EPG sources via Django ORM."""
-        return list(EPGSource.objects.all().values('id', 'name'))
+        return list(EPGSource.objects.all().values('id', 'name', 'priority', 'is_active'))
 
     def _batch_set_epg(self, associations, logger):
         """Set EPG data on channels via Django ORM.
@@ -1841,7 +1679,7 @@ class Plugin:
         """
         header_lines = []
         header_lines.append(f"# EPG Janitor v{self.version} - Export Report")
-        header_lines.append(f"# Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        header_lines.append(f"# Generated: {progress_status.format_local_now(fmt='%Y-%m-%d %H:%M:%S %Z')}")
         header_lines.append(f"# Channels Processed: {total_channels}")
         header_lines.append("#")
         header_lines.append("# Plugin Settings:")
@@ -1985,23 +1823,99 @@ class Plugin:
             LOGGER.error(f"Error in plugin run: {str(e)}")
             return {"status": "error", "message": str(e)}
 
+    # How long _run_scan_adaptive blocks the HTTP response waiting for a
+    # worker before handing it off to the 📊 Status / Results button. Jobs
+    # shorter than this feel synchronous — their results are returned inline.
+    _ADAPTIVE_WAIT_SECONDS = 10
+
+    def _run_scan_adaptive(self, worker):
+        """Run a scan worker adaptively: synchronous-feeling for fast jobs,
+        background for slow ones.
+
+        The worker always runs in a background thread, but the request
+        blocks for up to _ADAPTIVE_WAIT_SECONDS. If the worker finishes in
+        that window its real result dict is returned inline and the action
+        card shows it directly. If it is still running, a 'started' message
+        is returned and the user watches it via 📊 Status / Results — the
+        worker keeps updating the progress file and results as it goes.
+
+        Single-flight: an overlapping run is rejected. The flag is claimed
+        under the lock; the worker thread clears it when it finishes.
+        """
+        with self._scan_lock:
+            if self._scan_busy():
+                return {"status": "ok",
+                        "message": "⏳ A scan is already running — "
+                                   "click 📊 Status / Results to watch it."}
+            self._sync_scan_active = True
+
+        holder = {}
+
+        def _run():
+            try:
+                holder["result"] = worker()
+            except Exception as e:
+                LOGGER.error(f"{PLUGIN_NAME}: scan thread failed: {e}")
+                holder["result"] = {"status": "error",
+                                    "message": f"Scan failed: {e}"}
+                # Clear any 'running' record the worker left behind — otherwise
+                # _scan_busy() stays stuck and blocks every later scan.
+                try:
+                    self._publish_progress("done", summary={"error": str(e)[:200]})
+                except Exception:
+                    pass
+            finally:
+                # A manually-spawned thread never gets Django's
+                # request_finished signal, so close this thread's DB
+                # connections explicitly or they leak per scan.
+                try:
+                    from django.db import connections
+                    connections.close_all()
+                except Exception:
+                    pass
+                with self._scan_lock:
+                    self._sync_scan_active = False
+
+        t = threading.Thread(target=_run, daemon=True, name="epgj-scan")
+        t.start()
+        t.join(timeout=self._ADAPTIVE_WAIT_SECONDS)
+
+        if not t.is_alive():
+            # Finished inside the wait window — return the real result inline.
+            return holder.get("result",
+                              {"status": "ok", "message": "Scan complete."})
+        # Still running — hand off to the Status / Results button.
+        return {"status": "ok",
+                "message": "▶️ Scan started — this one is taking a while. "
+                           "Click 📊 Status / Results to watch progress and "
+                           "see the results when it finishes."}
+
     def preview_auto_match_action(self, settings, logger, context=None):
-        """Preview auto-match without applying changes"""
-        return self._auto_match_channels(settings, logger, dry_run=True)
+        """Preview auto-match without applying changes."""
+        return self._run_scan_adaptive(
+            lambda: self._auto_match_channels(settings, logger, dry_run=True))
 
     def apply_auto_match_action(self, settings, logger, context=None):
-        """Apply auto-match and assign EPG to channels"""
-        return self._auto_match_channels(settings, logger, dry_run=False)
+        """Apply auto-match and assign EPG to channels."""
+        return self._run_scan_adaptive(
+            lambda: self._auto_match_channels(settings, logger, dry_run=False))
 
     def scan_and_heal_dry_run_action(self, settings, logger, context=None):
-        """Scan for broken EPG and find replacements without applying changes"""
-        return self._scan_and_heal_worker(settings, logger, context, dry_run=True)
+        """Scan for broken EPG and find replacements (preview only)."""
+        return self._run_scan_adaptive(
+            lambda: self._scan_and_heal_worker(settings, logger, context, dry_run=True))
 
     def scan_and_heal_apply_action(self, settings, logger, context=None):
-        """Scan for broken EPG and automatically apply validated replacements"""
-        return self._scan_and_heal_worker(settings, logger, context, dry_run=False)
+        """Scan for broken EPG and apply validated replacements."""
+        return self._run_scan_adaptive(
+            lambda: self._scan_and_heal_worker(settings, logger, context, dry_run=False))
 
     def scan_missing_epg_action(self, settings, logger, context=None):
+        """Scan for channels with EPG assignments but no program data."""
+        return self._run_scan_adaptive(
+            lambda: self._scan_missing_epg_worker(settings, logger, context))
+
+    def _scan_missing_epg_worker(self, settings, logger, context=None):
         """Scan for channels with EPG but no program data"""
         try:
             check_hours = settings.get("check_hours", 12)
@@ -2029,7 +1943,8 @@ class Plugin:
             
             # Initialize progress tracking
             self.scan_progress = {"current": 0, "total": total_channels, "status": "running", "start_time": time.time()}
-            
+            self._publish_progress("running", action="scan_missing_epg", current=0, total=total_channels)
+
             channels_with_no_data = []
 
             # Pre-fetch EPG IDs that have program data in the time window (avoids N+1 queries)
@@ -2042,6 +1957,9 @@ class Plugin:
             # Check each channel for program data in the specified timeframe
             for i, channel in enumerate(channels_with_epg):
                 self.scan_progress["current"] = i + 1
+                if time.time() - getattr(self, "_last_progress_flush", 0) >= 2:
+                    self._publish_progress("running", action="scan_missing_epg",
+                                           current=i + 1, total=total_channels)
 
                 has_programs = channel.epg_data_id in epg_ids_with_programs
 
@@ -2061,6 +1979,9 @@ class Plugin:
             # If no channels are found based on filters
             if total_channels == 0:
                 self.scan_progress['status'] = 'idle'
+                self._publish_progress("done", action="scan_missing_epg",
+                                       current=self.scan_progress.get("current", 0),
+                                       total=self.scan_progress.get("total", 0))
                 return {
                     "status": "success",
                     "message": "No channels have EPG assignments in the selected groups/profiles. Check your filter settings or assign EPGs to channels first.",
@@ -2068,10 +1989,13 @@ class Plugin:
 
             # Mark scan as complete
             self.scan_progress['status'] = 'idle'
-            
+            self._publish_progress("done", action="scan_missing_epg",
+                                   current=self.scan_progress.get("current", 0),
+                                   total=self.scan_progress.get("total", 0))
+
             # Save results
             results = {
-                "scan_time": datetime.now().strftime("%Y-%m-%d %H:%M"),
+                "scan_time": progress_status.format_local_now(fmt="%Y-%m-%d %H:%M %Z"),
                 "check_hours": check_hours,
                 "selected_groups": settings.get("selected_groups", "").strip(),
                 "ignore_groups": settings.get("ignore_groups", "").strip(),
@@ -2093,31 +2017,18 @@ class Plugin:
             # Create summary message
             if channels_with_no_data:
                 message_parts = [
-                    f"EPG scan completed for next {check_hours} hours{group_filter_info}:",
-                    f"• Total channels with EPG: {total_channels}",
-                    f"• Channels missing program data: {len(channels_with_no_data)}",
+                    f"🔍 EPG scan complete — next {check_hours}h{group_filter_info}",
+                    f"• Channels with EPG: {total_channels}",
+                    f"• Missing program data: {len(channels_with_no_data)}",
                     "",
-                    "Channels with missing EPG data:"
+                    "Click 📄 Export CSV for the full list, "
+                    "or ❌ Remove Bad EPG to clear them.",
                 ]
-                
-                # Show first 10 channels with issues
-                for i, channel in enumerate(channels_with_no_data[:10]):
-                    group_info = f" ({channel['channel_group']})" if channel['channel_group'] != "No Group" else ""
-                    epg_info = f" [EPG: {channel['epg_channel_name']}]"
-                    message_parts.append(f"• {channel['channel_name']}{group_info}{epg_info}")
-                
-                if len(channels_with_no_data) > 10:
-                    message_parts.append(f"... and {len(channels_with_no_data) - 10} more channels")
-                
-                message_parts.append("")
-                message_parts.append("Use 'Export Results to CSV' to get the full list.")
-                message_parts.append("Use 'Remove EPG Assignments' to remove EPG from channels with missing data.")
-                
             else:
                 message_parts = [
-                    f"EPG scan completed for next {check_hours} hours{group_filter_info}:",
-                    f"• Total channels with EPG: {total_channels}",
-                    f"• All channels have program data - no issues found!"
+                    f"🔍 EPG scan complete — next {check_hours}h{group_filter_info}",
+                    f"• Channels with EPG: {total_channels}",
+                    "✅ All channels have program data — no issues found.",
                 ]
             
             return {
@@ -2131,13 +2042,16 @@ class Plugin:
             
         except Exception as e:
             self.scan_progress['status'] = 'idle'
+            self._publish_progress("done", action="scan_missing_epg",
+                                   current=self.scan_progress.get("current", 0),
+                                   total=self.scan_progress.get("total", 0))
             logger.error(f"{PLUGIN_NAME}: Error during EPG scan: {str(e)}")
             return {"status": "error", "message": f"Error during EPG scan: {str(e)}"}
 
     def remove_epg_assignments_action(self, settings, logger):
         """Remove EPG assignments from channels that were found missing program data in the last scan"""
         if not os.path.exists(self.results_file):
-            return {"status": "error", "message": "No scan results found. Please run 'Scan for Missing Program Data' first."}
+            return {"status": "error", "message": "No scan results found. Please click '🔍 Scan Missing' first."}
 
         try:
             # Load the last scan results
@@ -2184,7 +2098,7 @@ class Plugin:
     def add_bad_epg_suffix_action(self, settings, logger):
         """Add suffix to channels that were found missing program data in the last scan"""
         if not os.path.exists(self.results_file):
-            return {"status": "error", "message": "No scan results found. Please run 'Scan for Missing Program Data' first."}
+            return {"status": "error", "message": "No scan results found. Please click '🔍 Scan Missing' first."}
 
         try:
             bad_epg_suffix = settings.get("bad_epg_suffix", " [BadEPG]")
@@ -2210,7 +2124,6 @@ class Plugin:
 
             # Prepare bulk update payload to add suffix (and optionally remove EPG)
             payload = []
-            channels_to_update = []
 
             for channel in channels_with_missing_data:
                 channel_id = channel['channel_id']
@@ -2229,11 +2142,6 @@ class Plugin:
                         update_payload['epg_data_id'] = None
 
                     payload.append(update_payload)
-                    channels_to_update.append({
-                        'id': channel_id,
-                        'old_name': current_name,
-                        'new_name': new_name
-                    })
                 else:
                     logger.info(f"{PLUGIN_NAME}: Channel '{current_name}' already has the suffix, skipping")
 
@@ -2255,28 +2163,16 @@ class Plugin:
             # Trigger M3U refresh to update the GUI
             self._trigger_frontend_refresh(settings, logger)
 
-            # Create summary message with examples
+            # Per-channel detail lives in the channel grid; the UI caps
+            # notification text at ~380 chars, so keep this short.
             message_parts = [
-                f"Successfully added suffix '{bad_epg_suffix}' to {len(payload)} channels with missing EPG data."
+                f"🏷️ Added suffix '{bad_epg_suffix}' to {len(payload)} "
+                f"channels with missing EPG data."
             ]
-
             if remove_epg_enabled:
-                message_parts[0] += f"\nAlso removed EPG assignments from these {len(payload)} channels."
-
-            message_parts.extend([
-                "",
-                "Sample renamed channels:"
-            ])
-
-            # Show first 5 renamed channels as examples
-            for i, channel in enumerate(channels_to_update[:5]):
-                message_parts.append(f"• {channel['old_name']} → {channel['new_name']}")
-
-            if len(channels_to_update) > 5:
-                message_parts.append(f"... and {len(channels_to_update) - 5} more channels")
-
+                message_parts.append("Also removed their EPG assignments.")
             message_parts.append("")
-            message_parts.append("GUI refresh triggered - the changes should be visible in the interface shortly.")
+            message_parts.append("GUI refresh triggered — changes should be visible shortly.")
 
             return {
                 "status": "success",
@@ -2373,7 +2269,7 @@ class Plugin:
                 logger.info(f"{PLUGIN_NAME}: Bulk cleared EPG for {channels_set_to_dummy} channels")
             
             # Export results to CSV
-            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+            timestamp = datetime.now(tz=dt_timezone.utc).strftime('%Y%m%d_%H%M%S')
             csv_filename = f"epg_janitor_removal_{timestamp}.csv"
             csv_filepath = f"/data/exports/{csv_filename}"
             
@@ -2492,12 +2388,10 @@ class Plugin:
                 return {"status": "success", "message": f"No channels with EPG assignments found{group_filter_info}."}
 
             channel_ids_to_update = []
-            channels_updated_summary = []
             for channel in channels_to_check:
                 epg_name = channel.epg_data.name if channel.epg_data else ""
                 if epg_name and compiled_regex.search(epg_name):
                     channel_ids_to_update.append(channel.id)
-                    channels_updated_summary.append(f"• {channel.name} (EPG: {epg_name})")
 
             if not channel_ids_to_update:
                 return {"status": "success", "message": f"No EPG assignments matched the REGEX '{regex_pattern}'{group_filter_info}."}
@@ -2508,16 +2402,11 @@ class Plugin:
             self._trigger_frontend_refresh(settings, logger)
 
             message_parts = [
-                f"Successfully removed EPG assignments from {len(channel_ids_to_update)} channels{group_filter_info} matching REGEX: '{regex_pattern}'",
-                "\nChannels affected:"
+                f"❌ Removed EPG assignments from {len(channel_ids_to_update)} "
+                f"channels{group_filter_info} matching REGEX: '{regex_pattern}'",
+                "",
+                "GUI refresh triggered — changes should be visible shortly.",
             ]
-            message_parts.extend(channels_updated_summary[:10])
-            if len(channels_updated_summary) > 10:
-                message_parts.append(f"...and {len(channels_updated_summary) - 10} more.")
-            
-            message_parts.append("")
-            message_parts.append("GUI refresh triggered - the changes should be visible in the interface shortly.")
-
             return {"status": "success", "message": "\n".join(message_parts)}
 
         except Exception as e:
@@ -2584,7 +2473,7 @@ class Plugin:
     def export_results_action(self, settings, logger):
         """Export results to CSV"""
         if not os.path.exists(self.results_file):
-            return {"status": "error", "message": "No results to export. Run 'Scan for Missing Program Data' first."}
+            return {"status": "error", "message": "No results to export. Click '🔍 Scan Missing' first."}
         
         try:
             with open(self.results_file, 'r') as f:
@@ -2594,7 +2483,7 @@ class Plugin:
             if not channels:
                 return {"status": "error", "message": "No channel data found in results."}
             
-            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.now(tz=dt_timezone.utc).strftime("%Y%m%d_%H%M%S")
             filename = f"epg_janitor_results_{timestamp}.csv"
             filepath = os.path.join("/data/exports", filename)
             
@@ -2630,73 +2519,59 @@ class Plugin:
             logger.error(f"{PLUGIN_NAME}: Error exporting CSV: {str(e)}")
             return {"status": "error", "message": f"Error exporting results: {str(e)}"}
     
-    def get_summary_action(self, settings, logger):
-        """Display summary of last results"""
-        if not os.path.exists(self.results_file):
-            return {"status": "error", "message": "No results available. Run 'Scan for Missing Program Data' first."}
-        
+    def _scan_busy(self):
+        """True if a scan is running in this process, or the persisted
+        record says running (authoritative across plugin instances)."""
+        if getattr(self, "_sync_scan_active", False):
+            return True
+        return progress_status.load_progress(self._progress_path).get("status") == "running"
+
+    def _publish_progress(self, status, action=None, current=None, total=None,
+                          summary=None):
+        """Mirror self.scan_progress into the persisted progress file.
+
+        Best-effort: a write failure must never break the scan itself.
+        `summary` is a small dict of scalar counts, stored only on 'done'.
+        """
+        rec = {"status": status}
+        if action is not None:
+            rec["action"] = action
+        if current is not None:
+            rec["current"] = int(current)
+        if total is not None:
+            rec["total"] = int(total)
+        if status == "running":
+            rec["start_time"] = self.scan_progress.get("start_time") or time.time()
+        if status == "done":
+            rec["finished_at"] = time.time()
+            if isinstance(summary, dict) and summary:
+                rec["summary"] = summary
         try:
-            with open(self.results_file, 'r') as f:
-                results = json.load(f)
-            
-            channels = results.get('channels', [])
-            scan_time = results.get('scan_time', 'Unknown')
-            check_hours = results.get('check_hours', 12)
-            selected_groups = results.get('selected_groups', '')
-            ignore_groups = results.get('ignore_groups', '')
-            total_with_epg = results.get('total_channels_with_epg', 0)
-            
-            # Group by EPG source
-            source_summary = {}
-            group_summary = {}
-            
-            for channel in channels:
-                source = channel.get('epg_source', 'Unknown')
-                group = channel.get('channel_group', 'No Group')
-                
-                source_summary[source] = source_summary.get(source, 0) + 1
-                group_summary[group] = group_summary.get(group, 0) + 1
-            
-            # Determine group filter info
-            if selected_groups:
-                group_filter_info = f" (filtered to: {selected_groups})"
-            elif ignore_groups:
-                group_filter_info = f" (ignoring: {ignore_groups})"
-            else:
-                group_filter_info = " (all groups)"
-            
-            message_parts = [
-                f"Last EPG scan results:",
-                f"• Scan time: {scan_time}",
-                f"• Checked timeframe: next {check_hours} hours{group_filter_info}",
-                f"• Total channels with EPG: {total_with_epg}",
-                f"• Channels missing program data: {len(channels)}"
-            ]
-            
-            if source_summary:
-                message_parts.append("\nMissing data by EPG source:")
-                for source, count in sorted(source_summary.items(), key=lambda x: x[1], reverse=True):
-                    message_parts.append(f"• {source}: {count} channels")
-            
-            if group_summary:
-                message_parts.append("\nMissing data by channel group:")
-                for group, count in sorted(group_summary.items(), key=lambda x: x[1], reverse=True)[:5]:
-                    message_parts.append(f"• {group}: {count} channels")
-                if len(group_summary) > 5:
-                    message_parts.append(f"• ... and {len(group_summary) - 5} more groups")
-            
-            if channels:
-                message_parts.append(f"\nUse 'Export Results to CSV' to get the full list of {len(channels)} channels.")
-                message_parts.append("Use 'Remove EPG Assignments' to remove EPG from channels with missing data.")
-            
-            return {
-                "status": "success",
-                "message": "\n".join(message_parts)
-            }
-            
+            progress_status.save_progress_atomic(self._progress_path, rec)
+        except OSError:
+            pass
+        self._last_progress_flush = time.time()
+
+    def _load_progress(self):
+        return progress_status.load_progress(self._progress_path)
+
+    def get_summary_action(self, settings, logger):
+        """Status / Last-Results button: live progress if a run is active,
+        otherwise the last-results summary with a timestamp header."""
+        try:
+            progress = self._load_progress()
+            results = None
+            if os.path.exists(self.results_file):
+                try:
+                    with open(self.results_file, "r") as f:
+                        results = json.load(f)
+                except (json.JSONDecodeError, ValueError, OSError):
+                    results = None
+            message = progress_status.build_status_or_summary(progress, results)
+            return {"status": "success", "message": message}
         except Exception as e:
-            logger.error(f"{PLUGIN_NAME}: Error reading results: {str(e)}")
-            return {"status": "error", "message": f"Error reading results: {str(e)}"}
+            logger.error(f"{PLUGIN_NAME}: Error building status/summary: {str(e)}")
+            return {"status": "error", "message": f"Error reading status: {str(e)}"}
 
     def validate_settings_action(self, settings, logger):
         """Validate all plugin settings and database connectivity"""
@@ -2766,17 +2641,15 @@ class Plugin:
 
                 # Parse and validate configured groups
                 configured_groups = [g.strip() for g in re.split(r'[,\n]+', groups_to_validate) if g.strip()]
-                found_groups = []
-                missing_groups = []
-
-                for group_name in configured_groups:
-                    if group_name in all_groups:
-                        found_groups.append(group_name)
-                    else:
-                        missing_groups.append(group_name)
+                found_names, missing_groups = wildcard_match.expand_patterns(
+                    configured_groups, list(all_groups), ci_plain=False)
+                found_groups = found_names
 
                 if missing_groups:
-                    validation_results.append(f"⚠️ {group_type} not found: {', '.join(missing_groups)}")
+                    shown = ', '.join(missing_groups[:8])
+                    if len(missing_groups) > 8:
+                        shown += f" +{len(missing_groups) - 8} more"
+                    validation_results.append(f"⚠️ {group_type} not found: {shown}")
                     if found_groups:
                         validation_results.append(f"✅ {group_type}: {', '.join(found_groups)}")
                 else:
@@ -2847,7 +2720,7 @@ class Plugin:
         # Build final message (concise version)
         if all_valid:
             # For success, show only a brief summary
-            final_message = "✅ All settings validated successfully. Ready to Load/Process Channels."
+            final_message = "✅ All settings validated. You're ready to run 🔍 Scan Missing and 👁️ Preview Auto-Match."
         else:
             # For errors, show only the error/warning lines
             error_lines = [line for line in validation_results if line.startswith(("❌", "⚠️"))]

--- a/plugins/epg-janitor/progress_status.py
+++ b/plugins/epg-janitor/progress_status.py
@@ -1,0 +1,186 @@
+"""Pure, Django-free helpers for EPG-Janitor progress/results presentation.
+
+Lives outside plugin.py so the offline unittest harness (which prepends
+EPG-Janitor/ to sys.path) can import and test it without Dispatcharr/Django.
+"""
+
+import json
+import os
+import tempfile
+import time as _time
+from datetime import datetime
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # Python < 3.9 — never the case for Dispatcharr (3.13)
+    ZoneInfo = None
+
+
+def _display_tz():
+    """Resolve the TZ for user-facing timestamps.
+
+    Dispatcharr's Django pins ``TIME_ZONE = "UTC"`` and *rewrites* the
+    container's ``$TZ`` env var to ``"UTC"`` at startup, so reading
+    ``$TZ`` from inside the running process is useless. The authoritative
+    user-facing TZ lives in Dispatcharr's own settings via
+    ``CoreSettings.get_system_time_zone``. Fall back to ``$TZ`` only if
+    Django (or the test harness) isn't available."""
+    if ZoneInfo is None:
+        return None
+    try:
+        from core.models import CoreSettings  # local import: Django-optional
+        tz_name = CoreSettings.get_system_time_zone()
+        if tz_name:
+            return ZoneInfo(tz_name)
+    except Exception:
+        pass
+    tz_name = os.environ.get("TZ")
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:
+            pass
+    return None
+
+
+def format_local_timestamp(unix_ts, fmt="%Y-%m-%d %H:%M %Z"):
+    """Format a Unix timestamp in the operator's container TZ."""
+    tz = _display_tz()
+    if tz is not None:
+        return datetime.fromtimestamp(unix_ts, tz=tz).strftime(fmt).strip()
+    return datetime.fromtimestamp(unix_ts).strftime(fmt).strip()
+
+
+def format_local_now(fmt="%Y-%m-%d %H:%M %Z"):
+    """``datetime.now()`` formatted in the operator's container TZ."""
+    return format_local_timestamp(_time.time(), fmt=fmt)
+
+
+def format_eta(seconds):
+    """Human-readable ETA. Negative/zero -> '0s'."""
+    s = int(seconds)
+    if s <= 0:
+        return "0s"
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{h}h {m}m"
+    if m:
+        return f"{m}m {sec}s"
+    return f"{sec}s"
+
+
+IDLE = {"status": "idle"}
+
+
+def load_progress(path):
+    """Return the progress dict, or {'status': 'idle'} if missing/corrupt."""
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return dict(IDLE)
+        return data
+    except (FileNotFoundError, json.JSONDecodeError, ValueError, OSError):
+        return dict(IDLE)
+
+
+def save_progress_atomic(path, data):
+    """Write data as JSON via temp file + os.replace (atomic, no torn reads)."""
+    d = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=".epgj_prog_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp, path)
+    except Exception:
+        if os.path.exists(tmp):
+            os.remove(tmp)
+        raise
+
+
+def normalize_stale_progress(progress):
+    """A freshly-loaded process cannot have a live run; force running->idle.
+
+    Returns a new dict (does not mutate the input). Non-running states pass
+    through unchanged.
+    """
+    if progress.get("status") == "running":
+        out = dict(progress)
+        out["status"] = "idle"
+        return out
+    return progress
+
+
+ACTION_LABELS = {
+    "preview_auto_match": "Preview Auto-Match",
+    "apply_auto_match": "Apply Auto-Match",
+    "scan_and_heal_dry_run": "Preview Heal",
+    "scan_and_heal_apply": "Apply Heal",
+    "scan_missing_epg": "Scan Missing EPG",
+}
+
+
+def _action_label(action):
+    return ACTION_LABELS.get(action, "run")
+
+
+def build_status_or_summary(progress, results, now=None):
+    """Return the user-facing message for the Status / Results button.
+
+    - progress.status == 'running' -> live progress + ETA.
+    - else -> last-results summary with a timestamp/source header,
+      or a friendly prompt if there are no results.
+    """
+    if now is None:
+        now = _time.time()
+
+    if progress.get("status") == "running":
+        cur = int(progress.get("current", 0))
+        total = int(progress.get("total", 0))
+        label = _action_label(progress.get("action"))
+        pct = (cur / total * 100) if total > 0 else 0
+        start = progress.get("start_time")
+        if start is not None and cur > 0:
+            elapsed = now - start
+            remaining = (elapsed / cur) * (total - cur)
+            eta = f"ETA: {format_eta(remaining)}"
+        else:
+            eta = "ETA: calculating..."
+        return f"\U0001f504 {label} {cur}/{total} — {pct:.0f}% | {eta}"
+
+    label = _action_label(progress.get("action"))
+    summary = progress.get("summary")
+    if isinstance(summary, dict) and summary:
+        fin = progress.get("finished_at")
+        when = (format_local_timestamp(fin, fmt="%Y-%m-%d %H:%M %Z")
+                if fin else "recently")
+        lines = [f"\U0001f4ca {label} finished {when} (no run in progress)"]
+        order = ["mode", "matched", "applied", "healed", "candidates",
+                 "broken", "missing", "total", "total_with_epg", "callsigns"]
+        keys = [k for k in order if k in summary]
+        keys += [k for k in summary if k not in order]
+        for k in keys[:4]:
+            lines.append(f"• {k.replace('_', ' ').capitalize()}: {summary[k]}")
+        lines.append("Use \U0001f4c4 Export CSV for the full list.")
+        return "\n".join(lines)
+
+    if isinstance(results, dict) and results:
+        ts = results.get("scan_time", "unknown time")
+        n = results.get("total_channels_with_epg", 0)
+        m = len(results.get("channels", []))
+        return (
+            f"\U0001f4ca Last EPG scan — {ts} (no run in progress)\n"
+            f"• Total channels with EPG: {n}\n"
+            f"• Channels missing program data: {m}\n"
+            "Use \U0001f4c4 Export CSV for the full list."
+        )
+
+    if progress.get("status") == "done":
+        fin = progress.get("finished_at")
+        when = (format_local_timestamp(fin, fmt="%Y-%m-%d %H:%M %Z")
+                if fin else "recently")
+        return f"\U0001f4ca {label} finished {when} (no run in progress)"
+
+    return ("Nothing has been run yet. Use \U0001f50d Scan Missing "
+            "or \U0001f441️ Preview Auto-Match.")

--- a/plugins/epg-janitor/readme.txt
+++ b/plugins/epg-janitor/readme.txt
@@ -3,6 +3,7 @@ EPG Janitor — keep your Electronic Program Guide clean, accurate, and complete
 FEATURES
 - Auto-Match EPG to channels using callsign/location/network scoring + Lineuparr-style fuzzy pipeline (alias, exact, substring, token-sort) with ~200 built-in aliases
 - Scan & Heal broken EPG assignments with ranked-fallback replacement
+- EPG source selection by name or * / ? wildcard; only enabled sources used, score ties resolved by Dispatcharr source priority (higher wins)
 - Find channels with EPG assigned but no program data ("No Program Information Available")
 - Bulk operations: remove EPG by REGEX, from hidden channels, or from entire groups
 - Suffix-tag channels with missing program data for easy visual flagging

--- a/plugins/epg-janitor/wildcard_match.py
+++ b/plugins/epg-janitor/wildcard_match.py
@@ -1,0 +1,46 @@
+"""Pure, Django-free glob matching for plugin list settings.
+
+Lives outside plugin.py so the offline unittest harness (which prepends
+EPG-Janitor/ to sys.path) can import and test it without Dispatcharr/Django.
+"""
+import fnmatch
+
+
+def expand_patterns(tokens, available_names, ci_plain):
+    """Resolve user tokens (some glob, some literal) against available_names.
+
+    A token containing '*' or '?' is a glob, matched case-insensitively via
+    fnmatch.fnmatchcase on lowercased strings. Any other token is a literal:
+    case-insensitive when ci_plain is True, else case-sensitive exact.
+
+    Returns (matched_names, unmatched_tokens):
+      - matched_names: names matching >=1 token, ordered by
+        (lowest matching token index, then original available_names order),
+        de-duplicated.
+      - unmatched_tokens: tokens that matched no name, in input order.
+    """
+    avail = list(available_names)
+    avail_order = {name: i for i, name in enumerate(avail)}
+    matched_idx = {}          # name -> lowest token index that matched it
+    matched_token_idx = set()  # token indices that matched >=1 name
+
+    for ti, tok in enumerate(tokens):
+        is_glob = ("*" in tok) or ("?" in tok)
+        tok_l = tok.lower()
+        for name in avail:
+            if is_glob:
+                hit = fnmatch.fnmatchcase(name.lower(), tok_l)
+            elif ci_plain:
+                hit = name.lower() == tok_l
+            else:
+                hit = name == tok
+            if hit:
+                matched_token_idx.add(ti)
+                if name not in matched_idx or ti < matched_idx[name]:
+                    matched_idx[name] = ti
+
+    matched_names = sorted(
+        matched_idx, key=lambda n: (matched_idx[n], avail_order[n]))
+    unmatched_tokens = [t for i, t in enumerate(tokens)
+                        if i not in matched_token_idx]
+    return matched_names, unmatched_tokens


### PR DESCRIPTION
## EPG Janitor → 1.26.1420824

Update to the existing `plugins/epg-janitor/` plugin. Verified working on **Dispatcharr v0.25**.

### Changes since the published 1.26.1021352
- **Matching accuracy** — confidence-tiered callsign extraction with an asymmetric anchor in `match_all_streams` (both sides must carry a high-confidence callsign to floor/reject); fixed an alias-match false positive where a one-character substitution on a short alias scored as a match; matched EPG is now ordered by Dispatcharr source priority (active sources only).
- **Wildcard scope settings** — `EPG Sources to Match`, `Channel Groups`, and `Ignore Groups` accept glob patterns.
- **Adaptive action execution** — scans run in a background thread and block up to a measured 10 s; fast jobs return inline, slow jobs hand off to a Status / Results button, with progress persisted to disk.
- **UI** — count-based notification summaries, a Quick Start guide, reordered action buttons; removed the GitHub version-checker.
- **Channel databases refreshed** (US/CA/AU/ES/UK).

### New files
- `progress_status.py` — Django-free progress/results presentation helpers.
- `wildcard_match.py` — glob expander for list-valued settings.

`plugin.json` retains `license: "MIT"`, `author: "PiratesIRC"`, `maintainers: ["PiratesIRC"]`.
