### PR TITLE
[lineuparr]: v1.26.1421711 — combined lineups, callsign matching, GUI overhaul

### DIFF
--- a/plugins/lineuparr/UK_Combined_lineup.json
+++ b/plugins/lineuparr/UK_Combined_lineup.json
@@ -1,0 +1,1639 @@
+{
+  "package": "UK Combined",
+  "date": "2026-05-22",
+  "description": "Consolidated UK channel lineup merged and de-duplicated from Freeview and Sky TV UK (England) Full Lineup.",
+  "source": "Freeview + Sky TV UK (England) Full Lineup",
+  "notes": "This lineup is a de-duplicated union of the Freeview and Sky TV UK (England) Full lineups, using category-blocked numbering where each category's block widens to the next multiple of 100 to accommodate large categories.",
+  "categories": {
+    "News": [
+      {
+        "name": "Al Jazeera HD",
+        "number": 101
+      },
+      {
+        "name": "Arirang TV HD",
+        "number": 102
+      },
+      {
+        "name": "Arise News",
+        "number": 103
+      },
+      {
+        "name": "BBC News",
+        "number": 104
+      },
+      {
+        "name": "BBC Parliament",
+        "number": 106
+      },
+      {
+        "name": "Bloomberg HD",
+        "number": 108
+      },
+      {
+        "name": "Channels 24",
+        "number": 109
+      },
+      {
+        "name": "CNBC HD",
+        "number": 110
+      },
+      {
+        "name": "CNN HD",
+        "number": 111
+      },
+      {
+        "name": "DM News English",
+        "number": 112
+      },
+      {
+        "name": "France 24 English HD",
+        "number": 113
+      },
+      {
+        "name": "GB News",
+        "number": 114
+      },
+      {
+        "name": "NDTV World",
+        "number": 116
+      },
+      {
+        "name": "NTD",
+        "number": 118
+      },
+      {
+        "name": "Sky News",
+        "number": 119
+      },
+      {
+        "name": "TVC News",
+        "number": 122
+      }
+    ],
+    "Sports": [
+      {
+        "name": "LFCTV HD",
+        "number": 201
+      },
+      {
+        "name": "MUTV HD",
+        "number": 202
+      },
+      {
+        "name": "Premier Sports 1 HD",
+        "number": 203
+      },
+      {
+        "name": "Premier Sports 2 HD",
+        "number": 204
+      },
+      {
+        "name": "Racing TV HD",
+        "number": 205
+      },
+      {
+        "name": "Sky Sports Action HD",
+        "number": 206
+      },
+      {
+        "name": "Sky Sports Box Office HD",
+        "number": 207
+      },
+      {
+        "name": "Sky Sports Cricket HD",
+        "number": 208
+      },
+      {
+        "name": "Sky Sports Football HD",
+        "number": 210
+      },
+      {
+        "name": "Sky Sports Golf HD",
+        "number": 211
+      },
+      {
+        "name": "Sky Sports Premier League HD",
+        "number": 215
+      },
+      {
+        "name": "Sky Sports Racing HD",
+        "number": 216
+      },
+      {
+        "name": "Sky Sports Tennis HD",
+        "number": 217
+      },
+      {
+        "name": "Sky Sports+ HD",
+        "number": 218
+      },
+      {
+        "name": "TNT Sports 10",
+        "number": 220
+      },
+      {
+        "name": "TNT Sports 5 HD",
+        "number": 224
+      },
+      {
+        "name": "TNT Sports 6",
+        "number": 225
+      },
+      {
+        "name": "TNT Sports 7",
+        "number": 226
+      },
+      {
+        "name": "TNT Sports 8",
+        "number": 227
+      },
+      {
+        "name": "TNT Sports 9",
+        "number": 228
+      },
+      {
+        "name": "TNT Sports Box Office 2 HD",
+        "number": 229
+      },
+      {
+        "name": "TNT Sports Box Office HD",
+        "number": 230
+      },
+      {
+        "name": "TNT Sports Ultimate UHD",
+        "number": 231
+      }
+    ],
+    "Movies": [
+      {
+        "name": "Disney+ Cinema HD",
+        "number": 301
+      },
+      {
+        "name": "GREAT! Action +1",
+        "number": 303
+      },
+      {
+        "name": "GREAT! Mystery +1",
+        "number": 304
+      },
+      {
+        "name": "GREAT! Romance",
+        "number": 305
+      },
+      {
+        "name": "GREAT! Romance +1",
+        "number": 306
+      },
+      {
+        "name": "Legend Xtra +1",
+        "number": 307
+      },
+      {
+        "name": "Movies24",
+        "number": 308
+      },
+      {
+        "name": "Movies24+",
+        "number": 309
+      },
+      {
+        "name": "Sky Cinema Action HD",
+        "number": 310
+      },
+      {
+        "name": "Sky Cinema Comedy HD",
+        "number": 311
+      },
+      {
+        "name": "Sky Cinema Decades HD",
+        "number": 312
+      },
+      {
+        "name": "Sky Cinema Drama HD",
+        "number": 313
+      },
+      {
+        "name": "Sky Cinema Family HD",
+        "number": 314
+      },
+      {
+        "name": "Sky Cinema Fast HD",
+        "number": 315
+      },
+      {
+        "name": "Sky Cinema Greats HD",
+        "number": 316
+      },
+      {
+        "name": "Sky Cinema Premiere HD",
+        "number": 317
+      },
+      {
+        "name": "Sky Cinema Sci-Fi & Horror HD",
+        "number": 318
+      },
+      {
+        "name": "Sky Cinema Thriller HD",
+        "number": 319
+      },
+      {
+        "name": "Talking Pictures TV",
+        "number": 320
+      }
+    ],
+    "Kids": [
+      {
+        "name": "BabyTV",
+        "number": 401
+      },
+      {
+        "name": "Boomerang +1",
+        "number": 402
+      },
+      {
+        "name": "Cartoon Classics",
+        "number": 404
+      },
+      {
+        "name": "Cartoon Network +1",
+        "number": 405
+      },
+      {
+        "name": "Cartoonito",
+        "number": 407
+      },
+      {
+        "name": "CBBC",
+        "number": 408
+      },
+      {
+        "name": "CBeebies",
+        "number": 410
+      },
+      {
+        "name": "Disney Jr.",
+        "number": 412
+      },
+      {
+        "name": "Ketchup Too",
+        "number": 413
+      },
+      {
+        "name": "Ketchup TV",
+        "number": 414
+      },
+      {
+        "name": "Nick Jr. +1",
+        "number": 415
+      },
+      {
+        "name": "Nick Jr. Peppa",
+        "number": 417
+      },
+      {
+        "name": "Nickelodeon +1",
+        "number": 418
+      },
+      {
+        "name": "Nicktoons",
+        "number": 420
+      },
+      {
+        "name": "POP",
+        "number": 421
+      },
+      {
+        "name": "Pop Up",
+        "number": 422
+      },
+      {
+        "name": "Sky Kids HD",
+        "number": 423
+      },
+      {
+        "name": "Tiny Pop",
+        "number": 424
+      }
+    ],
+    "Entertainment": [
+      {
+        "name": "4seven",
+        "number": 501
+      },
+      {
+        "name": "5",
+        "number": 502
+      },
+      {
+        "name": "5 +1",
+        "number": 503
+      },
+      {
+        "name": "5ACTION",
+        "number": 504
+      },
+      {
+        "name": "5SELECT",
+        "number": 505
+      },
+      {
+        "name": "5STAR",
+        "number": 506
+      },
+      {
+        "name": "5USA",
+        "number": 507
+      },
+      {
+        "name": "Animal Planet",
+        "number": 508
+      },
+      {
+        "name": "BBC Alba HD",
+        "number": 509
+      },
+      {
+        "name": "BBC Four",
+        "number": 510
+      },
+      {
+        "name": "BBC One",
+        "number": 511
+      },
+      {
+        "name": "BBC Scotland HD",
+        "number": 512
+      },
+      {
+        "name": "BBC Three",
+        "number": 513
+      },
+      {
+        "name": "BBC Two",
+        "number": 514
+      },
+      {
+        "name": "Blaze",
+        "number": 515
+      },
+      {
+        "name": "Blaze +1",
+        "number": 516
+      },
+      {
+        "name": "Challenge",
+        "number": 517
+      },
+      {
+        "name": "Channel 4",
+        "number": 518
+      },
+      {
+        "name": "Channel 4 +1",
+        "number": 519
+      },
+      {
+        "name": "Channel 5 HD",
+        "number": 520
+      },
+      {
+        "name": "Comedy Central Extra",
+        "number": 521
+      },
+      {
+        "name": "Court TV",
+        "number": 523
+      },
+      {
+        "name": "Dave",
+        "number": 525
+      },
+      {
+        "name": "Dave ja vu",
+        "number": 526
+      },
+      {
+        "name": "Discovery History",
+        "number": 528
+      },
+      {
+        "name": "Discovery Science",
+        "number": 529
+      },
+      {
+        "name": "Discovery Turbo",
+        "number": 530
+      },
+      {
+        "name": "DMAX",
+        "number": 531
+      },
+      {
+        "name": "Drama",
+        "number": 532
+      },
+      {
+        "name": "Drama +1",
+        "number": 533
+      },
+      {
+        "name": "E4",
+        "number": 534
+      },
+      {
+        "name": "E4 +1",
+        "number": 535
+      },
+      {
+        "name": "E4 Extra",
+        "number": 536
+      },
+      {
+        "name": "Film4",
+        "number": 538
+      },
+      {
+        "name": "Film4 +1",
+        "number": 539
+      },
+      {
+        "name": "Food Network",
+        "number": 540
+      },
+      {
+        "name": "Gems TV",
+        "number": 541
+      },
+      {
+        "name": "Great! Action",
+        "number": 542
+      },
+      {
+        "name": "Great! Christmas",
+        "number": 543
+      },
+      {
+        "name": "Great! Movies",
+        "number": 544
+      },
+      {
+        "name": "Great! Mystery",
+        "number": 545
+      },
+      {
+        "name": "Great! Player",
+        "number": 546
+      },
+      {
+        "name": "GREAT! tv",
+        "number": 547
+      },
+      {
+        "name": "Great! TV +1",
+        "number": 548
+      },
+      {
+        "name": "HGTV",
+        "number": 549
+      },
+      {
+        "name": "High Street TV",
+        "number": 550
+      },
+      {
+        "name": "HobbyMaker",
+        "number": 551
+      },
+      {
+        "name": "Ideal World",
+        "number": 552
+      },
+      {
+        "name": "Investigation Discovery",
+        "number": 553
+      },
+      {
+        "name": "ITV",
+        "number": 554
+      },
+      {
+        "name": "ITV +1",
+        "number": 555
+      },
+      {
+        "name": "ITV Quiz HD",
+        "number": 556
+      },
+      {
+        "name": "ITV1 HD",
+        "number": 557
+      },
+      {
+        "name": "ITV2",
+        "number": 558
+      },
+      {
+        "name": "ITV2 +1",
+        "number": 559
+      },
+      {
+        "name": "ITV3",
+        "number": 561
+      },
+      {
+        "name": "ITV3 +1",
+        "number": 562
+      },
+      {
+        "name": "ITV4",
+        "number": 564
+      },
+      {
+        "name": "ITV4 +1",
+        "number": 565
+      },
+      {
+        "name": "ITVBe",
+        "number": 567
+      },
+      {
+        "name": "Jewellery Maker",
+        "number": 568
+      },
+      {
+        "name": "LEGEND",
+        "number": 569
+      },
+      {
+        "name": "LEGEND XTRA",
+        "number": 570
+      },
+      {
+        "name": "London TV",
+        "number": 571
+      },
+      {
+        "name": "More4",
+        "number": 572
+      },
+      {
+        "name": "Must Have Ideas",
+        "number": 575
+      },
+      {
+        "name": "PBS America",
+        "number": 578
+      },
+      {
+        "name": "QUEST",
+        "number": 579
+      },
+      {
+        "name": "QUEST +1",
+        "number": 580
+      },
+      {
+        "name": "Quest Red",
+        "number": 582
+      },
+      {
+        "name": "QVC",
+        "number": 583
+      },
+      {
+        "name": "QVC Beauty",
+        "number": 584
+      },
+      {
+        "name": "Really",
+        "number": 585
+      },
+      {
+        "name": "Rewind TV",
+        "number": 586
+      },
+      {
+        "name": "Shop On TV",
+        "number": 588
+      },
+      {
+        "name": "Shop Unlimited",
+        "number": 589
+      },
+      {
+        "name": "Sky Arts",
+        "number": 590
+      },
+      {
+        "name": "Sky History 2",
+        "number": 596
+      },
+      {
+        "name": "Sky Mix",
+        "number": 598
+      },
+      {
+        "name": "SonLife",
+        "number": 604
+      },
+      {
+        "name": "TBN UK",
+        "number": 606
+      },
+      {
+        "name": "TCC",
+        "number": 607
+      },
+      {
+        "name": "That's 20th Century",
+        "number": 608
+      },
+      {
+        "name": "That's 60s",
+        "number": 609
+      },
+      {
+        "name": "That's 70s",
+        "number": 610
+      },
+      {
+        "name": "That's TV",
+        "number": 611
+      },
+      {
+        "name": "That's TV (UK)",
+        "number": 612
+      },
+      {
+        "name": "That's TV 2",
+        "number": 613
+      },
+      {
+        "name": "TJC",
+        "number": 614
+      },
+      {
+        "name": "Together TV",
+        "number": 617
+      },
+      {
+        "name": "Together TV+1",
+        "number": 618
+      },
+      {
+        "name": "Travelxp",
+        "number": 619
+      },
+      {
+        "name": "TRUE CRIME",
+        "number": 620
+      },
+      {
+        "name": "TRUE CRIME XTRA",
+        "number": 621
+      },
+      {
+        "name": "U&Drama",
+        "number": 624
+      },
+      {
+        "name": "U&Eden",
+        "number": 625
+      },
+      {
+        "name": "U&W",
+        "number": 627
+      },
+      {
+        "name": "U&Yesterday",
+        "number": 628
+      },
+      {
+        "name": "W",
+        "number": 629
+      },
+      {
+        "name": "wedotv Movies UK",
+        "number": 630
+      },
+      {
+        "name": "WildEarth",
+        "number": 631
+      },
+      {
+        "name": "Yesterday",
+        "number": 632
+      }
+    ],
+    "Faith": [
+      {
+        "name": "Daystar HD",
+        "number": 701
+      },
+      {
+        "name": "Dunamis TV",
+        "number": 702
+      },
+      {
+        "name": "EWTN Catholic",
+        "number": 703
+      },
+      {
+        "name": "Faith UK",
+        "number": 704
+      },
+      {
+        "name": "Faith World TV",
+        "number": 705
+      },
+      {
+        "name": "God Channel",
+        "number": 706
+      },
+      {
+        "name": "LoveWorld HD",
+        "number": 707
+      },
+      {
+        "name": "Revelation",
+        "number": 708
+      },
+      {
+        "name": "SonLife Broadcasting Network",
+        "number": 709
+      }
+    ],
+    "Music": [
+      {
+        "name": "Clubland TV",
+        "number": 801
+      },
+      {
+        "name": "Now 70s",
+        "number": 802
+      },
+      {
+        "name": "Now 80s",
+        "number": 803
+      },
+      {
+        "name": "Now 90s & 00s",
+        "number": 804
+      },
+      {
+        "name": "Now Rock",
+        "number": 805
+      }
+    ],
+    "Shopping": [
+      {
+        "name": "Best Direct",
+        "number": 901
+      },
+      {
+        "name": "Cruise1st.TV",
+        "number": 902
+      },
+      {
+        "name": "Gemporia HD",
+        "number": 903
+      },
+      {
+        "name": "High Street TV 1",
+        "number": 904
+      },
+      {
+        "name": "High Street TV 2",
+        "number": 905
+      },
+      {
+        "name": "QVC Extra",
+        "number": 909
+      },
+      {
+        "name": "QVC Style HD",
+        "number": 911
+      },
+      {
+        "name": "TV Warehouse",
+        "number": 913
+      }
+    ],
+    "Adult": [
+      {
+        "name": "Babenation",
+        "number": 1001
+      },
+      {
+        "name": "Babes&Brazzers",
+        "number": 1002
+      },
+      {
+        "name": "Television X",
+        "number": 1003
+      },
+      {
+        "name": "The Adult Channel",
+        "number": 1004
+      },
+      {
+        "name": "TVX 40+",
+        "number": 1005
+      },
+      {
+        "name": "Xpanded TV",
+        "number": 1006
+      },
+      {
+        "name": "XXX Girl Girl",
+        "number": 1007
+      }
+    ],
+    "Entertainment & Documentaries +1": [
+      {
+        "name": "5STAR +1",
+        "number": 1101
+      },
+      {
+        "name": "5USA +1",
+        "number": 1102
+      },
+      {
+        "name": "Animal Planet +1",
+        "number": 1103
+      },
+      {
+        "name": "Channel 5 +1",
+        "number": 1104
+      },
+      {
+        "name": "Comedy Central +1",
+        "number": 1105
+      },
+      {
+        "name": "Crime+Investigation +1",
+        "number": 1106
+      },
+      {
+        "name": "Discovery Channel +1",
+        "number": 1107
+      },
+      {
+        "name": "Discovery History +1",
+        "number": 1108
+      },
+      {
+        "name": "Discovery Science +1",
+        "number": 1109
+      },
+      {
+        "name": "Discovery Turbo +1",
+        "number": 1110
+      },
+      {
+        "name": "DMAX +1",
+        "number": 1111
+      },
+      {
+        "name": "Food Network +1",
+        "number": 1112
+      },
+      {
+        "name": "Investigation Discovery +1",
+        "number": 1113
+      },
+      {
+        "name": "ITV1 London +1",
+        "number": 1114
+      },
+      {
+        "name": "More4 +1",
+        "number": 1115
+      },
+      {
+        "name": "National Geographic +1",
+        "number": 1116
+      },
+      {
+        "name": "Quest Red +1",
+        "number": 1117
+      },
+      {
+        "name": "Really +1",
+        "number": 1118
+      },
+      {
+        "name": "Sky Atlantic +1",
+        "number": 1119
+      },
+      {
+        "name": "Sky Crime +1",
+        "number": 1120
+      },
+      {
+        "name": "Sky Witness +1",
+        "number": 1121
+      },
+      {
+        "name": "TLC +1",
+        "number": 1122
+      },
+      {
+        "name": "True Crime +1",
+        "number": 1123
+      },
+      {
+        "name": "U&Alibi +1",
+        "number": 1124
+      },
+      {
+        "name": "U&DaveJaVu",
+        "number": 1125
+      },
+      {
+        "name": "U&Drama +1",
+        "number": 1126
+      },
+      {
+        "name": "U&Eden +1",
+        "number": 1127
+      },
+      {
+        "name": "U&Gold +1",
+        "number": 1128
+      },
+      {
+        "name": "U&W +1",
+        "number": 1129
+      },
+      {
+        "name": "U&Yesterday +1",
+        "number": 1130
+      }
+    ],
+    "Hybrid Streamed and Text": [
+      {
+        "name": "AL ARABIYA",
+        "number": 1301
+      },
+      {
+        "name": "Al Jazeera Arabic",
+        "number": 1302
+      },
+      {
+        "name": "Al Jazeera English",
+        "number": 1303
+      },
+      {
+        "name": "Alaraby Network",
+        "number": 1304
+      },
+      {
+        "name": "Amazing Facts",
+        "number": 1305
+      },
+      {
+        "name": "ASHARQ NEWS",
+        "number": 1306
+      },
+      {
+        "name": "BBC Red Button",
+        "number": 1307
+      },
+      {
+        "name": "Channelbox",
+        "number": 1308
+      },
+      {
+        "name": "CNA Originals",
+        "number": 1309
+      },
+      {
+        "name": "EuroNews",
+        "number": 1310
+      },
+      {
+        "name": "FRANCE 24",
+        "number": 1311
+      },
+      {
+        "name": "GIGS",
+        "number": 1312
+      },
+      {
+        "name": "Global Arabic +",
+        "number": 1313
+      },
+      {
+        "name": "It Is Written TV",
+        "number": 1314
+      },
+      {
+        "name": "MBC",
+        "number": 1315
+      },
+      {
+        "name": "MBC Group",
+        "number": 1316
+      },
+      {
+        "name": "Music & Memories",
+        "number": 1317
+      },
+      {
+        "name": "New Media TV",
+        "number": 1318
+      },
+      {
+        "name": "Newsmax",
+        "number": 1319
+      },
+      {
+        "name": "NHK WORLD",
+        "number": 1320
+      },
+      {
+        "name": "Nolly Africa",
+        "number": 1321
+      },
+      {
+        "name": "Nosey",
+        "number": 1322
+      },
+      {
+        "name": "Odyssey TV",
+        "number": 1323
+      },
+      {
+        "name": "On Demand 365",
+        "number": 1324
+      },
+      {
+        "name": "Outdoor Channel",
+        "number": 1325
+      },
+      {
+        "name": "OUTflix Proud",
+        "number": 1326
+      },
+      {
+        "name": "Purpose Media",
+        "number": 1327
+      },
+      {
+        "name": "Revelation TV",
+        "number": 1328
+      },
+      {
+        "name": "ROK",
+        "number": 1329
+      },
+      {
+        "name": "Talk",
+        "number": 1330
+      },
+      {
+        "name": "Together TV IP",
+        "number": 1331
+      },
+      {
+        "name": "Trailblazer",
+        "number": 1332
+      },
+      {
+        "name": "wedotv Big Stories",
+        "number": 1333
+      }
+    ],
+    "International": [
+      {
+        "name": "Aaj Tak",
+        "number": 1401
+      },
+      {
+        "name": "Aastha",
+        "number": 1402
+      },
+      {
+        "name": "Ahlebait TV",
+        "number": 1403
+      },
+      {
+        "name": "Akaal Channel",
+        "number": 1404
+      },
+      {
+        "name": "Apna MA TV",
+        "number": 1405
+      },
+      {
+        "name": "ARY Digital",
+        "number": 1406
+      },
+      {
+        "name": "ATN Bangla",
+        "number": 1407
+      },
+      {
+        "name": "B4U Movies",
+        "number": 1408
+      },
+      {
+        "name": "B4U Music",
+        "number": 1409
+      },
+      {
+        "name": "Channel S",
+        "number": 1410
+      },
+      {
+        "name": "Colors Cineplex",
+        "number": 1411
+      },
+      {
+        "name": "Colors Gujarati",
+        "number": 1412
+      },
+      {
+        "name": "Colors Rishtey",
+        "number": 1414
+      },
+      {
+        "name": "Deen TV",
+        "number": 1415
+      },
+      {
+        "name": "Eman Channel",
+        "number": 1416
+      },
+      {
+        "name": "Geo News",
+        "number": 1417
+      },
+      {
+        "name": "Geo TV",
+        "number": 1418
+      },
+      {
+        "name": "GTC Punjabi",
+        "number": 1419
+      },
+      {
+        "name": "Hum Europe",
+        "number": 1420
+      },
+      {
+        "name": "Hum News",
+        "number": 1421
+      },
+      {
+        "name": "iON TV",
+        "number": 1422
+      },
+      {
+        "name": "IQRA Bangla",
+        "number": 1423
+      },
+      {
+        "name": "IQRA TV",
+        "number": 1424
+      },
+      {
+        "name": "Islam Channel",
+        "number": 1425
+      },
+      {
+        "name": "Islam Channel Bangla",
+        "number": 1426
+      },
+      {
+        "name": "Islam Channel Urdu",
+        "number": 1427
+      },
+      {
+        "name": "Islam TV",
+        "number": 1428
+      },
+      {
+        "name": "Kanshi TV",
+        "number": 1429
+      },
+      {
+        "name": "Madani Channel",
+        "number": 1430
+      },
+      {
+        "name": "MTA1 World HD",
+        "number": 1431
+      },
+      {
+        "name": "New Vision TV",
+        "number": 1432
+      },
+      {
+        "name": "Noor TV",
+        "number": 1433
+      },
+      {
+        "name": "NTV",
+        "number": 1434
+      },
+      {
+        "name": "Panjab Broadcasting Channel",
+        "number": 1435
+      },
+      {
+        "name": "Panjab TV",
+        "number": 1436
+      },
+      {
+        "name": "Phoenix CNE HD",
+        "number": 1437
+      },
+      {
+        "name": "Pitaara",
+        "number": 1438
+      },
+      {
+        "name": "Politics Punjab",
+        "number": 1439
+      },
+      {
+        "name": "PTC Punjabi",
+        "number": 1440
+      },
+      {
+        "name": "QTV Religious",
+        "number": 1441
+      },
+      {
+        "name": "Sangat Television",
+        "number": 1442
+      },
+      {
+        "name": "Sanskar",
+        "number": 1443
+      },
+      {
+        "name": "Sikh Channel",
+        "number": 1444
+      },
+      {
+        "name": "Sky News Arabia",
+        "number": 1445
+      },
+      {
+        "name": "Sony Max 2",
+        "number": 1446
+      },
+      {
+        "name": "Sony SAB",
+        "number": 1448
+      },
+      {
+        "name": "Takbeer TV",
+        "number": 1450
+      },
+      {
+        "name": "TV One",
+        "number": 1451
+      },
+      {
+        "name": "Utsav Bharat",
+        "number": 1452
+      },
+      {
+        "name": "Zee Cinema",
+        "number": 1455
+      },
+      {
+        "name": "Zee Punjabi",
+        "number": 1456
+      }
+    ],
+    "Radio": [
+      {
+        "name": "BBC Asian Network",
+        "number": 1501
+      },
+      {
+        "name": "BBC Local Radio",
+        "number": 1502
+      },
+      {
+        "name": "BBC Radio 1",
+        "number": 1503
+      },
+      {
+        "name": "BBC Radio 1Xtra",
+        "number": 1504
+      },
+      {
+        "name": "BBC Radio 2",
+        "number": 1505
+      },
+      {
+        "name": "BBC Radio 3",
+        "number": 1506
+      },
+      {
+        "name": "BBC Radio 4",
+        "number": 1507
+      },
+      {
+        "name": "BBC Radio 4 Extra",
+        "number": 1508
+      },
+      {
+        "name": "BBC Radio 5 Live",
+        "number": 1509
+      },
+      {
+        "name": "BBC Radio 5 Sports Extra",
+        "number": 1510
+      },
+      {
+        "name": "BBC Radio 6 Music",
+        "number": 1511
+      },
+      {
+        "name": "BBC World Service",
+        "number": 1512
+      },
+      {
+        "name": "Capital",
+        "number": 1513
+      },
+      {
+        "name": "Classic FM",
+        "number": 1514
+      },
+      {
+        "name": "Heart",
+        "number": 1515
+      },
+      {
+        "name": "LBC",
+        "number": 1516
+      },
+      {
+        "name": "Premier Radio",
+        "number": 1517
+      },
+      {
+        "name": "RNIB Connect",
+        "number": 1518
+      },
+      {
+        "name": "Smooth Radio",
+        "number": 1519
+      },
+      {
+        "name": "talkSPORT",
+        "number": 1520
+      }
+    ],
+    "Regional & Interactive": [
+      {
+        "name": "BBC One Channel Islands HD",
+        "number": 1601
+      },
+      {
+        "name": "BBC One East HD",
+        "number": 1602
+      },
+      {
+        "name": "BBC One East Midlands HD",
+        "number": 1603
+      },
+      {
+        "name": "BBC One East Yorkshire & Lincolnshire HD",
+        "number": 1604
+      },
+      {
+        "name": "BBC One London HD",
+        "number": 1605
+      },
+      {
+        "name": "BBC One North East & Cumbria HD",
+        "number": 1606
+      },
+      {
+        "name": "BBC One North West HD",
+        "number": 1607
+      },
+      {
+        "name": "BBC One Northern Ireland HD",
+        "number": 1608
+      },
+      {
+        "name": "BBC One Scotland HD",
+        "number": 1609
+      },
+      {
+        "name": "BBC One South East HD",
+        "number": 1610
+      },
+      {
+        "name": "BBC One South HD",
+        "number": 1611
+      },
+      {
+        "name": "BBC One South West HD",
+        "number": 1612
+      },
+      {
+        "name": "BBC One Wales HD",
+        "number": 1613
+      },
+      {
+        "name": "BBC One West HD",
+        "number": 1614
+      },
+      {
+        "name": "BBC One West Midlands HD",
+        "number": 1615
+      },
+      {
+        "name": "BBC One Yorkshire HD",
+        "number": 1616
+      },
+      {
+        "name": "BBC Red Button 1 HD",
+        "number": 1617
+      },
+      {
+        "name": "BBC Two Northern Ireland HD",
+        "number": 1618
+      },
+      {
+        "name": "BBC Two Wales HD",
+        "number": 1619
+      }
+    ],
+    "Secondary & Information": [
+      {
+        "name": "Boomerang",
+        "number": 1701
+      },
+      {
+        "name": "Cartoon Network",
+        "number": 1702
+      },
+      {
+        "name": "Channel Line-up",
+        "number": 1703
+      },
+      {
+        "name": "Colors",
+        "number": 1704
+      },
+      {
+        "name": "Comedy Central",
+        "number": 1705
+      },
+      {
+        "name": "Crime+Investigation",
+        "number": 1706
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 1707
+      },
+      {
+        "name": "MTV",
+        "number": 1708
+      },
+      {
+        "name": "National Geographic",
+        "number": 1709
+      },
+      {
+        "name": "National Geographic Wild",
+        "number": 1710
+      },
+      {
+        "name": "Nick Jr.",
+        "number": 1711
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 1712
+      },
+      {
+        "name": "S4C",
+        "number": 1713
+      },
+      {
+        "name": "Sky Atlantic",
+        "number": 1714
+      },
+      {
+        "name": "Sky Comedy",
+        "number": 1715
+      },
+      {
+        "name": "Sky Crime",
+        "number": 1716
+      },
+      {
+        "name": "Sky Documentaries",
+        "number": 1717
+      },
+      {
+        "name": "Sky History",
+        "number": 1718
+      },
+      {
+        "name": "Sky Nature",
+        "number": 1719
+      },
+      {
+        "name": "Sky One",
+        "number": 1720
+      },
+      {
+        "name": "Sky Sci-Fi",
+        "number": 1721
+      },
+      {
+        "name": "Sky Sports F1",
+        "number": 1722
+      },
+      {
+        "name": "Sky Sports Main Event",
+        "number": 1724
+      },
+      {
+        "name": "Sky Sports Mix",
+        "number": 1726
+      },
+      {
+        "name": "Sky Sports News",
+        "number": 1727
+      },
+      {
+        "name": "Sky Witness",
+        "number": 1728
+      },
+      {
+        "name": "Sony Max",
+        "number": 1729
+      },
+      {
+        "name": "Sony TV",
+        "number": 1730
+      },
+      {
+        "name": "TLC",
+        "number": 1731
+      },
+      {
+        "name": "TNT Sports 1",
+        "number": 1732
+      },
+      {
+        "name": "TNT Sports 2",
+        "number": 1733
+      },
+      {
+        "name": "TNT Sports 3",
+        "number": 1734
+      },
+      {
+        "name": "TNT Sports 4",
+        "number": 1735
+      },
+      {
+        "name": "TRT World",
+        "number": 1736
+      },
+      {
+        "name": "U&Alibi",
+        "number": 1737
+      },
+      {
+        "name": "U&Dave",
+        "number": 1738
+      },
+      {
+        "name": "U&Gold",
+        "number": 1739
+      },
+      {
+        "name": "Utsav Gold",
+        "number": 1740
+      },
+      {
+        "name": "Utsav Plus",
+        "number": 1741
+      },
+      {
+        "name": "Zee TV",
+        "number": 1742
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/UK_Freeview_lineup.json
+++ b/plugins/lineuparr/UK_Freeview_lineup.json
@@ -1,0 +1,667 @@
+{
+  "package": "Freeview UK",
+  "date": "2026-05-20",
+  "description": "Freeview UK channel lineup based with data from freeview.co.uk",
+  "source": "Freeview",
+  "notes": "Categories are derived from the Freeview LCN specification.",
+  "categories": {
+    "Entertainment": [
+      {
+        "name": "BBC One",
+        "number": 1
+      },
+      {
+        "name": "BBC Two",
+        "number": 2
+      },
+      {
+        "name": "ITV",
+        "number": 3
+      },
+      {
+        "name": "Channel 4",
+        "number": 4
+      },
+      {
+        "name": "5",
+        "number": 5
+      },
+      {
+        "name": "ITV2",
+        "number": 6
+      },
+      {
+        "name": "London TV",
+        "number": 8
+      },
+      {
+        "name": "BBC Four",
+        "number": 9
+      },
+      {
+        "name": "ITV3",
+        "number": 10
+      },
+      {
+        "name": "Sky Mix",
+        "number": 11
+      },
+      {
+        "name": "HGTV",
+        "number": 12
+      },
+      {
+        "name": "E4",
+        "number": 13
+      },
+      {
+        "name": "Film4",
+        "number": 14
+      },
+      {
+        "name": "Channel 4 +1",
+        "number": 15
+      },
+      {
+        "name": "QVC",
+        "number": 16
+      },
+      {
+        "name": "QUEST",
+        "number": 17
+      },
+      {
+        "name": "More4",
+        "number": 18
+      },
+      {
+        "name": "Dave",
+        "number": 19
+      },
+      {
+        "name": "Drama",
+        "number": 20
+      },
+      {
+        "name": "5USA",
+        "number": 21
+      },
+      {
+        "name": "TJC",
+        "number": 22
+      },
+      {
+        "name": "BBC Three",
+        "number": 23
+      },
+      {
+        "name": "W",
+        "number": 25
+      },
+      {
+        "name": "ITV4",
+        "number": 26
+      },
+      {
+        "name": "Yesterday",
+        "number": 27
+      },
+      {
+        "name": "ITVBe",
+        "number": 28
+      },
+      {
+        "name": "ITV2 +1",
+        "number": 29
+      },
+      {
+        "name": "E4 +1",
+        "number": 30
+      },
+      {
+        "name": "E4 Extra",
+        "number": 31
+      },
+      {
+        "name": "5STAR",
+        "number": 32
+      },
+      {
+        "name": "5ACTION",
+        "number": 33
+      },
+      {
+        "name": "GREAT! tv",
+        "number": 34
+      },
+      {
+        "name": "ITV +1",
+        "number": 35
+      },
+      {
+        "name": "Sky Arts",
+        "number": 36
+      },
+      {
+        "name": "QVC Beauty",
+        "number": 37
+      },
+      {
+        "name": "5 +1",
+        "number": 38
+      },
+      {
+        "name": "DMAX",
+        "number": 39
+      },
+      {
+        "name": "Quest Red",
+        "number": 40
+      },
+      {
+        "name": "LEGEND",
+        "number": 41
+      },
+      {
+        "name": "Great! Action",
+        "number": 42
+      },
+      {
+        "name": "Food Network",
+        "number": 43
+      },
+      {
+        "name": "Really",
+        "number": 44
+      },
+      {
+        "name": "Gems TV",
+        "number": 45
+      },
+      {
+        "name": "5SELECT",
+        "number": 46
+      },
+      {
+        "name": "Film4 +1",
+        "number": 47
+      },
+      {
+        "name": "Challenge",
+        "number": 48
+      },
+      {
+        "name": "4seven",
+        "number": 49
+      },
+      {
+        "name": "Great! Mystery",
+        "number": 50
+      },
+      {
+        "name": "Ideal World",
+        "number": 51
+      },
+      {
+        "name": "Great! Christmas",
+        "number": 52
+      },
+      {
+        "name": "That's TV (UK)",
+        "number": 56
+      },
+      {
+        "name": "U&Eden",
+        "number": 57
+      },
+      {
+        "name": "ITV3 +1",
+        "number": 58
+      },
+      {
+        "name": "ITV4 +1",
+        "number": 59
+      },
+      {
+        "name": "Drama +1",
+        "number": 60
+      },
+      {
+        "name": "Great! TV +1",
+        "number": 61
+      },
+      {
+        "name": "Great! Movies",
+        "number": 62
+      },
+      {
+        "name": "Great! Player",
+        "number": 63
+      },
+      {
+        "name": "Blaze",
+        "number": 64
+      },
+      {
+        "name": "That's TV 2",
+        "number": 65
+      },
+      {
+        "name": "TBN UK",
+        "number": 66
+      },
+      {
+        "name": "TRUE CRIME",
+        "number": 67
+      },
+      {
+        "name": "TRUE CRIME XTRA",
+        "number": 68
+      },
+      {
+        "name": "LEGEND XTRA",
+        "number": 69
+      },
+      {
+        "name": "QUEST +1",
+        "number": 70
+      },
+      {
+        "name": "TCC",
+        "number": 71
+      },
+      {
+        "name": "Jewellery Maker",
+        "number": 72
+      },
+      {
+        "name": "HobbyMaker",
+        "number": 73
+      },
+      {
+        "name": "Dave ja vu",
+        "number": 74
+      },
+      {
+        "name": "That's 60s",
+        "number": 76
+      },
+      {
+        "name": "That's 70s",
+        "number": 78
+      },
+      {
+        "name": "Rewind TV",
+        "number": 81
+      },
+      {
+        "name": "TalkingPictures TV",
+        "number": 82
+      },
+      {
+        "name": "Together TV",
+        "number": 83
+      },
+      {
+        "name": "PBS America",
+        "number": 84
+      },
+      {
+        "name": "Shop On TV",
+        "number": 89
+      },
+      {
+        "name": "Together TV+1",
+        "number": 90
+      },
+      {
+        "name": "WildEarth",
+        "number": 91
+      },
+      {
+        "name": "Blaze +1",
+        "number": 92
+      },
+      {
+        "name": "SonLife",
+        "number": 94
+      },
+      {
+        "name": "High Street TV",
+        "number": 95
+      },
+      {
+        "name": "Must Have Ideas",
+        "number": 96
+      },
+      {
+        "name": "Shop Unlimited",
+        "number": 97
+      },
+      {
+        "name": "wedotv Movies UK",
+        "number": 98
+      },
+      {
+        "name": "TLC+1",
+        "number": 99
+      }
+    ],
+    "HD": [
+      {
+        "name": "BBC One HD",
+        "number": 101
+      },
+      {
+        "name": "BBC Two HD",
+        "number": 102
+      },
+      {
+        "name": "ITV HD",
+        "number": 103
+      },
+      {
+        "name": "Channel 4 HD",
+        "number": 104
+      },
+      {
+        "name": "5 HD",
+        "number": 105
+      },
+      {
+        "name": "BBC Four HD",
+        "number": 106
+      },
+      {
+        "name": "BBC Three HD",
+        "number": 107
+      }
+    ],
+    "Kids": [
+      {
+        "name": "CBBC",
+        "number": 201
+      },
+      {
+        "name": "CBeebies",
+        "number": 202
+      },
+      {
+        "name": "CBBC HD",
+        "number": 203
+      },
+      {
+        "name": "CBeebies HD",
+        "number": 204
+      },
+      {
+        "name": "POP",
+        "number": 205
+      },
+      {
+        "name": "Tiny Pop",
+        "number": 206
+      },
+      {
+        "name": "Pop Up",
+        "number": 207
+      },
+      {
+        "name": "Ketchup TV",
+        "number": 209
+      },
+      {
+        "name": "Ketchup Too",
+        "number": 210
+      },
+      {
+        "name": "Cartoon Classics",
+        "number": 214
+      }
+    ],
+    "News": [
+      {
+        "name": "BBC News",
+        "number": 231
+      },
+      {
+        "name": "BBC Parliament",
+        "number": 232
+      },
+      {
+        "name": "Sky News",
+        "number": 233
+      },
+      {
+        "name": "GB News",
+        "number": 236
+      }
+    ],
+    "Hybrid Streamed and Text": [
+      {
+        "name": "BBC Red Button",
+        "number": 250
+      },
+      {
+        "name": "Al Jazeera English",
+        "number": 251
+      },
+      {
+        "name": "Al Jazeera Arabic",
+        "number": 252
+      },
+      {
+        "name": "Trailblazer",
+        "number": 253
+      },
+      {
+        "name": "On Demand 365",
+        "number": 254
+      },
+      {
+        "name": "FRANCE 24",
+        "number": 255
+      },
+      {
+        "name": "Odyssey TV",
+        "number": 256
+      },
+      {
+        "name": "EuroNews",
+        "number": 257
+      },
+      {
+        "name": "MBC",
+        "number": 259
+      },
+      {
+        "name": "ASHARQ NEWS",
+        "number": 260
+      },
+      {
+        "name": "AL ARABIYA",
+        "number": 261
+      },
+      {
+        "name": "Sonlife",
+        "number": 263
+      },
+      {
+        "name": "Alaraby Network",
+        "number": 264
+      },
+      {
+        "name": "ROK",
+        "number": 265
+      },
+      {
+        "name": "Revelation TV",
+        "number": 266
+      },
+      {
+        "name": "It Is Written TV",
+        "number": 268
+      },
+      {
+        "name": "New Media TV",
+        "number": 269
+      },
+      {
+        "name": "Together TV IP",
+        "number": 270
+      },
+      {
+        "name": "Channelbox",
+        "number": 271
+      },
+      {
+        "name": "NHK WORLD",
+        "number": 272
+      },
+      {
+        "name": "Newsmax",
+        "number": 273
+      },
+      {
+        "name": "Amazing Facts",
+        "number": 274
+      },
+      {
+        "name": "wedotv Big Stories",
+        "number": 275
+      },
+      {
+        "name": "CNA Originals",
+        "number": 276
+      },
+      {
+        "name": "Nosey",
+        "number": 278
+      },
+      {
+        "name": "Purpose Media",
+        "number": 279
+      },
+      {
+        "name": "Talk",
+        "number": 280
+      },
+      {
+        "name": "Global Arabic +",
+        "number": 283
+      },
+      {
+        "name": "GIGS",
+        "number": 284
+      },
+      {
+        "name": "Nolly Africa",
+        "number": 287
+      },
+      {
+        "name": "OUTflix Proud",
+        "number": 288
+      },
+      {
+        "name": "MBC Group",
+        "number": 289
+      },
+      {
+        "name": "Music & Memories",
+        "number": 290
+      },
+      {
+        "name": "Outdoor Channel",
+        "number": 291
+      }
+    ],
+    "Interactive Services": [
+      {
+        "name": "BBC Red Button",
+        "number": 601
+      }
+    ],
+    "Radio": [
+      {
+        "name": "BBC Radio 1",
+        "number": 700
+      },
+      {
+        "name": "BBC Radio 1Xtra",
+        "number": 701
+      },
+      {
+        "name": "BBC Radio 2",
+        "number": 702
+      },
+      {
+        "name": "BBC Radio 3",
+        "number": 703
+      },
+      {
+        "name": "BBC Radio 4",
+        "number": 704
+      },
+      {
+        "name": "BBC Radio 5 Live",
+        "number": 705
+      },
+      {
+        "name": "BBC Radio 5 Sports Extra",
+        "number": 706
+      },
+      {
+        "name": "BBC Radio 6 Music",
+        "number": 707
+      },
+      {
+        "name": "BBC Radio 4 Extra",
+        "number": 708
+      },
+      {
+        "name": "BBC Asian Network",
+        "number": 709
+      },
+      {
+        "name": "BBC World Service",
+        "number": 710
+      },
+      {
+        "name": "BBC Local Radio",
+        "number": 711
+      },
+      {
+        "name": "Smooth Radio",
+        "number": 718
+      },
+      {
+        "name": "talkSPORT",
+        "number": 723
+      },
+      {
+        "name": "Capital",
+        "number": 724
+      },
+      {
+        "name": "Premier Radio",
+        "number": 725
+      },
+      {
+        "name": "Heart",
+        "number": 728
+      },
+      {
+        "name": "RNIB Connect",
+        "number": 730
+      },
+      {
+        "name": "Classic FM",
+        "number": 731
+      },
+      {
+        "name": "LBC",
+        "number": 732
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/UK_SkyTV_ENG_full_lineup.json
+++ b/plugins/lineuparr/UK_SkyTV_ENG_full_lineup.json
@@ -1,0 +1,1483 @@
+{
+  "package": "Sky TV UK (England) Full Lineup",
+  "date": "2026-05-04",
+  "description": "Sky TV UK (England) lineup with timeshift, HD, and regional variations",
+  "source": "Sky Q",
+  "notes": "This lineup includes the main channels available on Sky TV in the UK (England), categorized by genre. It also includes timeshift channels (+1) and HD channels where available. Regional variations are included in this full lineup.",
+  "categories": {
+    "Entertainment": [
+      {
+        "name": "BBC One HD",
+        "number": 101
+      },
+      {
+        "name": "BBC Two HD",
+        "number": 102
+      },
+      {
+        "name": "ITV1 HD",
+        "number": 103
+      },
+      {
+        "name": "Channel 4 HD",
+        "number": 104
+      },
+      {
+        "name": "Channel 5 HD",
+        "number": 105
+      },
+      {
+        "name": "Sky One HD",
+        "number": 106
+      },
+      {
+        "name": "Sky Witness HD",
+        "number": 107
+      },
+      {
+        "name": "Sky Atlantic HD",
+        "number": 108
+      },
+      {
+        "name": "U&Alibi HD",
+        "number": 109
+      },
+      {
+        "name": "U&Gold HD",
+        "number": 110
+      },
+      {
+        "name": "U&Dave HD",
+        "number": 111
+      },
+      {
+        "name": "Comedy Central HD",
+        "number": 112
+      },
+      {
+        "name": "Sky Comedy HD",
+        "number": 113
+      },
+      {
+        "name": "Sky Documentaries HD",
+        "number": 114
+      },
+      {
+        "name": "BBC Three HD",
+        "number": 115
+      },
+      {
+        "name": "BBC Four HD",
+        "number": 116
+      },
+      {
+        "name": "London TV",
+        "number": 117
+      },
+      {
+        "name": "ITV2 HD",
+        "number": 118
+      },
+      {
+        "name": "ITV3 HD",
+        "number": 119
+      },
+      {
+        "name": "ITV4 HD",
+        "number": 120
+      },
+      {
+        "name": "Sky Crime HD",
+        "number": 121
+      },
+      {
+        "name": "Sky Arts HD",
+        "number": 122
+      },
+      {
+        "name": "Sky History HD",
+        "number": 123
+      },
+      {
+        "name": "Sky Nature HD",
+        "number": 124
+      },
+      {
+        "name": "Discovery Channel HD",
+        "number": 125
+      },
+      {
+        "name": "MTV HD",
+        "number": 126
+      },
+      {
+        "name": "Comedy Central Extra",
+        "number": 127
+      },
+      {
+        "name": "5STAR",
+        "number": 128
+      },
+      {
+        "name": "National Geographic HD",
+        "number": 129
+      },
+      {
+        "name": "Challenge",
+        "number": 130
+      },
+      {
+        "name": "ITV Quiz HD",
+        "number": 131
+      },
+      {
+        "name": "U&W",
+        "number": 132
+      },
+      {
+        "name": "TLC HD",
+        "number": 133
+      },
+      {
+        "name": "S4C HD",
+        "number": 134
+      },
+      {
+        "name": "E4 HD",
+        "number": 135
+      },
+      {
+        "name": "More4 HD",
+        "number": 136
+      },
+      {
+        "name": "4seven",
+        "number": 137
+      },
+      {
+        "name": "E4 Extra",
+        "number": 138
+      },
+      {
+        "name": "Crime+Investigation HD",
+        "number": 139
+      },
+      {
+        "name": "Quest HD",
+        "number": 140
+      },
+      {
+        "name": "5USA",
+        "number": 141
+      },
+      {
+        "name": "Really",
+        "number": 142
+      },
+      {
+        "name": "U&Drama",
+        "number": 143
+      },
+      {
+        "name": "Food Network",
+        "number": 144
+      },
+      {
+        "name": "Sky Sci-Fi HD",
+        "number": 145
+      },
+      {
+        "name": "True Crime",
+        "number": 146
+      },
+      {
+        "name": "True Crime Xtra",
+        "number": 147
+      },
+      {
+        "name": "Legend",
+        "number": 148
+      },
+      {
+        "name": "Quest Red",
+        "number": 149
+      },
+      {
+        "name": "5ACTION",
+        "number": 150
+      },
+      {
+        "name": "Sky Mix HD",
+        "number": 151
+      },
+      {
+        "name": "5SELECT",
+        "number": 153
+      },
+      {
+        "name": "Investigation Discovery",
+        "number": 154
+      },
+      {
+        "name": "U&Yesterday",
+        "number": 155
+      },
+      {
+        "name": "Blaze",
+        "number": 156
+      },
+      {
+        "name": "GREAT! TV",
+        "number": 157
+      },
+      {
+        "name": "Discovery Turbo",
+        "number": 158
+      },
+      {
+        "name": "DMAX",
+        "number": 159
+      },
+      {
+        "name": "Discovery History",
+        "number": 161
+      },
+      {
+        "name": "Animal Planet",
+        "number": 162
+      },
+      {
+        "name": "Sky History 2",
+        "number": 163
+      },
+      {
+        "name": "National Geographic Wild HD",
+        "number": 165
+      },
+      {
+        "name": "U&Eden",
+        "number": 166
+      },
+      {
+        "name": "Discovery Science",
+        "number": 167
+      },
+      {
+        "name": "BBC Alba HD",
+        "number": 169
+      },
+      {
+        "name": "Together TV",
+        "number": 170
+      },
+      {
+        "name": "That's TV",
+        "number": 171
+      },
+      {
+        "name": "PBS America",
+        "number": 173
+      },
+      {
+        "name": "Court TV",
+        "number": 176
+      },
+      {
+        "name": "Travelxp",
+        "number": 178
+      },
+      {
+        "name": "BBC Scotland HD",
+        "number": 180
+      },
+      {
+        "name": "That's TV 2",
+        "number": 181
+      },
+      {
+        "name": "Rewind TV",
+        "number": 182
+      },
+      {
+        "name": "That's 20th Century",
+        "number": 183
+      }
+    ],
+    "Entertainment & Documentaries +1": [
+      {
+        "name": "ITV1 London +1",
+        "number": 203
+      },
+      {
+        "name": "Channel 4 +1",
+        "number": 204
+      },
+      {
+        "name": "Channel 5 +1",
+        "number": 205
+      },
+      {
+        "name": "Sky Witness +1",
+        "number": 207
+      },
+      {
+        "name": "Sky Atlantic +1",
+        "number": 208
+      },
+      {
+        "name": "U&Alibi +1",
+        "number": 209
+      },
+      {
+        "name": "U&Gold +1",
+        "number": 210
+      },
+      {
+        "name": "U&DaveJaVu",
+        "number": 211
+      },
+      {
+        "name": "Comedy Central +1",
+        "number": 212
+      },
+      {
+        "name": "ITV2 +1",
+        "number": 218
+      },
+      {
+        "name": "ITV3 +1",
+        "number": 219
+      },
+      {
+        "name": "ITV4 +1",
+        "number": 220
+      },
+      {
+        "name": "Sky Crime +1",
+        "number": 221
+      },
+      {
+        "name": "Discovery Channel +1",
+        "number": 225
+      },
+      {
+        "name": "5STAR +1",
+        "number": 228
+      },
+      {
+        "name": "National Geographic +1",
+        "number": 229
+      },
+      {
+        "name": "U&W +1",
+        "number": 232
+      },
+      {
+        "name": "TLC +1",
+        "number": 233
+      },
+      {
+        "name": "E4 +1",
+        "number": 235
+      },
+      {
+        "name": "More4 +1",
+        "number": 236
+      },
+      {
+        "name": "Crime+Investigation +1",
+        "number": 239
+      },
+      {
+        "name": "Quest +1",
+        "number": 240
+      },
+      {
+        "name": "5USA +1",
+        "number": 241
+      },
+      {
+        "name": "Really +1",
+        "number": 242
+      },
+      {
+        "name": "U&Drama +1",
+        "number": 243
+      },
+      {
+        "name": "Food Network +1",
+        "number": 244
+      },
+      {
+        "name": "True Crime +1",
+        "number": 246
+      },
+      {
+        "name": "Quest Red +1",
+        "number": 249
+      },
+      {
+        "name": "Investigation Discovery +1",
+        "number": 254
+      },
+      {
+        "name": "U&Yesterday +1",
+        "number": 255
+      },
+      {
+        "name": "GREAT! TV +1",
+        "number": 257
+      },
+      {
+        "name": "Discovery Turbo +1",
+        "number": 258
+      },
+      {
+        "name": "DMAX +1",
+        "number": 259
+      },
+      {
+        "name": "Discovery History +1",
+        "number": 261
+      },
+      {
+        "name": "Animal Planet +1",
+        "number": 262
+      },
+      {
+        "name": "U&Eden +1",
+        "number": 266
+      },
+      {
+        "name": "Discovery Science +1",
+        "number": 267
+      }
+    ],
+    "Movies": [
+      {
+        "name": "Sky Cinema Premiere HD",
+        "number": 301
+      },
+      {
+        "name": "Sky Cinema Decades HD",
+        "number": 302
+      },
+      {
+        "name": "Sky Cinema Fast HD",
+        "number": 303
+      },
+      {
+        "name": "Sky Cinema Family HD",
+        "number": 304
+      },
+      {
+        "name": "Disney+ Cinema HD",
+        "number": 305
+      },
+      {
+        "name": "Sky Cinema Action HD",
+        "number": 306
+      },
+      {
+        "name": "Sky Cinema Greats HD",
+        "number": 307
+      },
+      {
+        "name": "Sky Cinema Comedy HD",
+        "number": 308
+      },
+      {
+        "name": "Sky Cinema Thriller HD",
+        "number": 309
+      },
+      {
+        "name": "Sky Cinema Drama HD",
+        "number": 310
+      },
+      {
+        "name": "Sky Cinema Sci-Fi & Horror HD",
+        "number": 311
+      },
+      {
+        "name": "Movies24",
+        "number": 312
+      },
+      {
+        "name": "Film4 HD",
+        "number": 313
+      },
+      {
+        "name": "Film4 +1",
+        "number": 314
+      },
+      {
+        "name": "Movies24+",
+        "number": 315
+      },
+      {
+        "name": "Legend Xtra",
+        "number": 316
+      },
+      {
+        "name": "Legend Xtra +1",
+        "number": 317
+      },
+      {
+        "name": "GREAT! Action",
+        "number": 318
+      },
+      {
+        "name": "GREAT! Action +1",
+        "number": 319
+      },
+      {
+        "name": "GREAT! Mystery",
+        "number": 320
+      },
+      {
+        "name": "GREAT! Mystery +1",
+        "number": 321
+      },
+      {
+        "name": "GREAT! Romance",
+        "number": 322
+      },
+      {
+        "name": "GREAT! Romance +1",
+        "number": 323
+      },
+      {
+        "name": "Talking Pictures TV",
+        "number": 324
+      }
+    ],
+    "Music": [
+      {
+        "name": "Clubland TV",
+        "number": 354
+      },
+      {
+        "name": "Now 70s",
+        "number": 355
+      },
+      {
+        "name": "Now 80s",
+        "number": 356
+      },
+      {
+        "name": "Now 90s & 00s",
+        "number": 357
+      },
+      {
+        "name": "Now Rock",
+        "number": 358
+      }
+    ],
+    "Sports": [
+      {
+        "name": "Sky Sports Main Event UHD",
+        "number": 401
+      },
+      {
+        "name": "Sky Sports Premier League HD",
+        "number": 402
+      },
+      {
+        "name": "Sky Sports Football HD",
+        "number": 403
+      },
+      {
+        "name": "Sky Sports+ HD",
+        "number": 404
+      },
+      {
+        "name": "Sky Sports Cricket HD",
+        "number": 405
+      },
+      {
+        "name": "Sky Sports Golf HD",
+        "number": 406
+      },
+      {
+        "name": "Sky Sports F1 UHD",
+        "number": 407
+      },
+      {
+        "name": "Sky Sports Tennis HD",
+        "number": 408
+      },
+      {
+        "name": "Sky Sports News HD",
+        "number": 409
+      },
+      {
+        "name": "TNT Sports 1 HD",
+        "number": 410
+      },
+      {
+        "name": "TNT Sports 2 HD",
+        "number": 411
+      },
+      {
+        "name": "Sky Sports Action HD",
+        "number": 412
+      },
+      {
+        "name": "TNT Sports 3 HD",
+        "number": 413
+      },
+      {
+        "name": "TNT Sports 4 HD",
+        "number": 414
+      },
+      {
+        "name": "Sky Sports Racing HD",
+        "number": 415
+      },
+      {
+        "name": "Sky Sports Mix HD",
+        "number": 416
+      },
+      {
+        "name": "MUTV HD",
+        "number": 418
+      },
+      {
+        "name": "Premier Sports 1 HD",
+        "number": 419
+      },
+      {
+        "name": "Premier Sports 2 HD",
+        "number": 420
+      },
+      {
+        "name": "LFCTV HD",
+        "number": 423
+      },
+      {
+        "name": "Racing TV HD",
+        "number": 424
+      },
+      {
+        "name": "TNT Sports Box Office HD",
+        "number": 490
+      },
+      {
+        "name": "Sky Sports Box Office HD",
+        "number": 491
+      },
+      {
+        "name": "TNT Sports Ultimate UHD",
+        "number": 493
+      },
+      {
+        "name": "TNT Sports Box Office 2 HD",
+        "number": 494
+      },
+      {
+        "name": "TNT Sports 5 HD",
+        "number": 3006
+      },
+      {
+        "name": "TNT Sports 6",
+        "number": 3007
+      },
+      {
+        "name": "TNT Sports 7",
+        "number": 3008
+      },
+      {
+        "name": "TNT Sports 8",
+        "number": 3009
+      },
+      {
+        "name": "TNT Sports 9",
+        "number": 3010
+      },
+      {
+        "name": "TNT Sports 10",
+        "number": 3011
+      }
+    ],
+    "News": [
+      {
+        "name": "Sky News HD",
+        "number": 501
+      },
+      {
+        "name": "Bloomberg HD",
+        "number": 502
+      },
+      {
+        "name": "BBC News HD",
+        "number": 503
+      },
+      {
+        "name": "BBC Parliament HD",
+        "number": 504
+      },
+      {
+        "name": "CNBC HD",
+        "number": 505
+      },
+      {
+        "name": "CNN HD",
+        "number": 506
+      },
+      {
+        "name": "NHK World HD",
+        "number": 507
+      },
+      {
+        "name": "Euronews",
+        "number": 508
+      },
+      {
+        "name": "NDTV World",
+        "number": 509
+      },
+      {
+        "name": "France 24 English HD",
+        "number": 510
+      },
+      {
+        "name": "Al Jazeera HD",
+        "number": 511
+      },
+      {
+        "name": "GB News HD",
+        "number": 512
+      },
+      {
+        "name": "TRT World HD",
+        "number": 513
+      },
+      {
+        "name": "Channels 24",
+        "number": 515
+      },
+      {
+        "name": "Arise News",
+        "number": 516
+      },
+      {
+        "name": "Arirang TV HD",
+        "number": 518
+      },
+      {
+        "name": "TVC News",
+        "number": 520
+      },
+      {
+        "name": "NTD",
+        "number": 521
+      },
+      {
+        "name": "DM News English",
+        "number": 522
+      }
+    ],
+    "Faith": [
+      {
+        "name": "God Channel",
+        "number": 580
+      },
+      {
+        "name": "Revelation",
+        "number": 581
+      },
+      {
+        "name": "TBN UK",
+        "number": 582
+      },
+      {
+        "name": "Daystar HD",
+        "number": 583
+      },
+      {
+        "name": "LoveWorld HD",
+        "number": 585
+      },
+      {
+        "name": "EWTN Catholic",
+        "number": 586
+      },
+      {
+        "name": "Faith World TV",
+        "number": 588
+      },
+      {
+        "name": "Faith UK",
+        "number": 590
+      },
+      {
+        "name": "Dunamis TV",
+        "number": 592
+      },
+      {
+        "name": "SonLife Broadcasting Network",
+        "number": 593
+      }
+    ],
+    "Kids": [
+      {
+        "name": "Cartoon Network HD",
+        "number": 601
+      },
+      {
+        "name": "Cartoon Network +1",
+        "number": 602
+      },
+      {
+        "name": "Boomerang HD",
+        "number": 603
+      },
+      {
+        "name": "Nickelodeon HD",
+        "number": 604
+      },
+      {
+        "name": "Nicktoons",
+        "number": 605
+      },
+      {
+        "name": "Nick Jr. HD",
+        "number": 606
+      },
+      {
+        "name": "CBBC HD",
+        "number": 607
+      },
+      {
+        "name": "CBeebies HD",
+        "number": 608
+      },
+      {
+        "name": "Sky Kids HD",
+        "number": 609
+      },
+      {
+        "name": "Cartoonito",
+        "number": 610
+      },
+      {
+        "name": "Boomerang +1",
+        "number": 611
+      },
+      {
+        "name": "Nick Jr. Peppa",
+        "number": 612
+      },
+      {
+        "name": "Disney Jr.",
+        "number": 613
+      },
+      {
+        "name": "Nickelodeon +1",
+        "number": 615
+      },
+      {
+        "name": "Nick Jr. +1",
+        "number": 619
+      },
+      {
+        "name": "BabyTV",
+        "number": 623
+      }
+    ],
+    "Secondary & Information": [
+      {
+        "name": "Cartoon Network",
+        "number": 640
+      },
+      {
+        "name": "Boomerang",
+        "number": 641
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 642
+      },
+      {
+        "name": "Nick Jr.",
+        "number": 643
+      },
+      {
+        "name": "Sky One",
+        "number": 806
+      },
+      {
+        "name": "Sky Witness",
+        "number": 807
+      },
+      {
+        "name": "Sky Atlantic",
+        "number": 808
+      },
+      {
+        "name": "U&Alibi",
+        "number": 809
+      },
+      {
+        "name": "U&Gold",
+        "number": 810
+      },
+      {
+        "name": "U&Dave",
+        "number": 811
+      },
+      {
+        "name": "Comedy Central",
+        "number": 812
+      },
+      {
+        "name": "Sky Comedy",
+        "number": 813
+      },
+      {
+        "name": "Sky Documentaries",
+        "number": 814
+      },
+      {
+        "name": "Sky Crime",
+        "number": 819
+      },
+      {
+        "name": "Sky Arts",
+        "number": 820
+      },
+      {
+        "name": "Sky History",
+        "number": 821
+      },
+      {
+        "name": "Sky Nature",
+        "number": 822
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 823
+      },
+      {
+        "name": "MTV",
+        "number": 824
+      },
+      {
+        "name": "National Geographic",
+        "number": 825
+      },
+      {
+        "name": "TLC",
+        "number": 828
+      },
+      {
+        "name": "S4C",
+        "number": 829
+      },
+      {
+        "name": "E4",
+        "number": 830
+      },
+      {
+        "name": "More4",
+        "number": 831
+      },
+      {
+        "name": "Sky Sci-Fi",
+        "number": 836
+      },
+      {
+        "name": "Crime+Investigation",
+        "number": 837
+      },
+      {
+        "name": "National Geographic Wild",
+        "number": 841
+      },
+      {
+        "name": "Film4",
+        "number": 855
+      },
+      {
+        "name": "Sky Sports F1 HD",
+        "number": 857
+      },
+      {
+        "name": "Sky Sports Main Event HD",
+        "number": 858
+      },
+      {
+        "name": "Sky Sports Main Event",
+        "number": 859
+      },
+      {
+        "name": "Sky Sports F1",
+        "number": 865
+      },
+      {
+        "name": "Sky Sports News",
+        "number": 867
+      },
+      {
+        "name": "TNT Sports 1",
+        "number": 868
+      },
+      {
+        "name": "TNT Sports 2",
+        "number": 869
+      },
+      {
+        "name": "TNT Sports 3",
+        "number": 870
+      },
+      {
+        "name": "TNT Sports 4",
+        "number": 871
+      },
+      {
+        "name": "Sky Sports Mix",
+        "number": 873
+      },
+      {
+        "name": "Sky News",
+        "number": 881
+      },
+      {
+        "name": "TRT World",
+        "number": 886
+      },
+      {
+        "name": "Sony TV",
+        "number": 892
+      },
+      {
+        "name": "Utsav Plus",
+        "number": 893
+      },
+      {
+        "name": "Colors",
+        "number": 894
+      },
+      {
+        "name": "Sony Max",
+        "number": 895
+      },
+      {
+        "name": "Utsav Gold",
+        "number": 896
+      },
+      {
+        "name": "Zee TV",
+        "number": 898
+      },
+      {
+        "name": "Channel Line-up",
+        "number": 996
+      }
+    ],
+    "Shopping": [
+      {
+        "name": "QVC HD",
+        "number": 660
+      },
+      {
+        "name": "Must Have Ideas HD",
+        "number": 661
+      },
+      {
+        "name": "TJC HD",
+        "number": 662
+      },
+      {
+        "name": "QVC Beauty",
+        "number": 663
+      },
+      {
+        "name": "QVC Style HD",
+        "number": 664
+      },
+      {
+        "name": "Gemporia HD",
+        "number": 665
+      },
+      {
+        "name": "High Street TV 1",
+        "number": 666
+      },
+      {
+        "name": "High Street TV 2",
+        "number": 667
+      },
+      {
+        "name": "Ideal World HD",
+        "number": 668
+      },
+      {
+        "name": "Best Direct",
+        "number": 669
+      },
+      {
+        "name": "HobbyMaker HD",
+        "number": 670
+      },
+      {
+        "name": "QVC Extra",
+        "number": 671
+      },
+      {
+        "name": "Shop Unlimited",
+        "number": 672
+      },
+      {
+        "name": "TV Warehouse",
+        "number": 673
+      },
+      {
+        "name": "Jewellery Maker",
+        "number": 674
+      },
+      {
+        "name": "Cruise1st.TV",
+        "number": 675
+      }
+    ],
+    "International": [
+      {
+        "name": "B4U Movies",
+        "number": 701
+      },
+      {
+        "name": "B4U Music",
+        "number": 702
+      },
+      {
+        "name": "Sony TV HD",
+        "number": 703
+      },
+      {
+        "name": "Utsav Bharat",
+        "number": 704
+      },
+      {
+        "name": "Utsav Plus HD",
+        "number": 705
+      },
+      {
+        "name": "Colors HD",
+        "number": 706
+      },
+      {
+        "name": "Zee TV HD",
+        "number": 707
+      },
+      {
+        "name": "Zee Cinema",
+        "number": 708
+      },
+      {
+        "name": "Apna MA TV",
+        "number": 709
+      },
+      {
+        "name": "Aaj Tak",
+        "number": 710
+      },
+      {
+        "name": "Colors Rishtey",
+        "number": 712
+      },
+      {
+        "name": "Colors Cineplex",
+        "number": 713
+      },
+      {
+        "name": "Sony Max HD",
+        "number": 714
+      },
+      {
+        "name": "Utsav Gold HD",
+        "number": 715
+      },
+      {
+        "name": "Sony SAB",
+        "number": 716
+      },
+      {
+        "name": "Sony Max 2",
+        "number": 717
+      },
+      {
+        "name": "Aastha",
+        "number": 718
+      },
+      {
+        "name": "Sanskar",
+        "number": 719
+      },
+      {
+        "name": "MTA1 World HD",
+        "number": 731
+      },
+      {
+        "name": "Hum News",
+        "number": 732
+      },
+      {
+        "name": "Geo News",
+        "number": 734
+      },
+      {
+        "name": "New Vision TV",
+        "number": 735
+      },
+      {
+        "name": "Islam Channel",
+        "number": 736
+      },
+      {
+        "name": "Geo TV",
+        "number": 737
+      },
+      {
+        "name": "Noor TV",
+        "number": 738
+      },
+      {
+        "name": "IQRA TV",
+        "number": 739
+      },
+      {
+        "name": "Islam TV",
+        "number": 741
+      },
+      {
+        "name": "Ahlebait TV",
+        "number": 742
+      },
+      {
+        "name": "Takbeer TV",
+        "number": 743
+      },
+      {
+        "name": "Hum Europe",
+        "number": 744
+      },
+      {
+        "name": "Islam Channel Urdu",
+        "number": 745
+      },
+      {
+        "name": "Madani Channel",
+        "number": 746
+      },
+      {
+        "name": "Eman Channel",
+        "number": 747
+      },
+      {
+        "name": "ARY Digital",
+        "number": 748
+      },
+      {
+        "name": "QTV Religious",
+        "number": 751
+      },
+      {
+        "name": "PTC Punjabi",
+        "number": 760
+      },
+      {
+        "name": "Panjab TV",
+        "number": 761
+      },
+      {
+        "name": "Sikh Channel",
+        "number": 762
+      },
+      {
+        "name": "Sangat Television",
+        "number": 763
+      },
+      {
+        "name": "Akaal Channel",
+        "number": 764
+      },
+      {
+        "name": "Kanshi TV",
+        "number": 765
+      },
+      {
+        "name": "Pitaara",
+        "number": 766
+      },
+      {
+        "name": "Politics Punjab",
+        "number": 767
+      },
+      {
+        "name": "Panjab Broadcasting Channel",
+        "number": 768
+      },
+      {
+        "name": "Zee Punjabi",
+        "number": 769
+      },
+      {
+        "name": "GTC Punjabi",
+        "number": 770
+      },
+      {
+        "name": "Channel S",
+        "number": 777
+      },
+      {
+        "name": "IQRA Bangla",
+        "number": 778
+      },
+      {
+        "name": "ATN Bangla",
+        "number": 779
+      },
+      {
+        "name": "NTV",
+        "number": 780
+      },
+      {
+        "name": "TV One",
+        "number": 781
+      },
+      {
+        "name": "iON TV",
+        "number": 782
+      },
+      {
+        "name": "Deen TV",
+        "number": 783
+      },
+      {
+        "name": "Islam Channel Bangla",
+        "number": 784
+      },
+      {
+        "name": "Sky News Arabia",
+        "number": 788
+      },
+      {
+        "name": "Phoenix CNE HD",
+        "number": 789
+      },
+      {
+        "name": "Colors Gujarati",
+        "number": 790
+      }
+    ],
+    "Adult": [
+      {
+        "name": "Television X",
+        "number": 900
+      },
+      {
+        "name": "The Adult Channel",
+        "number": 901
+      },
+      {
+        "name": "Xpanded TV",
+        "number": 902
+      },
+      {
+        "name": "Babes&Brazzers",
+        "number": 903
+      },
+      {
+        "name": "Babenation",
+        "number": 904
+      },
+      {
+        "name": "TVX 40+",
+        "number": 907
+      },
+      {
+        "name": "XXX Girl Girl",
+        "number": 908
+      }
+    ],
+    "Regional & Interactive": [
+      {
+        "name": "BBC One London HD",
+        "number": 951
+      },
+      {
+        "name": "BBC One North East & Cumbria HD",
+        "number": 952
+      },
+      {
+        "name": "BBC One North West HD",
+        "number": 953
+      },
+      {
+        "name": "BBC One Yorkshire HD",
+        "number": 954
+      },
+      {
+        "name": "BBC One East Yorkshire & Lincolnshire HD",
+        "number": 955
+      },
+      {
+        "name": "BBC One West Midlands HD",
+        "number": 956
+      },
+      {
+        "name": "BBC One East Midlands HD",
+        "number": 957
+      },
+      {
+        "name": "BBC One East HD",
+        "number": 958
+      },
+      {
+        "name": "BBC One South East HD",
+        "number": 959
+      },
+      {
+        "name": "BBC One West HD",
+        "number": 960
+      },
+      {
+        "name": "BBC One South HD",
+        "number": 961
+      },
+      {
+        "name": "BBC One South West HD",
+        "number": 962
+      },
+      {
+        "name": "BBC One Channel Islands HD",
+        "number": 963
+      },
+      {
+        "name": "BBC One Scotland HD",
+        "number": 964
+      },
+      {
+        "name": "BBC One Wales HD",
+        "number": 965
+      },
+      {
+        "name": "BBC One Northern Ireland HD",
+        "number": 966
+      },
+      {
+        "name": "BBC Two Wales HD",
+        "number": 968
+      },
+      {
+        "name": "BBC Two Northern Ireland HD",
+        "number": 969
+      },
+      {
+        "name": "BBC Red Button 1 HD",
+        "number": 970
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/UK_SkyTV_ENG_simple_lineup.json
+++ b/plugins/lineuparr/UK_SkyTV_ENG_simple_lineup.json
@@ -1,0 +1,1221 @@
+{
+  "package": "Sky TV UK (England) Simple Lineup",
+  "date": "2026-05-04",
+  "description": "Sky TV UK (England) lineup with timeshift, HD, and no regional variations",
+  "source": "Sky Q",
+  "notes": "This lineup includes the main channels available on Sky TV in the UK (England), categorized by genre. It also includes timeshift channels (+1) where available. Regional variations and HD channels are not included in this simple lineup.",
+  "categories": {
+    "Entertainment": [
+      {
+        "name": "BBC One",
+        "number": 101
+      },
+      {
+        "name": "BBC Two",
+        "number": 102
+      },
+      {
+        "name": "ITV1",
+        "number": 103
+      },
+      {
+        "name": "Channel 4",
+        "number": 104
+      },
+      {
+        "name": "Channel 5",
+        "number": 105
+      },
+      {
+        "name": "Sky One",
+        "number": 106
+      },
+      {
+        "name": "Sky Witness",
+        "number": 107
+      },
+      {
+        "name": "Sky Atlantic",
+        "number": 108
+      },
+      {
+        "name": "U&Alibi",
+        "number": 109
+      },
+      {
+        "name": "U&Gold",
+        "number": 110
+      },
+      {
+        "name": "U&Dave",
+        "number": 111
+      },
+      {
+        "name": "Comedy Central",
+        "number": 112
+      },
+      {
+        "name": "Sky Comedy",
+        "number": 113
+      },
+      {
+        "name": "Sky Documentaries",
+        "number": 114
+      },
+      {
+        "name": "BBC Three",
+        "number": 115
+      },
+      {
+        "name": "BBC Four",
+        "number": 116
+      },
+      {
+        "name": "London TV",
+        "number": 117
+      },
+      {
+        "name": "ITV2",
+        "number": 118
+      },
+      {
+        "name": "ITV3",
+        "number": 119
+      },
+      {
+        "name": "ITV4",
+        "number": 120
+      },
+      {
+        "name": "Sky Crime",
+        "number": 121
+      },
+      {
+        "name": "Sky Arts",
+        "number": 122
+      },
+      {
+        "name": "Sky History",
+        "number": 123
+      },
+      {
+        "name": "Sky Nature",
+        "number": 124
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 125
+      },
+      {
+        "name": "MTV",
+        "number": 126
+      },
+      {
+        "name": "Comedy Central Extra",
+        "number": 127
+      },
+      {
+        "name": "5STAR",
+        "number": 128
+      },
+      {
+        "name": "National Geographic",
+        "number": 129
+      },
+      {
+        "name": "Challenge",
+        "number": 130
+      },
+      {
+        "name": "ITV Quiz",
+        "number": 131
+      },
+      {
+        "name": "U&W",
+        "number": 132
+      },
+      {
+        "name": "TLC",
+        "number": 133
+      },
+      {
+        "name": "S4C",
+        "number": 134
+      },
+      {
+        "name": "E4",
+        "number": 135
+      },
+      {
+        "name": "More4",
+        "number": 136
+      },
+      {
+        "name": "4seven",
+        "number": 137
+      },
+      {
+        "name": "E4 Extra",
+        "number": 138
+      },
+      {
+        "name": "Crime+Investigation",
+        "number": 139
+      },
+      {
+        "name": "Quest",
+        "number": 140
+      },
+      {
+        "name": "5USA",
+        "number": 141
+      },
+      {
+        "name": "Really",
+        "number": 142
+      },
+      {
+        "name": "U&Drama",
+        "number": 143
+      },
+      {
+        "name": "Food Network",
+        "number": 144
+      },
+      {
+        "name": "Sky Sci-Fi",
+        "number": 145
+      },
+      {
+        "name": "True Crime",
+        "number": 146
+      },
+      {
+        "name": "True Crime Xtra",
+        "number": 147
+      },
+      {
+        "name": "Legend",
+        "number": 148
+      },
+      {
+        "name": "Quest Red",
+        "number": 149
+      },
+      {
+        "name": "5ACTION",
+        "number": 150
+      },
+      {
+        "name": "Sky Mix",
+        "number": 151
+      },
+      {
+        "name": "5SELECT",
+        "number": 153
+      },
+      {
+        "name": "Investigation Discovery",
+        "number": 154
+      },
+      {
+        "name": "U&Yesterday",
+        "number": 155
+      },
+      {
+        "name": "Blaze",
+        "number": 156
+      },
+      {
+        "name": "GREAT! TV",
+        "number": 157
+      },
+      {
+        "name": "Discovery Turbo",
+        "number": 158
+      },
+      {
+        "name": "DMAX",
+        "number": 159
+      },
+      {
+        "name": "Discovery History",
+        "number": 161
+      },
+      {
+        "name": "Animal Planet",
+        "number": 162
+      },
+      {
+        "name": "Sky History 2",
+        "number": 163
+      },
+      {
+        "name": "National Geographic Wild",
+        "number": 165
+      },
+      {
+        "name": "U&Eden",
+        "number": 166
+      },
+      {
+        "name": "Discovery Science",
+        "number": 167
+      },
+      {
+        "name": "BBC Alba",
+        "number": 169
+      },
+      {
+        "name": "Together TV",
+        "number": 170
+      },
+      {
+        "name": "That's TV",
+        "number": 171
+      },
+      {
+        "name": "PBS America",
+        "number": 173
+      },
+      {
+        "name": "Court TV",
+        "number": 176
+      },
+      {
+        "name": "Travelxp",
+        "number": 178
+      },
+      {
+        "name": "BBC Scotland",
+        "number": 180
+      },
+      {
+        "name": "That's TV 2",
+        "number": 181
+      },
+      {
+        "name": "Rewind TV",
+        "number": 182
+      },
+      {
+        "name": "That's 20th Century",
+        "number": 183
+      }
+    ],
+    "Entertainment & Documentaries +1": [
+      {
+        "name": "ITV1 +1",
+        "number": 203
+      },
+      {
+        "name": "Channel 4 +1",
+        "number": 204
+      },
+      {
+        "name": "Channel 5 +1",
+        "number": 205
+      },
+      {
+        "name": "Sky Witness +1",
+        "number": 207
+      },
+      {
+        "name": "Sky Atlantic +1",
+        "number": 208
+      },
+      {
+        "name": "U&Alibi +1",
+        "number": 209
+      },
+      {
+        "name": "U&Gold +1",
+        "number": 210
+      },
+      {
+        "name": "U&DaveJaVu",
+        "number": 211
+      },
+      {
+        "name": "Comedy Central +1",
+        "number": 212
+      },
+      {
+        "name": "ITV2 +1",
+        "number": 218
+      },
+      {
+        "name": "ITV3 +1",
+        "number": 219
+      },
+      {
+        "name": "ITV4 +1",
+        "number": 220
+      },
+      {
+        "name": "Sky Crime +1",
+        "number": 221
+      },
+      {
+        "name": "Discovery Channel +1",
+        "number": 225
+      },
+      {
+        "name": "5STAR +1",
+        "number": 228
+      },
+      {
+        "name": "National Geographic +1",
+        "number": 229
+      },
+      {
+        "name": "U&W +1",
+        "number": 232
+      },
+      {
+        "name": "TLC +1",
+        "number": 233
+      },
+      {
+        "name": "E4 +1",
+        "number": 235
+      },
+      {
+        "name": "More4 +1",
+        "number": 236
+      },
+      {
+        "name": "Crime+Investigation +1",
+        "number": 239
+      },
+      {
+        "name": "Quest +1",
+        "number": 240
+      },
+      {
+        "name": "5USA +1",
+        "number": 241
+      },
+      {
+        "name": "Really +1",
+        "number": 242
+      },
+      {
+        "name": "U&Drama +1",
+        "number": 243
+      },
+      {
+        "name": "Food Network +1",
+        "number": 244
+      },
+      {
+        "name": "True Crime +1",
+        "number": 246
+      },
+      {
+        "name": "Quest Red +1",
+        "number": 249
+      },
+      {
+        "name": "Investigation Discovery +1",
+        "number": 254
+      },
+      {
+        "name": "U&Yesterday +1",
+        "number": 255
+      },
+      {
+        "name": "GREAT! TV +1",
+        "number": 257
+      },
+      {
+        "name": "Discovery Turbo +1",
+        "number": 258
+      },
+      {
+        "name": "DMAX +1",
+        "number": 259
+      },
+      {
+        "name": "Discovery History +1",
+        "number": 261
+      },
+      {
+        "name": "Animal Planet +1",
+        "number": 262
+      },
+      {
+        "name": "U&Eden +1",
+        "number": 266
+      },
+      {
+        "name": "Discovery Science +1",
+        "number": 267
+      }
+    ],
+    "Movies": [
+      {
+        "name": "Sky Cinema Premiere",
+        "number": 301
+      },
+      {
+        "name": "Sky Cinema Decades",
+        "number": 302
+      },
+      {
+        "name": "Sky Cinema Fast",
+        "number": 303
+      },
+      {
+        "name": "Sky Cinema Family",
+        "number": 304
+      },
+      {
+        "name": "Disney+ Cinema",
+        "number": 305
+      },
+      {
+        "name": "Sky Cinema Action",
+        "number": 306
+      },
+      {
+        "name": "Sky Cinema Greats",
+        "number": 307
+      },
+      {
+        "name": "Sky Cinema Comedy",
+        "number": 308
+      },
+      {
+        "name": "Sky Cinema Thriller ",
+        "number": 309
+      },
+      {
+        "name": "Sky Cinema Drama",
+        "number": 310
+      },
+      {
+        "name": "Sky Cinema Sci-Fi & Horror",
+        "number": 311
+      },
+      {
+        "name": "Movies24",
+        "number": 312
+      },
+      {
+        "name": "Film4",
+        "number": 313
+      },
+      {
+        "name": "Film4 +1",
+        "number": 314
+      },
+      {
+        "name": "Movies24+",
+        "number": 315
+      },
+      {
+        "name": "Legend Xtra",
+        "number": 316
+      },
+      {
+        "name": "Legend Xtra +1",
+        "number": 317
+      },
+      {
+        "name": "GREAT! Action",
+        "number": 318
+      },
+      {
+        "name": "GREAT! Action +1",
+        "number": 319
+      },
+      {
+        "name": "GREAT! Mystery",
+        "number": 320
+      },
+      {
+        "name": "GREAT! Mystery +1",
+        "number": 321
+      },
+      {
+        "name": "GREAT! Romance",
+        "number": 322
+      },
+      {
+        "name": "GREAT! Romance +1",
+        "number": 323
+      },
+      {
+        "name": "Talking Pictures TV",
+        "number": 324
+      }
+    ],
+    "Music": [
+      {
+        "name": "Clubland TV",
+        "number": 354
+      },
+      {
+        "name": "Now 70s",
+        "number": 355
+      },
+      {
+        "name": "Now 80s",
+        "number": 356
+      },
+      {
+        "name": "Now 90s & 00s",
+        "number": 357
+      },
+      {
+        "name": "Now Rock",
+        "number": 358
+      }
+    ],
+    "Sports": [
+      {
+        "name": "Sky Sports Main Event",
+        "number": 401
+      },
+      {
+        "name": "Sky Sports Premier League",
+        "number": 402
+      },
+      {
+        "name": "Sky Sports Football",
+        "number": 403
+      },
+      {
+        "name": "Sky Sports+",
+        "number": 404
+      },
+      {
+        "name": "Sky Sports Cricket",
+        "number": 405
+      },
+      {
+        "name": "Sky Sports Golf",
+        "number": 406
+      },
+      {
+        "name": "Sky Sports F1",
+        "number": 407
+      },
+      {
+        "name": "Sky Sports Tennis",
+        "number": 408
+      },
+      {
+        "name": "Sky Sports News",
+        "number": 409
+      },
+      {
+        "name": "TNT Sports 1",
+        "number": 410
+      },
+      {
+        "name": "TNT Sports 2",
+        "number": 411
+      },
+      {
+        "name": "Sky Sports Action",
+        "number": 412
+      },
+      {
+        "name": "TNT Sports 3",
+        "number": 413
+      },
+      {
+        "name": "TNT Sports 4",
+        "number": 414
+      },
+      {
+        "name": "Sky Sports Racing",
+        "number": 415
+      },
+      {
+        "name": "Sky Sports Mix",
+        "number": 416
+      },
+      {
+        "name": "MUTV",
+        "number": 418
+      },
+      {
+        "name": "Premier Sports 1",
+        "number": 419
+      },
+      {
+        "name": "Premier Sports 2",
+        "number": 420
+      },
+      {
+        "name": "LFCTV",
+        "number": 423
+      },
+      {
+        "name": "Racing TV",
+        "number": 424
+      },
+      {
+        "name": "TNT Sports Box Office",
+        "number": 490
+      },
+      {
+        "name": "Sky Sports Box Office",
+        "number": 491
+      },
+      {
+        "name": "TNT Sports Ultimate",
+        "number": 493
+      },
+      {
+        "name": "TNT Sports Box Office 2",
+        "number": 494
+      },
+      {
+        "name": "TNT Sports 5",
+        "number": 3006
+      },
+      {
+        "name": "TNT Sports 6",
+        "number": 3007
+      },
+      {
+        "name": "TNT Sports 7",
+        "number": 3008
+      },
+      {
+        "name": "TNT Sports 8",
+        "number": 3009
+      },
+      {
+        "name": "TNT Sports 9",
+        "number": 3010
+      },
+      {
+        "name": "TNT Sports 10",
+        "number": 3011
+      }
+    ],
+    "News": [
+      {
+        "name": "Sky News",
+        "number": 501
+      },
+      {
+        "name": "Bloomberg",
+        "number": 502
+      },
+      {
+        "name": "BBC News",
+        "number": 503
+      },
+      {
+        "name": "BBC Parliament",
+        "number": 504
+      },
+      {
+        "name": "CNBC",
+        "number": 505
+      },
+      {
+        "name": "CNN",
+        "number": 506
+      },
+      {
+        "name": "NHK World",
+        "number": 507
+      },
+      {
+        "name": "Euronews",
+        "number": 508
+      },
+      {
+        "name": "NDTV World",
+        "number": 509
+      },
+      {
+        "name": "France 24 English",
+        "number": 510
+      },
+      {
+        "name": "Al Jazeera",
+        "number": 511
+      },
+      {
+        "name": "GB News",
+        "number": 512
+      },
+      {
+        "name": "TRT World",
+        "number": 513
+      },
+      {
+        "name": "Channels 24",
+        "number": 515
+      },
+      {
+        "name": "Arise News",
+        "number": 516
+      },
+      {
+        "name": "Arirang TV",
+        "number": 518
+      },
+      {
+        "name": "TVC News",
+        "number": 520
+      },
+      {
+        "name": "NTD",
+        "number": 521
+      },
+      {
+        "name": "DM News English",
+        "number": 522
+      }
+    ],
+    "Faith": [
+      {
+        "name": "God Channel",
+        "number": 580
+      },
+      {
+        "name": "Revelation",
+        "number": 581
+      },
+      {
+        "name": "TBN UK",
+        "number": 582
+      },
+      {
+        "name": "Daystar",
+        "number": 583
+      },
+      {
+        "name": "LoveWorld",
+        "number": 585
+      },
+      {
+        "name": "EWTN Catholic",
+        "number": 586
+      },
+      {
+        "name": "Faith World TV",
+        "number": 588
+      },
+      {
+        "name": "Faith UK",
+        "number": 590
+      },
+      {
+        "name": "Dunamis TV",
+        "number": 592
+      },
+      {
+        "name": "SonLife Broadcasting Network",
+        "number": 593
+      }
+    ],
+    "Kids": [
+      {
+        "name": "Cartoon Network",
+        "number": 601
+      },
+      {
+        "name": "Cartoon Network +1",
+        "number": 602
+      },
+      {
+        "name": "Boomerang",
+        "number": 603
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 604
+      },
+      {
+        "name": "Nicktoons",
+        "number": 605
+      },
+      {
+        "name": "Nick Jr.",
+        "number": 606
+      },
+      {
+        "name": "CBBC",
+        "number": 607
+      },
+      {
+        "name": "Cbeebies",
+        "number": 608
+      },
+      {
+        "name": "Sky Kids",
+        "number": 609
+      },
+      {
+        "name": "Cartoonito",
+        "number": 610
+      },
+      {
+        "name": "Boomerang +1",
+        "number": 611
+      },
+      {
+        "name": "Nick Jr. Peppa",
+        "number": 612
+      },
+      {
+        "name": "Disney Jr.",
+        "number": 613
+      },
+      {
+        "name": "Nickelodeon +1",
+        "number": 615
+      },
+      {
+        "name": "Nick Jr. +1",
+        "number": 619
+      },
+      {
+        "name": "BabyTV",
+        "number": 623
+      }
+    ],
+    "Shopping": [
+      {
+        "name": "QVC",
+        "number": 660
+      },
+      {
+        "name": "Must Have Ideas",
+        "number": 661
+      },
+      {
+        "name": "TJC",
+        "number": 662
+      },
+      {
+        "name": "QVC Beauty",
+        "number": 663
+      },
+      {
+        "name": "QVC Style",
+        "number": 664
+      },
+      {
+        "name": "Gemporia",
+        "number": 665
+      },
+      {
+        "name": "High Street TV 1",
+        "number": 666
+      },
+      {
+        "name": "High Street TV 2",
+        "number": 667
+      },
+      {
+        "name": "Ideal World",
+        "number": 668
+      },
+      {
+        "name": "Best Direct",
+        "number": 669
+      },
+      {
+        "name": "HobbyMaker",
+        "number": 670
+      },
+      {
+        "name": "QVC Extra",
+        "number": 671
+      },
+      {
+        "name": "Shop Unlimited",
+        "number": 672
+      },
+      {
+        "name": "TV Warehouse",
+        "number": 673
+      },
+      {
+        "name": "Jewellery Maker",
+        "number": 674
+      },
+      {
+        "name": "Cruise1st.TV",
+        "number": 675
+      }
+    ],
+    "International": [
+      {
+        "name": "B4U Movies",
+        "number": 701
+      },
+      {
+        "name": "B4U Music",
+        "number": 702
+      },
+      {
+        "name": "Sony TV",
+        "number": 703
+      },
+      {
+        "name": "Utsav Bharat",
+        "number": 704
+      },
+      {
+        "name": "Utsav Plus",
+        "number": 705
+      },
+      {
+        "name": "Colors",
+        "number": 706
+      },
+      {
+        "name": "Zee TV",
+        "number": 707
+      },
+      {
+        "name": "Zee Cinema",
+        "number": 708
+      },
+      {
+        "name": "Apna MA TV",
+        "number": 709
+      },
+      {
+        "name": "Aaj Tak",
+        "number": 710
+      },
+      {
+        "name": "Colors Rishtey",
+        "number": 712
+      },
+      {
+        "name": "Colors Cineplex",
+        "number": 713
+      },
+      {
+        "name": "Sony Max",
+        "number": 714
+      },
+      {
+        "name": "Utsav Gold",
+        "number": 715
+      },
+      {
+        "name": "Sony SAB",
+        "number": 716
+      },
+      {
+        "name": "Sony Max 2",
+        "number": 717
+      },
+      {
+        "name": "Aastha",
+        "number": 718
+      },
+      {
+        "name": "Sanskar",
+        "number": 719
+      },
+      {
+        "name": "MTA1 World",
+        "number": 731
+      },
+      {
+        "name": "Hum News",
+        "number": 732
+      },
+      {
+        "name": "Geo News",
+        "number": 734
+      },
+      {
+        "name": "New Vision TV",
+        "number": 735
+      },
+      {
+        "name": "Islam Channel",
+        "number": 736
+      },
+      {
+        "name": "Geo TV",
+        "number": 737
+      },
+      {
+        "name": "Noor TV",
+        "number": 738
+      },
+      {
+        "name": "IQRA TV",
+        "number": 739
+      },
+      {
+        "name": "Islam TV",
+        "number": 741
+      },
+      {
+        "name": "Ahlebait TV",
+        "number": 742
+      },
+      {
+        "name": "Takbeer TV",
+        "number": 743
+      },
+      {
+        "name": "Hum Europe",
+        "number": 744
+      },
+      {
+        "name": "Islam Channel Urdu",
+        "number": 745
+      },
+      {
+        "name": "Madani Channel",
+        "number": 746
+      },
+      {
+        "name": "Eman Channel",
+        "number": 747
+      },
+      {
+        "name": "ARY Digital",
+        "number": 748
+      },
+      {
+        "name": "QTV Religious",
+        "number": 751
+      },
+      {
+        "name": "PTC Punjabi",
+        "number": 760
+      },
+      {
+        "name": "Panjab TV",
+        "number": 761
+      },
+      {
+        "name": "Sikh Channel",
+        "number": 762
+      },
+      {
+        "name": "Sangat Television",
+        "number": 763
+      },
+      {
+        "name": "Akaal Channel",
+        "number": 764
+      },
+      {
+        "name": "Kanshi TV",
+        "number": 765
+      },
+      {
+        "name": "Pitaara",
+        "number": 766
+      },
+      {
+        "name": "Politics Punjab",
+        "number": 767
+      },
+      {
+        "name": "Panjab Broadcasting Channel",
+        "number": 768
+      },
+      {
+        "name": "Zee Punjabi",
+        "number": 769
+      },
+      {
+        "name": "GTC Punjabi",
+        "number": 770
+      },
+      {
+        "name": "Channel S",
+        "number": 777
+      },
+      {
+        "name": "IQRA Bangla",
+        "number": 778
+      },
+      {
+        "name": "ATN Bangla",
+        "number": 779
+      },
+      {
+        "name": "NTV",
+        "number": 780
+      },
+      {
+        "name": "TV One",
+        "number": 781
+      },
+      {
+        "name": "iON TV",
+        "number": 782
+      },
+      {
+        "name": "Deen TV",
+        "number": 783
+      },
+      {
+        "name": "Islam Channel Bangla",
+        "number": 784
+      },
+      {
+        "name": "Sky News Arabia",
+        "number": 788
+      },
+      {
+        "name": "Phoenix CNE",
+        "number": 789
+      },
+      {
+        "name": "Colors Gujarati",
+        "number": 790
+      }
+    ],
+    "Adult": [
+      {
+        "name": "Television X",
+        "number": 900
+      },
+      {
+        "name": "The Adult Channel",
+        "number": 901
+      },
+      {
+        "name": "Xpanded TV",
+        "number": 902
+      },
+      {
+        "name": "Babes&Brazzers",
+        "number": 903
+      },
+      {
+        "name": "Babenation",
+        "number": 904
+      },
+      {
+        "name": "TVX 40+",
+        "number": 907
+      },
+      {
+        "name": "XXX Girl Girl",
+        "number": 908
+      }
+    ],
+    "Secondary & Information": [
+      {
+        "name": "Channel Line-up",
+        "number": 996
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/US_Combined_lineup.json
+++ b/plugins/lineuparr/US_Combined_lineup.json
@@ -1,0 +1,2225 @@
+{
+  "package": "US Combined",
+  "date": "2026-05-22",
+  "description": "Consolidated US channel lineup merged and de-duplicated from DIRECTV Premier, DISH Top 250, and Verizon FiOS.",
+  "source": "DIRECTV Premier + DISH Top 250 + Verizon FiOS",
+  "notes": "This lineup is a de-duplicated union of three US packages, renumbered with category-blocked numbering (News 100s, Sports 200s, and so on through Food & Travel 1600s).",
+  "categories": {
+    "News": [
+      {
+        "name": "ABC Localish",
+        "number": 101
+      },
+      {
+        "name": "ABC News Live",
+        "number": 102
+      },
+      {
+        "name": "AccuWeather",
+        "number": 103
+      },
+      {
+        "name": "BBC News",
+        "number": 104
+      },
+      {
+        "name": "BBC World News",
+        "number": 105
+      },
+      {
+        "name": "Bloomberg",
+        "number": 106
+      },
+      {
+        "name": "Bloomberg Television",
+        "number": 107
+      },
+      {
+        "name": "Bloomberg TV",
+        "number": 108
+      },
+      {
+        "name": "C-SPAN",
+        "number": 109
+      },
+      {
+        "name": "C-SPAN2",
+        "number": 110
+      },
+      {
+        "name": "CCTV News",
+        "number": 111
+      },
+      {
+        "name": "Cheddar News",
+        "number": 112
+      },
+      {
+        "name": "CNBC",
+        "number": 113
+      },
+      {
+        "name": "CNBC World",
+        "number": 114
+      },
+      {
+        "name": "CNN",
+        "number": 115
+      },
+      {
+        "name": "CNN En Español",
+        "number": 116
+      },
+      {
+        "name": "CNN International",
+        "number": 117
+      },
+      {
+        "name": "CNNi",
+        "number": 118
+      },
+      {
+        "name": "FOX Business Network",
+        "number": 119
+      },
+      {
+        "name": "Fox News",
+        "number": 120
+      },
+      {
+        "name": "FOX News Channel",
+        "number": 121
+      },
+      {
+        "name": "FOX Weather",
+        "number": 122
+      },
+      {
+        "name": "HLN",
+        "number": 123
+      },
+      {
+        "name": "HLN Headline News Network",
+        "number": 124
+      },
+      {
+        "name": "i24NEWS",
+        "number": 125
+      },
+      {
+        "name": "MS Now",
+        "number": 126
+      },
+      {
+        "name": "MSNBC",
+        "number": 127
+      },
+      {
+        "name": "NASA",
+        "number": 128
+      },
+      {
+        "name": "News Mix",
+        "number": 129
+      },
+      {
+        "name": "Newsmax",
+        "number": 130
+      },
+      {
+        "name": "NewsNation",
+        "number": 131
+      },
+      {
+        "name": "Russia Today",
+        "number": 132
+      },
+      {
+        "name": "Scripps News",
+        "number": 133
+      },
+      {
+        "name": "The First",
+        "number": 134
+      },
+      {
+        "name": "The Weather Channel",
+        "number": 135
+      },
+      {
+        "name": "WeatherNation",
+        "number": 137
+      },
+      {
+        "name": "Yahoo Finance",
+        "number": 138
+      }
+    ],
+    "Sports": [
+      {
+        "name": "ACC Digital Network",
+        "number": 201
+      },
+      {
+        "name": "ACC Network",
+        "number": 202
+      },
+      {
+        "name": "All Women's Sports",
+        "number": 203
+      },
+      {
+        "name": "beIN SPORT",
+        "number": 205
+      },
+      {
+        "name": "beIN Sports",
+        "number": 206
+      },
+      {
+        "name": "beIN SPORTS en Español",
+        "number": 207
+      },
+      {
+        "name": "beIN SPORTS XTRA",
+        "number": 208
+      },
+      {
+        "name": "Big 12",
+        "number": 209
+      },
+      {
+        "name": "Big Ten Network",
+        "number": 210
+      },
+      {
+        "name": "Billiard TV",
+        "number": 211
+      },
+      {
+        "name": "CBS Sports Network",
+        "number": 212
+      },
+      {
+        "name": "DAZN Ringside",
+        "number": 213
+      },
+      {
+        "name": "DIRECTV 4K Live 1",
+        "number": 214
+      },
+      {
+        "name": "DIRECTV 4K Live 2",
+        "number": 215
+      },
+      {
+        "name": "DraftKings",
+        "number": 216
+      },
+      {
+        "name": "Eleven Sports",
+        "number": 217
+      },
+      {
+        "name": "ESPN",
+        "number": 218
+      },
+      {
+        "name": "ESPN2",
+        "number": 220
+      },
+      {
+        "name": "ESPN8: The Ocho",
+        "number": 221
+      },
+      {
+        "name": "ESPNEWS",
+        "number": 222
+      },
+      {
+        "name": "ESPNU",
+        "number": 223
+      },
+      {
+        "name": "FanDuel TV",
+        "number": 224
+      },
+      {
+        "name": "Fight Network",
+        "number": 225
+      },
+      {
+        "name": "FOX Sports",
+        "number": 226
+      },
+      {
+        "name": "Fox Sports 1",
+        "number": 227
+      },
+      {
+        "name": "Fox Sports 2",
+        "number": 228
+      },
+      {
+        "name": "FS1",
+        "number": 229
+      },
+      {
+        "name": "FS2",
+        "number": 230
+      },
+      {
+        "name": "FUEL TV",
+        "number": 231
+      },
+      {
+        "name": "GOLF Channel",
+        "number": 232
+      },
+      {
+        "name": "GolfPass",
+        "number": 233
+      },
+      {
+        "name": "HerSphere",
+        "number": 234
+      },
+      {
+        "name": "League Sports Mix",
+        "number": 235
+      },
+      {
+        "name": "MLB Network",
+        "number": 237
+      },
+      {
+        "name": "MLB Network Strike Zone",
+        "number": 238
+      },
+      {
+        "name": "MLB Strike Zone",
+        "number": 239
+      },
+      {
+        "name": "NBA FAST Channel",
+        "number": 240
+      },
+      {
+        "name": "NBA League Pass",
+        "number": 241
+      },
+      {
+        "name": "NBA TV",
+        "number": 242
+      },
+      {
+        "name": "NBC Sports Now",
+        "number": 243
+      },
+      {
+        "name": "NBCSN",
+        "number": 244
+      },
+      {
+        "name": "NFL Network",
+        "number": 245
+      },
+      {
+        "name": "NFL RedZone",
+        "number": 246
+      },
+      {
+        "name": "NHL Network",
+        "number": 248
+      },
+      {
+        "name": "Olympic Channel",
+        "number": 249
+      },
+      {
+        "name": "Outside TV",
+        "number": 250
+      },
+      {
+        "name": "Pac-12 Network",
+        "number": 251
+      },
+      {
+        "name": "Pickleball TV",
+        "number": 252
+      },
+      {
+        "name": "Players TV",
+        "number": 253
+      },
+      {
+        "name": "PokerGO",
+        "number": 254
+      },
+      {
+        "name": "RACER Network",
+        "number": 255
+      },
+      {
+        "name": "Racing America",
+        "number": 256
+      },
+      {
+        "name": "Red Bull TV",
+        "number": 257
+      },
+      {
+        "name": "SEC Network",
+        "number": 258
+      },
+      {
+        "name": "Sports Illustrated",
+        "number": 259
+      },
+      {
+        "name": "Sports Mix",
+        "number": 260
+      },
+      {
+        "name": "SportsGrid",
+        "number": 261
+      },
+      {
+        "name": "Sportsman Channel",
+        "number": 262
+      },
+      {
+        "name": "Stadium Stream",
+        "number": 263
+      },
+      {
+        "name": "Surf Cinema",
+        "number": 264
+      },
+      {
+        "name": "Swerve Combat",
+        "number": 265
+      },
+      {
+        "name": "Tennis Channel",
+        "number": 266
+      },
+      {
+        "name": "Tennis Channel 2",
+        "number": 267
+      },
+      {
+        "name": "The Jim Rome Show",
+        "number": 269
+      },
+      {
+        "name": "TNA",
+        "number": 270
+      },
+      {
+        "name": "TUDN",
+        "number": 271
+      },
+      {
+        "name": "TV Games Network",
+        "number": 272
+      },
+      {
+        "name": "TVG2",
+        "number": 273
+      },
+      {
+        "name": "Willow Cricket",
+        "number": 274
+      },
+      {
+        "name": "Willow Sports",
+        "number": 275
+      },
+      {
+        "name": "WNBA on ION",
+        "number": 276
+      },
+      {
+        "name": "Women's Sports Network",
+        "number": 277
+      }
+    ],
+    "Regional Sports": [
+      {
+        "name": "Altitude Sports",
+        "number": 301
+      },
+      {
+        "name": "Big 10 Network",
+        "number": 302
+      },
+      {
+        "name": "Chicago Sports Network",
+        "number": 303
+      },
+      {
+        "name": "FanDuel Sports Cincinnati",
+        "number": 304
+      },
+      {
+        "name": "FanDuel Sports Detroit",
+        "number": 305
+      },
+      {
+        "name": "FanDuel Sports Florida",
+        "number": 306
+      },
+      {
+        "name": "FanDuel Sports Midwest",
+        "number": 307
+      },
+      {
+        "name": "FanDuel Sports North",
+        "number": 308
+      },
+      {
+        "name": "FanDuel Sports Ohio",
+        "number": 309
+      },
+      {
+        "name": "FanDuel Sports Oklahoma",
+        "number": 310
+      },
+      {
+        "name": "FanDuel Sports SoCal",
+        "number": 311
+      },
+      {
+        "name": "FanDuel Sports South",
+        "number": 312
+      },
+      {
+        "name": "FanDuel Sports Southeast",
+        "number": 313
+      },
+      {
+        "name": "FanDuel Sports Southwest",
+        "number": 314
+      },
+      {
+        "name": "FanDuel Sports Sun",
+        "number": 315
+      },
+      {
+        "name": "FanDuel Sports West",
+        "number": 316
+      },
+      {
+        "name": "FanDuel Sports Wisconsin",
+        "number": 317
+      },
+      {
+        "name": "Longhorn Network",
+        "number": 318
+      },
+      {
+        "name": "Marquee Sports Network",
+        "number": 319
+      },
+      {
+        "name": "MASN",
+        "number": 320
+      },
+      {
+        "name": "Monumental Sports Network",
+        "number": 321
+      },
+      {
+        "name": "MSG",
+        "number": 322
+      },
+      {
+        "name": "MSG Sportsnet",
+        "number": 323
+      },
+      {
+        "name": "NBA New Orleans Pelicans",
+        "number": 324
+      },
+      {
+        "name": "NBC Sports Bay Area",
+        "number": 325
+      },
+      {
+        "name": "NBC Sports Boston",
+        "number": 326
+      },
+      {
+        "name": "NBC Sports California",
+        "number": 327
+      },
+      {
+        "name": "NESN",
+        "number": 328
+      },
+      {
+        "name": "NESN National+",
+        "number": 329
+      },
+      {
+        "name": "NHL Network Alternate",
+        "number": 330
+      },
+      {
+        "name": "NHL Tampa Bay Lightning",
+        "number": 331
+      },
+      {
+        "name": "SNY",
+        "number": 333
+      },
+      {
+        "name": "Space City Home Network",
+        "number": 334
+      },
+      {
+        "name": "Spectrum SportsNet",
+        "number": 335
+      },
+      {
+        "name": "Spectrum SportsNet LA",
+        "number": 336
+      },
+      {
+        "name": "Sportsnet New York National",
+        "number": 337
+      },
+      {
+        "name": "SportsNet Pittsburgh",
+        "number": 338
+      },
+      {
+        "name": "YES National",
+        "number": 339
+      },
+      {
+        "name": "YES Network",
+        "number": 340
+      }
+    ],
+    "Movies": [
+      {
+        "name": "Action Max",
+        "number": 401
+      },
+      {
+        "name": "Cinemax",
+        "number": 402
+      },
+      {
+        "name": "Cinemax Action",
+        "number": 403
+      },
+      {
+        "name": "Cinemax Classics",
+        "number": 404
+      },
+      {
+        "name": "Cinemax East",
+        "number": 405
+      },
+      {
+        "name": "Cinemax Hits HD",
+        "number": 406
+      },
+      {
+        "name": "EPIX 1",
+        "number": 407
+      },
+      {
+        "name": "EPIX 2",
+        "number": 408
+      },
+      {
+        "name": "EPIX Drive-In",
+        "number": 409
+      },
+      {
+        "name": "EPIX Hits",
+        "number": 410
+      },
+      {
+        "name": "Family Movie Classics (FMC)",
+        "number": 411
+      },
+      {
+        "name": "Five Star Max",
+        "number": 412
+      },
+      {
+        "name": "FLIX",
+        "number": 413
+      },
+      {
+        "name": "FX Movie Channel",
+        "number": 414
+      },
+      {
+        "name": "FXM",
+        "number": 415
+      },
+      {
+        "name": "Hallmark Movies & Mysteries",
+        "number": 416
+      },
+      {
+        "name": "Hallmark Mystery",
+        "number": 417
+      },
+      {
+        "name": "HBO",
+        "number": 418
+      },
+      {
+        "name": "HBO 2",
+        "number": 419
+      },
+      {
+        "name": "HBO Comedy",
+        "number": 420
+      },
+      {
+        "name": "HBO Comedy East HD",
+        "number": 421
+      },
+      {
+        "name": "HBO Drama HD East",
+        "number": 422
+      },
+      {
+        "name": "HBO East",
+        "number": 423
+      },
+      {
+        "name": "HBO Family",
+        "number": 424
+      },
+      {
+        "name": "HBO Hits HD East",
+        "number": 425
+      },
+      {
+        "name": "HBO Latino",
+        "number": 426
+      },
+      {
+        "name": "HBO Movies HD",
+        "number": 427
+      },
+      {
+        "name": "HBO Signature",
+        "number": 428
+      },
+      {
+        "name": "HBO Zone",
+        "number": 429
+      },
+      {
+        "name": "HDNet Movies",
+        "number": 430
+      },
+      {
+        "name": "IndiePlex",
+        "number": 431
+      },
+      {
+        "name": "Lionsgate Collection",
+        "number": 432
+      },
+      {
+        "name": "MGM",
+        "number": 433
+      },
+      {
+        "name": "MGM+",
+        "number": 434
+      },
+      {
+        "name": "MGM+ Hits",
+        "number": 435
+      },
+      {
+        "name": "More Max",
+        "number": 436
+      },
+      {
+        "name": "Movie Favorites by Lifetime",
+        "number": 437
+      },
+      {
+        "name": "Movie Max",
+        "number": 438
+      },
+      {
+        "name": "MoviePlex",
+        "number": 439
+      },
+      {
+        "name": "MovieSphere",
+        "number": 440
+      },
+      {
+        "name": "MovieSphere Gold",
+        "number": 441
+      },
+      {
+        "name": "Outer Max",
+        "number": 442
+      },
+      {
+        "name": "Paramount+ with SHOWTIME",
+        "number": 443
+      },
+      {
+        "name": "Paramount+ with SHOWTIME EAST",
+        "number": 444
+      },
+      {
+        "name": "PixL",
+        "number": 445
+      },
+      {
+        "name": "RetroPlex",
+        "number": 446
+      },
+      {
+        "name": "SHO x BET",
+        "number": 447
+      },
+      {
+        "name": "ShortsTV",
+        "number": 448
+      },
+      {
+        "name": "Showtime (E)",
+        "number": 449
+      },
+      {
+        "name": "Showtime (W)",
+        "number": 450
+      },
+      {
+        "name": "Showtime 2",
+        "number": 451
+      },
+      {
+        "name": "SHOWTIME 2 East",
+        "number": 452
+      },
+      {
+        "name": "Showtime Beyond",
+        "number": 453
+      },
+      {
+        "name": "SHOWTIME EXTREME",
+        "number": 454
+      },
+      {
+        "name": "SHOWTIME Family Zone",
+        "number": 455
+      },
+      {
+        "name": "SHOWTIME Next",
+        "number": 456
+      },
+      {
+        "name": "SHOWTIME Showcase",
+        "number": 457
+      },
+      {
+        "name": "Sony Movie Channel",
+        "number": 458
+      },
+      {
+        "name": "STARZ",
+        "number": 459
+      },
+      {
+        "name": "STARZ (E)",
+        "number": 460
+      },
+      {
+        "name": "STARZ (W)",
+        "number": 461
+      },
+      {
+        "name": "STARZ Cinema",
+        "number": 462
+      },
+      {
+        "name": "STARZ Cinema East HD",
+        "number": 463
+      },
+      {
+        "name": "STARZ Comedy",
+        "number": 464
+      },
+      {
+        "name": "STARZ Comedy East HD",
+        "number": 465
+      },
+      {
+        "name": "STARZ Edge",
+        "number": 466
+      },
+      {
+        "name": "STARZ Edge East HD",
+        "number": 467
+      },
+      {
+        "name": "Starz Encore",
+        "number": 468
+      },
+      {
+        "name": "STARZ Encore (E)",
+        "number": 469
+      },
+      {
+        "name": "STARZ Encore (W)",
+        "number": 470
+      },
+      {
+        "name": "STARZ ENCORE Action",
+        "number": 471
+      },
+      {
+        "name": "STARZ ENCORE Black",
+        "number": 472
+      },
+      {
+        "name": "STARZ ENCORE Classic",
+        "number": 473
+      },
+      {
+        "name": "STARZ ENCORE East",
+        "number": 474
+      },
+      {
+        "name": "STARZ ENCORE Family",
+        "number": 475
+      },
+      {
+        "name": "STARZ ENCORE Suspense",
+        "number": 476
+      },
+      {
+        "name": "STARZ ENCORE West",
+        "number": 477
+      },
+      {
+        "name": "STARZ ENCORE Westerns",
+        "number": 478
+      },
+      {
+        "name": "STARZ In Black",
+        "number": 479
+      },
+      {
+        "name": "STARZ In Black East HD",
+        "number": 480
+      },
+      {
+        "name": "STARZ Kids & Family",
+        "number": 481
+      },
+      {
+        "name": "SundanceTV",
+        "number": 483
+      },
+      {
+        "name": "TCM",
+        "number": 484
+      },
+      {
+        "name": "The Movie Channel",
+        "number": 485
+      },
+      {
+        "name": "The Movie Channel (E)",
+        "number": 486
+      },
+      {
+        "name": "The Movie Channel (W)",
+        "number": 487
+      },
+      {
+        "name": "The Movie Channel Xtra",
+        "number": 488
+      },
+      {
+        "name": "The Movie Channel Xtra (E)",
+        "number": 489
+      },
+      {
+        "name": "Thriller Max",
+        "number": 490
+      },
+      {
+        "name": "Tribeca Festival+",
+        "number": 491
+      },
+      {
+        "name": "Turner Classic Movies",
+        "number": 492
+      }
+    ],
+    "Kids": [
+      {
+        "name": "Baby TV",
+        "number": 501
+      },
+      {
+        "name": "BabyFirst",
+        "number": 502
+      },
+      {
+        "name": "BabyFirstTV",
+        "number": 504
+      },
+      {
+        "name": "Boomerang",
+        "number": 505
+      },
+      {
+        "name": "Cartoon Network",
+        "number": 506
+      },
+      {
+        "name": "Cartoon Network (E)",
+        "number": 507
+      },
+      {
+        "name": "Cartoon Network (W)",
+        "number": 508
+      },
+      {
+        "name": "Cartoon Network East",
+        "number": 509
+      },
+      {
+        "name": "Disney Channel",
+        "number": 510
+      },
+      {
+        "name": "Disney Channel (E)",
+        "number": 511
+      },
+      {
+        "name": "Disney Channel (W)",
+        "number": 512
+      },
+      {
+        "name": "Disney Channel East",
+        "number": 513
+      },
+      {
+        "name": "Disney Junior",
+        "number": 514
+      },
+      {
+        "name": "Disney XD",
+        "number": 515
+      },
+      {
+        "name": "Kids Mix",
+        "number": 516
+      },
+      {
+        "name": "LooLooKids",
+        "number": 517
+      },
+      {
+        "name": "MeTV Toons",
+        "number": 518
+      },
+      {
+        "name": "Nick 2",
+        "number": 519
+      },
+      {
+        "name": "Nick Jr.",
+        "number": 520
+      },
+      {
+        "name": "Nick/Nick at Nite (E)",
+        "number": 522
+      },
+      {
+        "name": "Nick/Nick at Nite (W)",
+        "number": 523
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 524
+      },
+      {
+        "name": "Nickelodeon East",
+        "number": 525
+      },
+      {
+        "name": "Nicktoons",
+        "number": 526
+      },
+      {
+        "name": "PBS Kids",
+        "number": 527
+      },
+      {
+        "name": "TeenNick",
+        "number": 528
+      },
+      {
+        "name": "Yu-Gi-Oh!",
+        "number": 529
+      }
+    ],
+    "Entertainment": [
+      {
+        "name": "A&E",
+        "number": 601
+      },
+      {
+        "name": "AMC",
+        "number": 602
+      },
+      {
+        "name": "Aspire",
+        "number": 603
+      },
+      {
+        "name": "AXS TV",
+        "number": 604
+      },
+      {
+        "name": "BBC America",
+        "number": 605
+      },
+      {
+        "name": "BET",
+        "number": 606
+      },
+      {
+        "name": "BET Gospel",
+        "number": 607
+      },
+      {
+        "name": "BET Her",
+        "number": 608
+      },
+      {
+        "name": "BET Jams",
+        "number": 609
+      },
+      {
+        "name": "BET Soul",
+        "number": 610
+      },
+      {
+        "name": "Cleo TV",
+        "number": 611
+      },
+      {
+        "name": "Comet",
+        "number": 613
+      },
+      {
+        "name": "E!",
+        "number": 614
+      },
+      {
+        "name": "E! Entertainment Television",
+        "number": 615
+      },
+      {
+        "name": "EBONY TV",
+        "number": 616
+      },
+      {
+        "name": "FETV",
+        "number": 617
+      },
+      {
+        "name": "FOX Soul",
+        "number": 618
+      },
+      {
+        "name": "Freeform",
+        "number": 619
+      },
+      {
+        "name": "FX",
+        "number": 620
+      },
+      {
+        "name": "FXX",
+        "number": 621
+      },
+      {
+        "name": "FYI",
+        "number": 622
+      },
+      {
+        "name": "GET",
+        "number": 623
+      },
+      {
+        "name": "getTV",
+        "number": 624
+      },
+      {
+        "name": "GSN",
+        "number": 625
+      },
+      {
+        "name": "Hallmark Channel",
+        "number": 626
+      },
+      {
+        "name": "Hallmark Drama",
+        "number": 627
+      },
+      {
+        "name": "HBCU GO",
+        "number": 628
+      },
+      {
+        "name": "Heroes & Icons (H&I)",
+        "number": 629
+      },
+      {
+        "name": "IFC",
+        "number": 630
+      },
+      {
+        "name": "Ion",
+        "number": 631
+      },
+      {
+        "name": "ION East HD",
+        "number": 632
+      },
+      {
+        "name": "LAFF TV",
+        "number": 633
+      },
+      {
+        "name": "Lifetime",
+        "number": 634
+      },
+      {
+        "name": "Lifetime Movie Network",
+        "number": 635
+      },
+      {
+        "name": "LMN",
+        "number": 636
+      },
+      {
+        "name": "Logo",
+        "number": 637
+      },
+      {
+        "name": "Logo TV",
+        "number": 639
+      },
+      {
+        "name": "MeTV",
+        "number": 640
+      },
+      {
+        "name": "Ovation",
+        "number": 641
+      },
+      {
+        "name": "OWN: Oprah Winfrey Network",
+        "number": 642
+      },
+      {
+        "name": "Oxygen",
+        "number": 643
+      },
+      {
+        "name": "Paramount Network",
+        "number": 644
+      },
+      {
+        "name": "Pop",
+        "number": 645
+      },
+      {
+        "name": "Pop TV",
+        "number": 646
+      },
+      {
+        "name": "REELZ",
+        "number": 647
+      },
+      {
+        "name": "ReelzChannel",
+        "number": 648
+      },
+      {
+        "name": "Revolt",
+        "number": 649
+      },
+      {
+        "name": "Start TV",
+        "number": 650
+      },
+      {
+        "name": "StellarTV",
+        "number": 651
+      },
+      {
+        "name": "Syfy",
+        "number": 652
+      },
+      {
+        "name": "TBS",
+        "number": 653
+      },
+      {
+        "name": "The Walking Dead Universe",
+        "number": 654
+      },
+      {
+        "name": "TheGrio",
+        "number": 655
+      },
+      {
+        "name": "TNT",
+        "number": 656
+      },
+      {
+        "name": "True CRMZ",
+        "number": 657
+      },
+      {
+        "name": "TV Land",
+        "number": 658
+      },
+      {
+        "name": "TV One",
+        "number": 659
+      },
+      {
+        "name": "TV One (HD only)",
+        "number": 660
+      },
+      {
+        "name": "UP",
+        "number": 661
+      },
+      {
+        "name": "Uplifting Entertainment",
+        "number": 662
+      },
+      {
+        "name": "USA",
+        "number": 663
+      },
+      {
+        "name": "USA Network",
+        "number": 664
+      },
+      {
+        "name": "VICE",
+        "number": 665
+      },
+      {
+        "name": "Viceland",
+        "number": 666
+      },
+      {
+        "name": "WE tv",
+        "number": 667
+      },
+      {
+        "name": "WGN America",
+        "number": 668
+      }
+    ],
+    "Reality & Lifestyle": [
+      {
+        "name": "All Reality WeTV",
+        "number": 701
+      },
+      {
+        "name": "Bravo",
+        "number": 702
+      },
+      {
+        "name": "Bravo Vault",
+        "number": 703
+      },
+      {
+        "name": "BUZZ",
+        "number": 704
+      },
+      {
+        "name": "Dance Moms by Lifetime",
+        "number": 705
+      },
+      {
+        "name": "Deal Zone",
+        "number": 706
+      },
+      {
+        "name": "DIY",
+        "number": 707
+      },
+      {
+        "name": "E! Keeping Up",
+        "number": 708
+      },
+      {
+        "name": "EVINE Live",
+        "number": 709
+      },
+      {
+        "name": "HGTV",
+        "number": 710
+      },
+      {
+        "name": "Love After Lockup",
+        "number": 711
+      },
+      {
+        "name": "Magnolia Network",
+        "number": 712
+      },
+      {
+        "name": "Million Dollar Listing Vault",
+        "number": 713
+      },
+      {
+        "name": "OWN",
+        "number": 714
+      },
+      {
+        "name": "Real Housewives Vault",
+        "number": 715
+      },
+      {
+        "name": "Say Yes To The Dress",
+        "number": 716
+      },
+      {
+        "name": "The Design Network",
+        "number": 717
+      },
+      {
+        "name": "The Masked Singer",
+        "number": 718
+      },
+      {
+        "name": "The Pet Collective",
+        "number": 719
+      },
+      {
+        "name": "Tiny House Nation",
+        "number": 720
+      },
+      {
+        "name": "TLC",
+        "number": 721
+      },
+      {
+        "name": "UPTV",
+        "number": 722
+      }
+    ],
+    "Comedy": [
+      {
+        "name": "20/20",
+        "number": 801
+      },
+      {
+        "name": "Always Funny",
+        "number": 802
+      },
+      {
+        "name": "America's Funniest Home Videos",
+        "number": 803
+      },
+      {
+        "name": "Anger Management",
+        "number": 804
+      },
+      {
+        "name": "Are We There Yet",
+        "number": 805
+      },
+      {
+        "name": "BOUNCE TV",
+        "number": 806
+      },
+      {
+        "name": "Comedy Central",
+        "number": 807
+      },
+      {
+        "name": "Comedy Dynamics",
+        "number": 808
+      },
+      {
+        "name": "Comedy TV",
+        "number": 809
+      },
+      {
+        "name": "Cozi TV",
+        "number": 811
+      },
+      {
+        "name": "FailArmy",
+        "number": 812
+      },
+      {
+        "name": "Family Feud (Steve Harvey)",
+        "number": 813
+      },
+      {
+        "name": "Game Show Network",
+        "number": 814
+      },
+      {
+        "name": "GRIT",
+        "number": 815
+      },
+      {
+        "name": "INFAST",
+        "number": 816
+      },
+      {
+        "name": "Let's Make a Deal",
+        "number": 817
+      },
+      {
+        "name": "Portlandia",
+        "number": 818
+      },
+      {
+        "name": "SNL Vault",
+        "number": 819
+      },
+      {
+        "name": "Supermarket Sweep",
+        "number": 820
+      },
+      {
+        "name": "The Price is Right: Drew Carey",
+        "number": 821
+      },
+      {
+        "name": "The Price is Right: The Barker Era",
+        "number": 822
+      },
+      {
+        "name": "Three Stooges",
+        "number": 823
+      },
+      {
+        "name": "truTV",
+        "number": 824
+      }
+    ],
+    "Discovery": [
+      {
+        "name": "American Heroes Channel",
+        "number": 901
+      },
+      {
+        "name": "Animal Planet",
+        "number": 902
+      },
+      {
+        "name": "Ax Men",
+        "number": 903
+      },
+      {
+        "name": "Bizarre Foods with Andrew Zimmern",
+        "number": 904
+      },
+      {
+        "name": "Bob Ross",
+        "number": 905
+      },
+      {
+        "name": "Cosmic Frontiers",
+        "number": 906
+      },
+      {
+        "name": "Declassified",
+        "number": 907
+      },
+      {
+        "name": "Destination America",
+        "number": 908
+      },
+      {
+        "name": "Discovery",
+        "number": 909
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 910
+      },
+      {
+        "name": "Discovery Family",
+        "number": 911
+      },
+      {
+        "name": "Discovery Family Channel",
+        "number": 912
+      },
+      {
+        "name": "Discovery Life",
+        "number": 913
+      },
+      {
+        "name": "Documentary+",
+        "number": 914
+      },
+      {
+        "name": "Duck Dynasty",
+        "number": 915
+      },
+      {
+        "name": "Earth Touch",
+        "number": 916
+      },
+      {
+        "name": "EarthX",
+        "number": 917
+      },
+      {
+        "name": "Ghosts are Real",
+        "number": 918
+      },
+      {
+        "name": "History",
+        "number": 919
+      },
+      {
+        "name": "History & Warfare",
+        "number": 920
+      },
+      {
+        "name": "History Channel",
+        "number": 921
+      },
+      {
+        "name": "HISTORY Channel, The",
+        "number": 922
+      },
+      {
+        "name": "How To",
+        "number": 923
+      },
+      {
+        "name": "Ice Road Truckers",
+        "number": 924
+      },
+      {
+        "name": "INWONDER",
+        "number": 925
+      },
+      {
+        "name": "Love Nature",
+        "number": 926
+      },
+      {
+        "name": "MagellanTV Wildest",
+        "number": 927
+      },
+      {
+        "name": "Military Heroes",
+        "number": 928
+      },
+      {
+        "name": "Military History Channel",
+        "number": 929
+      },
+      {
+        "name": "Modern Marvels",
+        "number": 930
+      },
+      {
+        "name": "Motor Trend",
+        "number": 931
+      },
+      {
+        "name": "Mysterious Worlds",
+        "number": 932
+      },
+      {
+        "name": "Mythbusters",
+        "number": 933
+      },
+      {
+        "name": "Nat Geo WILD",
+        "number": 934
+      },
+      {
+        "name": "National Geographic",
+        "number": 935
+      },
+      {
+        "name": "National Geographic Channel",
+        "number": 936
+      },
+      {
+        "name": "Science",
+        "number": 937
+      },
+      {
+        "name": "Smithsonian Channel",
+        "number": 938
+      },
+      {
+        "name": "Torque by History",
+        "number": 939
+      },
+      {
+        "name": "UnXplained Zone",
+        "number": 940
+      }
+    ],
+    "Crime": [
+      {
+        "name": "Cold Case Files",
+        "number": 1001
+      },
+      {
+        "name": "Confess by Nosey",
+        "number": 1002
+      },
+      {
+        "name": "Court TV",
+        "number": 1003
+      },
+      {
+        "name": "Crime & Investigation",
+        "number": 1004
+      },
+      {
+        "name": "Crime & Investigation Network",
+        "number": 1005
+      },
+      {
+        "name": "Crime 360",
+        "number": 1006
+      },
+      {
+        "name": "Crime Scenes",
+        "number": 1007
+      },
+      {
+        "name": "DangerTV",
+        "number": 1008
+      },
+      {
+        "name": "I (Almost) Got Away With It",
+        "number": 1009
+      },
+      {
+        "name": "Investigation Discovery",
+        "number": 1010
+      },
+      {
+        "name": "Justice Central",
+        "number": 1011
+      },
+      {
+        "name": "Justice Network",
+        "number": 1012
+      },
+      {
+        "name": "JusticeCentral.TV",
+        "number": 1013
+      },
+      {
+        "name": "Law & Crime Network",
+        "number": 1014
+      },
+      {
+        "name": "Living With Evil",
+        "number": 1015
+      },
+      {
+        "name": "Love Kills",
+        "number": 1016
+      },
+      {
+        "name": "Nosey",
+        "number": 1017
+      },
+      {
+        "name": "Oxygen True Crime",
+        "number": 1018
+      },
+      {
+        "name": "Oxygen True Crime Archives",
+        "number": 1019
+      },
+      {
+        "name": "Total Crime",
+        "number": 1020
+      },
+      {
+        "name": "True Crime Now",
+        "number": 1021
+      }
+    ],
+    "Faith": [
+      {
+        "name": "Christian Television Network",
+        "number": 1101
+      },
+      {
+        "name": "Daystar",
+        "number": 1102
+      },
+      {
+        "name": "Dove TV",
+        "number": 1103
+      },
+      {
+        "name": "EWTN",
+        "number": 1104
+      },
+      {
+        "name": "Hillsong Channel",
+        "number": 1105
+      },
+      {
+        "name": "Impact Network",
+        "number": 1106
+      },
+      {
+        "name": "INSP",
+        "number": 1107
+      },
+      {
+        "name": "Joel Osteen",
+        "number": 1108
+      },
+      {
+        "name": "Living Faith Network HD",
+        "number": 1109
+      },
+      {
+        "name": "PTL TV",
+        "number": 1110
+      },
+      {
+        "name": "Pureflix TV",
+        "number": 1111
+      },
+      {
+        "name": "Scientology Network",
+        "number": 1112
+      },
+      {
+        "name": "Shepherd's Chapel Network",
+        "number": 1113
+      },
+      {
+        "name": "SonLife Broadcasting Network",
+        "number": 1114
+      },
+      {
+        "name": "TBN",
+        "number": 1115
+      },
+      {
+        "name": "The Word",
+        "number": 1118
+      },
+      {
+        "name": "Three Angels Broadcasting Network",
+        "number": 1120
+      },
+      {
+        "name": "Victory",
+        "number": 1121
+      }
+    ],
+    "Music": [
+      {
+        "name": "CMT",
+        "number": 1201
+      },
+      {
+        "name": "CMT Music",
+        "number": 1202
+      },
+      {
+        "name": "FM",
+        "number": 1204
+      },
+      {
+        "name": "Fuse",
+        "number": 1205
+      },
+      {
+        "name": "MTV",
+        "number": 1206
+      },
+      {
+        "name": "MTV Classic",
+        "number": 1207
+      },
+      {
+        "name": "MTV Live",
+        "number": 1208
+      },
+      {
+        "name": "MTV2",
+        "number": 1209
+      },
+      {
+        "name": "mtvU",
+        "number": 1210
+      },
+      {
+        "name": "Music Choice",
+        "number": 1211
+      },
+      {
+        "name": "NickMusic",
+        "number": 1212
+      },
+      {
+        "name": "VH1",
+        "number": 1215
+      }
+    ],
+    "Shopping": [
+      {
+        "name": "BeautyIQ",
+        "number": 1301
+      },
+      {
+        "name": "Gem Shopping Network",
+        "number": 1302
+      },
+      {
+        "name": "HSN",
+        "number": 1303
+      },
+      {
+        "name": "HSN2",
+        "number": 1304
+      },
+      {
+        "name": "Jewelry Television",
+        "number": 1305
+      },
+      {
+        "name": "Jewelry TV",
+        "number": 1306
+      },
+      {
+        "name": "QVC",
+        "number": 1307
+      },
+      {
+        "name": "QVC 2",
+        "number": 1308
+      },
+      {
+        "name": "QVC 3",
+        "number": 1309
+      },
+      {
+        "name": "Sale",
+        "number": 1312
+      },
+      {
+        "name": "ShopLC",
+        "number": 1314
+      }
+    ],
+    "Spanish": [
+      {
+        "name": "Antena 3",
+        "number": 1401
+      },
+      {
+        "name": "Canal SUR",
+        "number": 1402
+      },
+      {
+        "name": "Caracol TV",
+        "number": 1403
+      },
+      {
+        "name": "CCTV-E",
+        "number": 1404
+      },
+      {
+        "name": "De Película",
+        "number": 1405
+      },
+      {
+        "name": "Discovery En Español",
+        "number": 1406
+      },
+      {
+        "name": "Discovery Familia",
+        "number": 1407
+      },
+      {
+        "name": "Enlace",
+        "number": 1408
+      },
+      {
+        "name": "ESPN Deportes",
+        "number": 1409
+      },
+      {
+        "name": "Estrella TV",
+        "number": 1410
+      },
+      {
+        "name": "Fox Deportes",
+        "number": 1411
+      },
+      {
+        "name": "Galavisión",
+        "number": 1413
+      },
+      {
+        "name": "HITN",
+        "number": 1414
+      },
+      {
+        "name": "MAX Latino",
+        "number": 1415
+      },
+      {
+        "name": "Nat Geo Mundo",
+        "number": 1416
+      },
+      {
+        "name": "NBC Universo",
+        "number": 1417
+      },
+      {
+        "name": "Somos Novelas",
+        "number": 1418
+      },
+      {
+        "name": "Starz Encore Español",
+        "number": 1419
+      },
+      {
+        "name": "Telemicro Internacional",
+        "number": 1420
+      },
+      {
+        "name": "Telemundo",
+        "number": 1421
+      },
+      {
+        "name": "TVE Internacional",
+        "number": 1422
+      },
+      {
+        "name": "UniMás",
+        "number": 1424
+      },
+      {
+        "name": "UNIVERSO",
+        "number": 1425
+      },
+      {
+        "name": "Univision (Este)",
+        "number": 1426
+      },
+      {
+        "name": "Univision Deportes",
+        "number": 1427
+      },
+      {
+        "name": "Univision East",
+        "number": 1428
+      },
+      {
+        "name": "Univision tINovelas",
+        "number": 1429
+      },
+      {
+        "name": "Univision West",
+        "number": 1430
+      },
+      {
+        "name": "V-ME",
+        "number": 1431
+      }
+    ],
+    "Outdoors": [
+      {
+        "name": "Cars TV",
+        "number": 1501
+      },
+      {
+        "name": "Dog Whisperer",
+        "number": 1503
+      },
+      {
+        "name": "Drool",
+        "number": 1504
+      },
+      {
+        "name": "GoTraveler",
+        "number": 1505
+      },
+      {
+        "name": "Great American Adventures",
+        "number": 1506
+      },
+      {
+        "name": "Great American Country",
+        "number": 1507
+      },
+      {
+        "name": "Great American Family",
+        "number": 1508
+      },
+      {
+        "name": "In Country Television",
+        "number": 1509
+      },
+      {
+        "name": "MAV TV",
+        "number": 1510
+      },
+      {
+        "name": "MeatEater",
+        "number": 1511
+      },
+      {
+        "name": "MyDestination TV",
+        "number": 1513
+      },
+      {
+        "name": "Outdoor Channel",
+        "number": 1514
+      },
+      {
+        "name": "Pets.TV",
+        "number": 1515
+      },
+      {
+        "name": "Pursuit",
+        "number": 1516
+      },
+      {
+        "name": "Pursuit Channel",
+        "number": 1517
+      },
+      {
+        "name": "Pursuit UP",
+        "number": 1518
+      },
+      {
+        "name": "RECTV",
+        "number": 1519
+      },
+      {
+        "name": "RFD-TV",
+        "number": 1520
+      },
+      {
+        "name": "Ride TV",
+        "number": 1521
+      },
+      {
+        "name": "Rig TV",
+        "number": 1522
+      },
+      {
+        "name": "RVTV",
+        "number": 1523
+      },
+      {
+        "name": "Speedvision",
+        "number": 1524
+      },
+      {
+        "name": "Sweet Escapes",
+        "number": 1525
+      },
+      {
+        "name": "The Cowboy Channel",
+        "number": 1526
+      },
+      {
+        "name": "Travel Channel",
+        "number": 1527
+      },
+      {
+        "name": "Waypoint TV",
+        "number": 1528
+      },
+      {
+        "name": "WIRED2fish TV",
+        "number": 1529
+      },
+      {
+        "name": "World Fishing Network",
+        "number": 1530
+      }
+    ],
+    "Food & Travel": [
+      {
+        "name": "America's Test Kitchen",
+        "number": 1601
+      },
+      {
+        "name": "Cooking Channel",
+        "number": 1602
+      },
+      {
+        "name": "Food Network",
+        "number": 1603
+      },
+      {
+        "name": "Gusto TV",
+        "number": 1604
+      },
+      {
+        "name": "Jamie Oliver",
+        "number": 1605
+      },
+      {
+        "name": "Recipe TV",
+        "number": 1606
+      },
+      {
+        "name": "Tastemade",
+        "number": 1607
+      },
+      {
+        "name": "Tastemade Home",
+        "number": 1608
+      },
+      {
+        "name": "Tastemade Travel",
+        "number": 1609
+      },
+      {
+        "name": "Z Living",
+        "number": 1610
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/fuzzy_matcher.py
+++ b/plugins/lineuparr/fuzzy_matcher.py
@@ -10,7 +10,7 @@ import re
 import logging
 import unicodedata
 
-__version__ = "1.0.0"
+__version__ = "1.3.1"
 
 LOGGER = logging.getLogger("plugins.lineuparr.fuzzy_matcher")
 if not LOGGER.handlers:
@@ -52,6 +52,11 @@ GEOGRAPHIC_PATTERNS = [
 # Enhanced provider prefix patterns for IPTV-specific naming
 PROVIDER_PREFIX_PATTERNS = [
     r'^(?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\s*[:\-\|]\s*',
+    # Bare country tag + whitespace, no separator (e.g. "US Racer Network").
+    # Restricted to the 2-letter US/UK/CA/AU codes so it cannot eat a real
+    # channel name: "USA Network" (USA != US + space) and "In Country
+    # Television" ("IN") are both safe from this pattern.
+    r'^(?:US|UK|CA|AU)\s+',
     r'^\s*\((?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\)\s*',
     r'\s*\|\s*(?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\s*$',
 ]
@@ -83,12 +88,15 @@ _PLUTO_COUNTRY_MAP = {
     # "LATIN"/"EUROPE" etc. intentionally omitted — ambiguous region.
 }
 
-# Country pairs that share enough cross-border channels (CBS, ABC, ESPN, A&E,
-# TSN, etc.) that users consider them interchangeable. A US lineup should still
-# accept a `(CA) ESPN` stream and vice versa.
+# Country pairs that share enough cross-border channels that users consider
+# them interchangeable. US<->CA share CBS/ABC/ESPN/A&E/TSN etc.; US<->MX share
+# the US Spanish-language networks (Univision, Telemundo, Galavision, NBC
+# Universo), whose M3U feeds are frequently tagged MEX. A US lineup should
+# accept a `(CA) ESPN` or `MEX: Galavision` stream, and vice versa.
 _COMPATIBLE_COUNTRIES = {
-    "US": {"CA"},
+    "US": {"CA", "MX"},
     "CA": {"US"},
+    "MX": {"US"},
 }
 
 
@@ -145,6 +153,8 @@ class FuzzyMatcher:
         # match_all_streams calls. Callers reset this before a matching loop
         # and read it after, so they can log a summary.
         self.country_filter_drops = 0
+        # Cache for callsign extraction: raw_name -> (callsign|None, is_high_conf)
+        self._callsign_cache = {}
 
     def precompute_normalizations(self, names, user_ignored_tags=None):
         """
@@ -155,6 +165,7 @@ class FuzzyMatcher:
         self._norm_cache.clear()
         self._norm_nospace_cache.clear()
         self._processed_cache.clear()
+        self._callsign_cache.clear()
 
         for name in names:
             norm = self.normalize_name(name, user_ignored_tags)
@@ -206,6 +217,17 @@ class FuzzyMatcher:
 
         # Normalize hyphens to spaces
         name = re.sub(r'-', ' ', name)
+
+        # Preserve parenthesized East/West -- and the (E)/(W) abbreviations --
+        # as bare words so they survive both the leading-parenthetical strip
+        # below and the generic parenthetical strip (MISC_PATTERNS). Bare
+        # "East"/"West" are intentionally kept (they distinguish separate
+        # feeds); the parenthesized forms must be kept too, or a zoned lineup
+        # channel cannot match a zoned stream (e.g. "Cartoon Network (W)" vs
+        # "US: Cartoon Network West"). Only E/W are converted -- the other
+        # single letters (A/S/H/F/X/D) are stream source/quality tags.
+        name = re.sub(r'\(\s*(?:east|e)\s*\)', ' East ', name, flags=re.IGNORECASE)
+        name = re.sub(r'\(\s*(?:west|w)\s*\)', ' West ', name, flags=re.IGNORECASE)
 
         # Remove leading parenthetical prefixes
         while name.lstrip().startswith('('):
@@ -354,6 +376,16 @@ class FuzzyMatcher:
         tokens = sorted([token for token in cleaned_s.split() if token])
         return " ".join(tokens)
 
+    @staticmethod
+    def _trailing_number(name):
+        """Return the integer value of a space-separated, purely-numeric
+        trailing token, or None. 'HBO 2' -> 2, 'DIRECTV 4K Live 1' -> 1,
+        'ESPN' -> None, 'ESPN2' -> None (digit not space-separated). Used to
+        reject 'Foo 1' vs 'Foo 2' false positives -- different channels that
+        otherwise fuzzy-match almost perfectly."""
+        m = re.search(r'(?:^|\s)(\d{1,4})\s*$', name or "")
+        return int(m.group(1)) if m else None
+
     def _channel_number_boost(self, stream_name, expected_number):
         """
         Check if a stream name contains the expected channel number.
@@ -370,6 +402,96 @@ class FuzzyMatcher:
         if re.search(r'(?:^|[\s\[\(])' + re.escape(number_str) + r'(?:$|[\s\]\)])', stream_name):
             return 5
         return 0
+
+    # Words that match the callsign regex shape but are never US broadcast
+    # callsigns. A US callsign (K/W + 2-4 letters) is shape-identical to many
+    # common English words, so the loose Priority-4 pattern mis-extracts them —
+    # e.g. "with" in "Bizarre Foods with Andrew Zimmern" becomes callsign
+    # "WITH". Regex alone cannot tell "WITH" from "WABC"; frequent K/W-initial
+    # words are denied explicitly so they never extract as a callsign. WWE/WWF/
+    # WCW stop wrestling show names extracting as false-positive callsigns.
+    _CALLSIGN_DENYLIST = frozenset({
+        'WWE', 'WWF', 'WCW', 'EAST',
+        'WAR', 'WARS', 'WARM', 'WASH', 'WATCH', 'WAVE', 'WAVES', 'WAY', 'WAYS',
+        'WEB', 'WEEK', 'WELL', 'WENT', 'WERE', 'WEST', 'WHAT', 'WHEN', 'WHERE',
+        'WHICH', 'WHILE', 'WHITE', 'WHO', 'WHY', 'WIDE', 'WIFE', 'WILD', 'WILL',
+        'WIND', 'WINE', 'WING', 'WINGS', 'WINS', 'WIRE', 'WISE', 'WISH', 'WITH',
+        'WOLF', 'WOMAN', 'WOMEN', 'WOOD', 'WORD', 'WORDS', 'WORK', 'WORKS',
+        'WORLD', 'WORM', 'WORN', 'WRAP',
+        'KEEN', 'KEEP', 'KEPT', 'KEY', 'KEYS', 'KICK', 'KID', 'KIDS', 'KILL',
+        'KIND', 'KING', 'KINGS', 'KISS', 'KITE', 'KNEE', 'KNEW', 'KNOW', 'KNOWN',
+    })
+
+    def _compute_callsign_with_confidence(self, channel_name):
+        """
+        Extract US TV callsign with a confidence flag.
+
+        Returns (callsign, is_high_confidence). High confidence =
+        Priorities 1-3 (parenthesized / suffixed-paren / end-of-name).
+        Priority 4 (any loose word) is low confidence. (None, False)
+        when nothing extractable.
+        """
+        # Remove common provider prefixes
+        channel_name = re.sub(r'^D\d+-', '', channel_name)
+        channel_name = re.sub(r'^USA?\s*[^a-zA-Z0-9]*\s*', '', channel_name, flags=re.IGNORECASE)
+
+        # Priority 1: Callsigns in parentheses (most reliable)
+        paren_match = re.search(r'\(([KW][A-Z]{3})(?:-[A-Z\s]+)?\)', channel_name, re.IGNORECASE)
+        if paren_match:
+            callsign = paren_match.group(1).upper()
+            if callsign not in self._CALLSIGN_DENYLIST:
+                return callsign, True
+
+        # Priority 2: Callsigns with suffix in parentheses
+        paren_suffix_match = re.search(r'\(([KW][A-Z]{2,4}-(?:TV|CD|LP|DT|LD))\)', channel_name, re.IGNORECASE)
+        if paren_suffix_match:
+            return paren_suffix_match.group(1).upper(), True
+
+        # Priority 3: Callsigns at the end
+        end_match = re.search(r'\b([KW][A-Z]{2,4}(?:-(?:TV|CD|LP|DT|LD))?)\s*(?:\.[a-z]+)?\s*$', channel_name, re.IGNORECASE)
+        if end_match:
+            callsign = end_match.group(1).upper()
+            if callsign not in self._CALLSIGN_DENYLIST:
+                return callsign, True
+
+        # Priority 4: Any word matching callsign pattern (low confidence)
+        word_match = re.search(r'\b([KW][A-Z]{2,4}(?:-(?:TV|CD|LP|DT|LD))?)\b', channel_name, re.IGNORECASE)
+        if word_match:
+            callsign = word_match.group(1).upper()
+            if callsign not in self._CALLSIGN_DENYLIST:
+                return callsign, False
+
+        return None, False
+
+    def _extract_callsign_with_confidence(self, channel_name):
+        """
+        Cached wrapper around _compute_callsign_with_confidence.
+
+        Extraction is pure in channel_name, so results are memoized — the
+        anchor calls this once per stream over a fixed candidate list, which
+        is otherwise massively redundant across the per-channel matching
+        loop. Cache is cleared by precompute_normalizations.
+        """
+        cached = self._callsign_cache.get(channel_name)
+        if cached is not None:
+            return cached
+        result = self._compute_callsign_with_confidence(channel_name)
+        self._callsign_cache[channel_name] = result
+        return result
+
+    def extract_callsign(self, channel_name):
+        """
+        Extract US TV callsign from channel name with priority order.
+        Returns None if common false positives appear alone.
+        """
+        callsign, _ = self._extract_callsign_with_confidence(channel_name)
+        return callsign
+
+    def normalize_callsign(self, callsign):
+        """Remove the broadcast suffix (-TV/-CD/-LP/-DT/-LD) from a callsign."""
+        if callsign:
+            callsign = re.sub(r'-(?:TV|CD|LP|DT|LD)$', '', callsign)
+        return callsign
 
     def alias_match(self, lineup_name, candidate_names, alias_map, user_ignored_tags=None):
         """
@@ -573,6 +695,13 @@ class FuzzyMatcher:
         if user_ignored_tags is None:
             user_ignored_tags = []
 
+        # Callsign anchor (asymmetric): extract the lineup channel's US
+        # broadcast callsign up front. Used after the fuzzy stages to floor
+        # high-confidence callsign agreement and hard-reject disagreement.
+        query_callsign, query_cs_hc = self._extract_callsign_with_confidence(lineup_name or "")
+        query_callsign_norm = self.normalize_callsign(query_callsign) if query_callsign else None
+        callsign_anchored = set()  # candidate names exempt from the region filter
+
         all_matches = {}  # stream_name -> (score, match_type)
 
         # Stage 0: Alias matching
@@ -588,6 +717,10 @@ class FuzzyMatcher:
             normalized_query_lower = normalized_query.lower()
             normalized_query_nospace = re.sub(r'[\s&\-]+', '', normalized_query_lower)
             processed_query = self.process_string_for_matching(normalized_query)
+            # A differing space-separated trailing number means a different
+            # channel ("DIRECTV 4K Live 1" vs "... Live 2") -- used to skip
+            # those near-identical false positives in the fuzzy stages below.
+            query_trailing_num = self._trailing_number(normalized_query_lower)
 
             for candidate in candidate_names:
                 if candidate in all_matches:
@@ -597,6 +730,11 @@ class FuzzyMatcher:
                 candidate_lower, candidate_nospace = self._get_cached_norm(candidate, user_ignored_tags)
                 if not candidate_lower:
                     continue
+
+                if query_trailing_num is not None:
+                    cand_trailing_num = self._trailing_number(candidate_lower)
+                    if cand_trailing_num is not None and cand_trailing_num != query_trailing_num:
+                        continue  # "Foo 1" vs "Foo 2" -- different channel
 
                 score = 0
                 mtype = None
@@ -641,6 +779,26 @@ class FuzzyMatcher:
                     boost = self._channel_number_boost(candidate, channel_number)
                     all_matches[candidate] = (min(score + boost, 100), mtype)
 
+        # Callsign anchor: a shared high-confidence callsign rescues an
+        # otherwise-unmatched stream (floored at 95) and a disagreeing one
+        # hard-rejects a false positive. BOTH the floor and the reject require
+        # BOTH callsigns to be high-confidence (parenthesized or end-of-name).
+        # A loose mid-name word that merely has callsign shape (e.g. "WITH")
+        # is not a reliable callsign and must not floor or reject.
+        if query_callsign_norm and query_cs_hc:
+            for candidate in candidate_names:
+                cand_cs, cand_hc = self._extract_callsign_with_confidence(candidate)
+                if not cand_cs or not cand_hc:
+                    continue
+                if self.normalize_callsign(cand_cs) == query_callsign_norm:
+                    existing = all_matches.get(candidate)
+                    if existing is None or existing[0] < 95:
+                        all_matches[candidate] = (95, "callsign")
+                    callsign_anchored.add(candidate)
+                else:
+                    # High-confidence callsign disagreement → hard reject.
+                    all_matches.pop(candidate, None)
+
         # Filter out wrong-country matches. A stream whose name carries a
         # recognized country marker (e.g. "UK: Discovery Channel", "(IN) Bloomberg",
         # "(PLUTO Brazil) MTV") and that marker differs from the lineup's country
@@ -665,8 +823,9 @@ class FuzzyMatcher:
 
         # Filter out wrong-region matches (East vs West vs Pacific)
         # Check both normalized query AND original name for regional indicators.
-        # normalize_name strips parentheticals like (E)/(W) before we get here,
-        # so we must detect abbreviated regional suffixes from the original name.
+        # normalize_name converts (E)/(W) to bare East/West and strips other
+        # parentheticals, so detect abbreviated regional suffixes (incl. the
+        # Pacific (P) abbreviation it does drop) from the original name.
         query_lower = (normalized_query or "").lower()
         original_lower = (lineup_name or "").lower()
         # Detect (e)/(w)/(p) abbreviations in the original name
@@ -684,6 +843,9 @@ class FuzzyMatcher:
         if query_has_east or query_has_west or query_has_pacific:
             filtered = {}
             for stream_name, (score, mtype) in all_matches.items():
+                if stream_name in callsign_anchored:
+                    filtered[stream_name] = (score, mtype)
+                    continue
                 sn_lower = stream_name.lower()
                 stream_has_east = "east" in sn_lower
                 stream_has_west = "west" in sn_lower and "western" not in sn_lower
@@ -718,6 +880,9 @@ class FuzzyMatcher:
             # Regionless channel: prefer regionless EPG entries, reject Pacific/West
             filtered = {}
             for stream_name, (score, mtype) in all_matches.items():
+                if stream_name in callsign_anchored:
+                    filtered[stream_name] = (score, mtype)
+                    continue
                 sn_lower = stream_name.lower()
                 stream_has_pacific = "pacific" in sn_lower
                 stream_has_west = "west" in sn_lower and "western" not in sn_lower

--- a/plugins/lineuparr/plugin.json
+++ b/plugins/lineuparr/plugin.json
@@ -1,120 +1,27 @@
 {
   "name": "Lineuparr",
-  "version": "1.26.1370103",
+  "version": "1.26.1421711",
   "description": "Mirror real-world provider channel lineups by creating channel groups, channels, and fuzzy-matching IPTV streams to them.",
   "author": "PiratesIRC",
   "license": "MIT",
   "repo_url": "https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin",
   "min_dispatcharr_version": "v0.20.0",
-  "fields": [
-    {
-      "id": "lineup_file",
-      "label": "Lineup File",
-      "type": "string",
-      "default": "US_DirecTV-Premier_lineup.json"
-    },
-    {
-      "id": "m3u_sources",
-      "label": "M3U Source",
-      "type": "string",
-      "default": ""
-    },
-    {
-      "id": "channel_profiles",
-      "label": "Channel Profile",
-      "type": "string",
-      "default": ""
-    },
-    {
-      "id": "group_prefix",
-      "label": "Channel Group Prefix",
-      "type": "string",
-      "default": ""
-    },
-    {
-      "id": "match_sensitivity",
-      "label": "Match Sensitivity",
-      "type": "select",
-      "default": "normal",
-      "options": [
-        { "value": "relaxed", "label": "Relaxed \u2014 more matches, more false positives" },
-        { "value": "normal", "label": "Normal \u2014 balanced" },
-        { "value": "strict", "label": "Strict \u2014 fewer matches, high confidence" },
-        { "value": "exact", "label": "Exact \u2014 near-exact matches only" }
-      ]
-    },
-    {
-      "id": "channel_numbering",
-      "label": "Channel Numbering",
-      "type": "select",
-      "default": "lineup",
-      "options": [
-        { "value": "lineup", "label": "Use Channel Database Numbers" },
-        { "value": "auto_next", "label": "Auto-Assign Next Available" },
-        { "value": "auto_highest", "label": "Auto-Assign After Highest" },
-        { "value": "specific", "label": "Use Specific Number" }
-      ]
-    },
-    {
-      "id": "starting_channel_number",
-      "label": "Starting Channel Number",
-      "type": "string",
-      "default": ""
-    },
-    {
-      "id": "prioritize_quality",
-      "label": "\u2b50 Order Matched Streams by Quality",
-      "type": "boolean",
-      "default": true
-    },
-    {
-      "id": "preserve_existing_streams",
-      "label": "\u267b Preserve Existing Streams",
-      "type": "boolean",
-      "default": false,
-      "help_text": "When on, newly matched streams are appended to channels without deleting existing streams, duplicates are skipped, and unmatched channels are not deleted. Use this to add a second M3U source non-destructively."
-    },
-    {
-      "id": "single_channel_name",
-      "label": "\u2316 Single Channel Match",
-      "type": "string",
-      "default": "",
-      "help_text": "When set, Preview Stream Match, Apply Stream Match, Apply EPG Match, and Assign Logos operate ONLY on the lineup channel(s) whose name equals this value (case-insensitive). Leave blank to process the whole lineup. Full Sync ignores this setting."
-    },
-    {
-      "id": "rate_limiting",
-      "label": "\u23f3 Rate Limiting",
-      "type": "select",
-      "default": "none",
-      "options": [
-        { "value": "none", "label": "None \u2014 fastest" },
-        { "value": "low", "label": "Low \u2014 slight delay" },
-        { "value": "medium", "label": "Medium \u2014 moderate delay" },
-        { "value": "high", "label": "High \u2014 slowest, gentlest on API" }
-      ]
-    },
-    {
-      "id": "custom_aliases",
-      "label": "Custom Channel Aliases (JSON)",
-      "type": "string",
-      "default": ""
-    },
-    {
-      "id": "epg_sources",
-      "label": "EPG Sources",
-      "type": "select",
-      "default": "_all",
-      "options": [
-        { "value": "_all", "label": "All EPG sources" }
-      ]
-    }
-  ],
+  "_fields_note": "Settings fields are defined dynamically by the Plugin.fields property in plugin.py (the single source of truth \u2014 it builds live dropdowns for lineups, M3U/EPG sources and profiles). Dispatcharr only falls back to a manifest 'fields' array when the plugin provides none, so it is intentionally omitted here to prevent drift.",
+  "fields": [],
   "actions": [
     {
       "id": "validate_settings",
       "label": "Validate Settings",
       "button_label": "\u2705 Validate",
       "description": "Check all settings, show lineup summary and available profiles",
+      "button_variant": "outline",
+      "button_color": "blue"
+    },
+    {
+      "id": "plugin_status",
+      "label": "Show Status",
+      "button_label": "📊 Status",
+      "description": "Show progress of the current operation, or the result of the last one, without checking the logs",
       "button_variant": "outline",
       "button_color": "blue"
     },

--- a/plugins/lineuparr/plugin.py
+++ b/plugins/lineuparr/plugin.py
@@ -19,6 +19,7 @@ from django.db import transaction
 
 from .fuzzy_matcher import FuzzyMatcher
 from .aliases import CHANNEL_ALIASES
+from .progress_status import save_progress_atomic, load_progress, build_status_message
 
 from apps.channels.models import Channel, ChannelGroup, ChannelProfile, ChannelProfileMembership, ChannelStream, Stream
 from apps.m3u.models import M3UAccount
@@ -62,7 +63,7 @@ def _clean_json_text(s):
 
 
 class PluginConfig:
-    PLUGIN_VERSION = "1.26.1370103"
+    PLUGIN_VERSION = "1.26.1421711"
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True
@@ -103,6 +104,7 @@ class PluginConfig:
     DATA_DIR = "/data"
     EXPORTS_DIR = "/data/exports"
     STATE_FILE = "/data/lineuparr_state.json"
+    PROGRESS_FILE = "/data/lineuparr_progress.json"
     OPERATION_LOCK_FILE = "/data/lineuparr_operation.lock"
     OPERATION_LOCK_TIMEOUT_MINUTES = 10
 
@@ -155,6 +157,7 @@ class ProgressTracker:
             "type": "plugin", "plugin": "Lineuparr",
             "message": f"🔄 {action_id}: Starting ({total_items} items)"
         })
+        self._publish("running")
 
     def update(self, items_processed=1):
         self.processed_items += items_processed
@@ -170,8 +173,9 @@ class ProgressTracker:
                 "type": "plugin", "plugin": "Lineuparr",
                 "message": f"🔄 {self.action_id}: {pct:.0f}% ({self.processed_items}/{self.total_items}) - ⏱️ ETA: {eta_str}"
             })
+            self._publish("running")
 
-    def finish(self):
+    def finish(self, summary=None):
         elapsed = time.time() - self.start_time
         eta_str = self._format_eta(elapsed)
         self.logger.info(f"{LOG_PREFIX} [{self.action_id}] Complete: {self.processed_items}/{self.total_items} in {eta_str}")
@@ -179,6 +183,27 @@ class ProgressTracker:
             "type": "plugin", "plugin": "Lineuparr",
             "message": f"✅ {self.action_id}: Complete ({self.processed_items}/{self.total_items}) in {eta_str}"
         })
+        self._publish("done", summary=summary)
+
+    def _publish(self, status, summary=None):
+        """Write the progress state file (best-effort — a write failure is
+        logged but never interrupts the operation)."""
+        record = {
+            "status": status,
+            "action": self.action_id,
+            "current": self.processed_items,
+            "total": self.total_items,
+            "start_time": self.start_time,
+            "updated_at": time.time(),
+        }
+        if status == "done":
+            record["finished_at"] = record["updated_at"]
+            if summary:
+                record["summary"] = summary
+        try:
+            save_progress_atomic(PluginConfig.PROGRESS_FILE, record)
+        except Exception as e:
+            self.logger.warning(f"{LOG_PREFIX} Could not write progress file: {e}")
 
     def _format_eta(self, seconds):
         return ProgressTracker._format_eta_static(seconds)
@@ -223,6 +248,10 @@ class Plugin:
         self._stop_event = threading.Event()
         self._lineup_cache = None
         self._lineup_cache_file = None
+        # Set True while a multi-step operation (Full Sync) runs so its
+        # sub-steps don't each fire a channel-list refresh; the parent
+        # operation fires exactly one refresh when it finishes.
+        self._suppress_refresh = False
 
     def _try_start_thread(self, target, args):
         """Atomically check if a thread is running and start a new one.
@@ -262,6 +291,8 @@ class Plugin:
                     }
             except Exception:
                 pass
+        # Show the dropdown alphabetically by its visible label
+        lineup_options.sort(key=lambda o: o["label"].lower())
         if not lineup_options:
             lineup_options = [{"value": "_none", "label": "No lineup files found"}]
 
@@ -272,6 +303,8 @@ class Plugin:
                 m3u_options.append({"value": acc['name'], "label": acc['name']})
         except Exception:
             pass
+        # Alphabetize discovered sources, keeping "All sources" pinned first
+        m3u_options[1:] = sorted(m3u_options[1:], key=lambda o: o["label"].lower())
 
         # Discover EPG sources
         epg_source_options = [{"value": "_all", "label": "All EPG sources"}]
@@ -281,6 +314,8 @@ class Plugin:
                     epg_source_options.append({"value": src['name'], "label": src['name']})
             except Exception:
                 pass
+        # Alphabetize (case-insensitive), keeping "All EPG sources" pinned first
+        epg_source_options[1:] = sorted(epg_source_options[1:], key=lambda o: o["label"].lower())
 
         # Discover channel profiles
         profile_options = [{"value": "_none", "label": "None (don't enable in profiles)"}]
@@ -289,8 +324,17 @@ class Plugin:
                 profile_options.append({"value": p['name'], "label": p['name']})
         except Exception:
             pass
+        # Alphabetize discovered profiles, keeping "None" pinned first
+        profile_options[1:] = sorted(profile_options[1:], key=lambda o: o["label"].lower())
 
         return [
+            # --- Section: Lineup & Sources ---
+            {
+                "id": "_sec_sources",
+                "type": "info",
+                "label": "Lineup & Sources",
+                "help_text": "Choose the lineup to mirror and where streams and EPG data come from.",
+            },
             {
                 "id": "lineup_file",
                 "label": "Lineup File",
@@ -308,6 +352,14 @@ class Plugin:
                 "help_text": "Which M3U source to match streams from. 'All' uses every available source.",
             },
             {
+                "id": "epg_sources",
+                "label": "EPG Sources for Matching",
+                "type": "select",
+                "default": "_all",
+                "options": epg_source_options,
+                "help_text": "Which EPG source to match against. 'All' uses every source, ordered by the priority configured in Dispatcharr.",
+            },
+            {
                 "id": "channel_profiles",
                 "label": "Channel Profile",
                 "type": "select",
@@ -315,11 +367,19 @@ class Plugin:
                 "options": profile_options,
                 "help_text": "Automatically enable matched channels in this profile after sync.",
             },
+            # --- Section: Channel Groups & Numbering ---
+            {
+                "id": "_sec_groups",
+                "type": "info",
+                "label": "Channel Groups & Numbering",
+                "help_text": "How channels are grouped and numbered when they are created.",
+            },
             {
                 "id": "group_prefix",
                 "label": "Channel Group Prefix",
                 "type": "string",
                 "default": "",
+                "placeholder": "blank = auto  |  none = no prefix  |  e.g. US ",
                 "help_text": "Blank = auto from lineup name. 'none' = no prefix. Add trailing separator to control format (e.g. 'US ' or 'DTV-').",
             },
             {
@@ -336,19 +396,6 @@ class Plugin:
                 "help_text": "Controls how lineup categories are grouped. Refined merges into 6, Simple into 7, Normal keeps all original categories.",
             },
             {
-                "id": "match_sensitivity",
-                "label": "Match Sensitivity",
-                "type": "select",
-                "default": "normal",
-                "options": [
-                    {"value": "relaxed", "label": "Relaxed - more matches, more false positives"},
-                    {"value": "normal", "label": "Normal - balanced"},
-                    {"value": "strict", "label": "Strict - fewer matches, high confidence"},
-                    {"value": "exact", "label": "Exact - near-exact matches only"},
-                ],
-                "help_text": "How closely stream and EPG names must match channel names. Lower = more matches but more errors.",
-            },
-            {
                 "id": "channel_numbering",
                 "label": "Channel Numbering",
                 "type": "select",
@@ -363,21 +410,72 @@ class Plugin:
             },
             {
                 "id": "starting_channel_number",
-                "label": "Starting Channel Number",
+                "label": "Starting Channel Number (Specific mode only)",
                 "type": "string",
                 "default": "",
+                "placeholder": "e.g. 1000",
                 "help_text": "Starting channel number for 'Use Specific Number' mode. Channels are numbered sequentially from this value.",
+            },
+            # --- Section: Stream & EPG Matching ---
+            {
+                "id": "_sec_matching",
+                "type": "info",
+                "label": "Stream & EPG Matching",
+                "help_text": "Controls how streams and EPG entries are matched to lineup channels.",
+            },
+            {
+                "id": "match_sensitivity",
+                "label": "Match Sensitivity",
+                "type": "select",
+                "default": "normal",
+                "options": [
+                    {"value": "relaxed", "label": "Relaxed - more matches, more false positives"},
+                    {"value": "normal", "label": "Normal - balanced"},
+                    {"value": "strict", "label": "Strict - fewer matches, high confidence"},
+                    {"value": "exact", "label": "Exact - near-exact matches only"},
+                ],
+                "help_text": "How closely stream and EPG names must match channel names. Lower = more matches but more errors.",
             },
             {
                 "id": "prioritize_quality",
-                "label": "\u2b50 Order Matched Streams by Quality",
+                "label": "Order Matched Streams by Quality",
                 "type": "boolean",
                 "default": True,
                 "help_text": "Sort attached streams by quality (4K > UHD > FHD > HD > SD). Uses probed resolution if available.",
             },
             {
+                "id": "preserve_existing_streams",
+                "label": "Preserve Existing Streams",
+                "type": "boolean",
+                "default": False,
+                "help_text": "When on, newly matched streams are appended to channels without deleting existing streams, duplicates are skipped, and unmatched channels are not deleted. Use this to add a second M3U source non-destructively.",
+            },
+            {
+                "id": "single_channel_name",
+                "label": "Single Channel Match",
+                "type": "string",
+                "default": "",
+                "placeholder": "e.g. CNN  (blank = whole lineup)",
+                "help_text": "When set, Preview Stream Match, Apply Stream Match, Apply EPG Match, and Assign Logos operate ONLY on the lineup channel(s) whose name equals this value (case-insensitive). Leave blank to process the whole lineup. Full Sync ignores this setting.",
+            },
+            {
+                "id": "custom_aliases",
+                "label": "Custom Channel Aliases (advanced)",
+                "type": "text",
+                "default": "",
+                "placeholder": "{\"Channel Name\": [\"alias 1\", \"alias 2\"]}",
+                "help_text": "JSON object mapping a lineup channel name to extra alias names (a bare string is accepted as a single alias). Leave blank to use built-in aliases only.",
+            },
+            # --- Section: Advanced ---
+            {
+                "id": "_sec_advanced",
+                "type": "info",
+                "label": "Advanced",
+                "help_text": "Performance tuning - most setups can leave this at the default.",
+            },
+            {
                 "id": "rate_limiting",
-                "label": "\u23f3 Rate Limiting",
+                "label": "Rate Limiting",
                 "type": "select",
                 "default": "none",
                 "options": [
@@ -388,21 +486,6 @@ class Plugin:
                 ],
                 "help_text": "Add delays between API calls during sync. Use if Dispatcharr becomes unresponsive during operations.",
             },
-            {
-                "id": "custom_aliases",
-                "label": "Custom Channel Aliases (advanced)",
-                "type": "string",
-                "default": "",
-                "help_text": "JSON mapping extra names to lineup channels. Leave blank to use built-in aliases only.",
-            },
-            {
-                "id": "epg_sources",
-                "label": "EPG Sources for Matching",
-                "type": "select",
-                "default": "_all",
-                "options": epg_source_options,
-                "help_text": "Select which EPG source to match against, or 'All' to use every available source.",
-            },
         ]
 
     def run(self, action, params, context):
@@ -412,6 +495,7 @@ class Plugin:
         try:
             action_map = {
                 "validate_settings": self._validate_settings,
+                "plugin_status": self._plugin_status,
                 "scan_lineups": self._scan_lineups,
                 "preview_stream_match": self._preview_stream_match,
                 "full_sync": self._full_sync,
@@ -466,6 +550,14 @@ class Plugin:
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=5)
         logger.info(f"{LOG_PREFIX} Plugin stopped.")
+
+    def _plugin_status(self, settings, logger):
+        """Report current/last operation status from the progress file, so
+        the user can check progress on demand without reading the logs."""
+        progress = load_progress(PluginConfig.PROGRESS_FILE)
+        message = build_status_message(progress)
+        logger.info(f"{LOG_PREFIX} Status requested: {message.splitlines()[0]}")
+        return {"status": "ok", "message": message}
 
     # ========================================================================
     # HELPERS
@@ -534,10 +626,16 @@ class Plugin:
                         mapped_originals.add(orig)
                 if merged:
                     merged_cats[group_name] = merged
-            # Preserve any categories not in the mapping
+            # Fold any category not covered by the map into the broad
+            # Entertainment catch-all, so Refined/Simple yield only their
+            # documented fixed set of groups. A lineup with non-standard
+            # categories (e.g. UK lineups carrying Adult / Radio /
+            # International / HD) must not leak those through as their own
+            # groups -- that defeats the whole point of Refined/Simple.
+            catchall = "Entertainment" if detail == "refined" else "Entertainment & Lifestyle"
             for orig_name, channels in original_cats.items():
                 if orig_name not in mapped_originals and channels:
-                    merged_cats[orig_name] = channels
+                    merged_cats.setdefault(catchall, []).extend(channels)
             result["categories"] = merged_cats
             return result
 
@@ -730,16 +828,50 @@ class Plugin:
         if custom_str:
             try:
                 custom = json.loads(custom_str)
-                if isinstance(custom, dict):
-                    for k, v in custom.items():
-                        if isinstance(v, list):
-                            if k in alias_map:
-                                alias_map[k] = list(dict.fromkeys(alias_map[k] + v))
-                            else:
-                                alias_map[k] = v
-                    logger.info(f"{LOG_PREFIX} Merged {len(custom)} custom aliases")
             except json.JSONDecodeError as e:
                 logger.warning(f"{LOG_PREFIX} Failed to parse custom_aliases JSON: {e}")
+                custom = None
+
+            if isinstance(custom, dict):
+                merged = 0
+                for k, v in custom.items():
+                    # Accept a list of aliases, or a bare string as a single
+                    # alias. Anything else is a mistake — warn instead of
+                    # silently dropping it (silent drops were a known
+                    # source of "my aliases don't work" complaints).
+                    if isinstance(v, str):
+                        aliases = [v]
+                    elif isinstance(v, list):
+                        aliases = v
+                    else:
+                        logger.warning(
+                            f"{LOG_PREFIX} custom_aliases: ignoring '{k}' — value "
+                            f"must be a string or list, got {type(v).__name__}"
+                        )
+                        continue
+                    # Keep only non-empty string aliases.
+                    clean = [a.strip() for a in aliases
+                             if isinstance(a, str) and a.strip()]
+                    if not clean:
+                        logger.warning(
+                            f"{LOG_PREFIX} custom_aliases: ignoring '{k}' — no "
+                            f"usable (non-empty string) aliases"
+                        )
+                        continue
+                    if k in alias_map:
+                        alias_map[k] = list(dict.fromkeys(alias_map[k] + clean))
+                    else:
+                        alias_map[k] = clean
+                    merged += 1
+                logger.info(
+                    f"{LOG_PREFIX} Merged {merged} custom alias "
+                    f"{'entry' if merged == 1 else 'entries'}"
+                )
+            elif custom is not None:
+                logger.warning(
+                    f"{LOG_PREFIX} custom_aliases must be a JSON object mapping "
+                    f"channel names to aliases, got {type(custom).__name__} — ignored"
+                )
 
         return alias_map
 
@@ -754,6 +886,22 @@ class Plugin:
 
         epg_sources_str = (settings.get("epg_sources") or "").strip()
         if not epg_sources_str or epg_sources_str == "_all":
+            # "All" selected: order EPG entries by Dispatcharr's per-source
+            # priority (EPGSource.priority — higher number = higher priority)
+            # so downstream consumers that take the first match honor the
+            # priority the user configured in Dispatcharr.
+            priority_by_id = {
+                src['id']: (src['priority'] or 0)
+                for src in EPGSource.objects.all().values('id', 'priority')
+            }
+            all_epg.sort(
+                key=lambda e: priority_by_id.get(e.get('epg_source'), 0),
+                reverse=True,
+            )
+            logger.info(
+                f"{LOG_PREFIX} EPG 'All': {len(all_epg)} entries ordered by "
+                f"source priority ({len(priority_by_id)} sources)"
+            )
             return all_epg
 
         # Map source names to IDs (case-insensitive)
@@ -1019,14 +1167,24 @@ class Plugin:
             logger.error(f"{LOG_PREFIX} Failed to save state: {e}")
 
     def _trigger_frontend_refresh(self, logger):
-        """Notify frontend of channel updates via WebSocket."""
+        """Tell the Dispatcharr UI to refetch the channel list.
+
+        The frontend re-queries channels and streams when it receives a
+        'channels_created' websocket event -- verified against Dispatcharr's
+        own handler, which calls requeryChannels()/requeryStreams() for that
+        type. A generic plugin toast does NOT refresh the list, so this emits
+        the same event shape Dispatcharr itself sends after creating channels
+        (see apps/channels/api_views.py). count is omitted, so the frontend
+        shows "...created multiple channel(s)"; Lineuparr's own completion
+        notification carries the exact numbers."""
+        if self._suppress_refresh:
+            return  # a multi-step op (Full Sync) fires one refresh at the end
         try:
             send_websocket_update('updates', 'update', {
-                "type": "plugin", "plugin": "Lineuparr",
-                "message": "Channels updated"
+                "type": "channels_created",
             })
         except Exception as e:
-            logger.error(f"{LOG_PREFIX} WebSocket update failed: {e}")
+            logger.error(f"{LOG_PREFIX} WebSocket refresh failed: {e}")
 
     # ========================================================================
     # NON-DESTRUCTIVE ACTIONS
@@ -1307,7 +1465,7 @@ class Plugin:
             return {"status": "error", "message": "An operation is already running. Please wait for it to finish."}
         return {
             "status": "ok",
-            "message": f"Preview started: matching {total_channels} channels against {stream_count} streams. ETA: ~{eta_str}. Check notifications for progress.",
+            "message": f"Preview started: matching {total_channels} channels against {stream_count} streams. ETA: ~{eta_str}. Click 📊 Status to watch progress.",
             "background": True,
         }
 
@@ -1404,8 +1562,6 @@ class Plugin:
 
                     progress.update()
 
-            progress.finish()
-
             if lineup_cc and matcher.country_filter_drops:
                 logger.info(
                     f"{LOG_PREFIX} Country filter dropped "
@@ -1428,6 +1584,7 @@ class Plugin:
                 f"{unmatched_count} unmatched. "
                 f"Types: {type_breakdown}. CSV exported."
             )
+            progress.finish(summary=msg)
             logger.info(f"{LOG_PREFIX} {msg}")
             send_websocket_update('updates', 'update', {
                 "type": "plugin", "plugin": "Lineuparr",
@@ -1505,7 +1662,7 @@ class Plugin:
             return {"status": "error", "message": "An operation is already running. Please wait for it to finish."}
         return {
             "status": "ok",
-            "message": f"Sync Channels started: {total_channels} channels. ETA: ~{eta_str}. Check notifications for progress.",
+            "message": f"Sync Channels started: {total_channels} channels. ETA: ~{eta_str}. Click 📊 Status to watch progress.",
             "background": True,
         }
 
@@ -1645,7 +1802,7 @@ class Plugin:
             return {"status": "error", "message": "An operation is already running. Please wait for it to finish."}
         return {
             "status": "ok",
-            "message": f"Stream matching started for {total_channels} channels. ETA: ~{eta_str}. Check notifications for progress.",
+            "message": f"Stream matching started for {total_channels} channels. ETA: ~{eta_str}. Click 📊 Status to watch progress.",
             "background": True,
         }
 
@@ -1672,7 +1829,7 @@ class Plugin:
             return {"status": "error", "message": "An operation is already running. Please wait for it to finish."}
         return {
             "status": "ok",
-            "message": f"EPG matching started for {total_channels} channels. ETA: ~{eta_str}. Check notifications for progress.",
+            "message": f"EPG matching started for {total_channels} channels. ETA: ~{eta_str}. Click 📊 Status to watch progress.",
             "background": True,
         }
 
@@ -1699,7 +1856,7 @@ class Plugin:
             return {"status": "error", "message": "An operation is already running. Please wait for it to finish."}
         return {
             "status": "ok",
-            "message": f"Logo assignment started for {total_channels} channels. ETA: ~{eta_str}. Check notifications for progress.",
+            "message": f"Logo assignment started for {total_channels} channels. ETA: ~{eta_str}. Click 📊 Status to watch progress.",
             "background": True,
         }
 
@@ -2535,12 +2692,15 @@ class Plugin:
             return {"status": "error", "message": "An operation is already running. Please wait for it to finish."}
         return {
             "status": "ok",
-            "message": f"Full Sync started: groups, channels, stream matching, EPG matching, and logo assignment.{eta_msg} Check notifications for progress.",
+            "message": f"Full Sync started: groups, channels, stream matching, EPG matching, and logo assignment.{eta_msg} Click 📊 Status to watch progress.",
             "background": True,
         }
 
     def _do_full_sync(self, settings, logger):
         """Background thread for full sync."""
+        # Sub-steps each call _trigger_frontend_refresh; suppress those so a
+        # Full Sync emits exactly one channel-list refresh, at the end.
+        self._suppress_refresh = True
         try:
             # Full Sync is whole-lineup by contract. Its sub-steps route
             # through the same _do_apply_* methods that honor
@@ -2632,6 +2792,7 @@ class Plugin:
             elapsed = time.time() - sync_start
             elapsed_str = ProgressTracker._format_eta_static(elapsed)
             logger.info(f"{LOG_PREFIX} === FULL SYNC COMPLETE ({elapsed_str}) ===")
+            self._suppress_refresh = False
             self._trigger_frontend_refresh(logger)
             send_websocket_update('updates', 'update', {
                 "type": "plugin", "plugin": "Lineuparr",
@@ -2644,6 +2805,10 @@ class Plugin:
                 "type": "plugin", "plugin": "Lineuparr",
                 "message": f"❌ Full sync error: {e}"
             })
+        finally:
+            # Always clear the flag -- including on early returns (cancel/
+            # abort) and exceptions -- so later operations refresh normally.
+            self._suppress_refresh = False
 
     def _clear_csv_exports(self, settings, logger):
         """Delete all Lineuparr CSV export files."""

--- a/plugins/lineuparr/progress_status.py
+++ b/plugins/lineuparr/progress_status.py
@@ -1,0 +1,159 @@
+"""Pure, Django-free helpers for Lineuparr progress/status presentation.
+
+Lives outside plugin.py so it can be imported and unit-tested without
+Dispatcharr/Django. ProgressTracker writes the progress file during
+background operations; the "Show Status" action reads it back via
+build_status_message() so the user can check progress on demand instead
+of watching transient toast notifications or the container logs.
+"""
+
+import json
+import os
+import tempfile
+import time as _time
+from datetime import datetime
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - Dispatcharr ships Python 3.13
+    ZoneInfo = None
+
+# A "running" record whose last update is older than this is treated as
+# stale: the operation almost certainly died or the container restarted
+# mid-run (ProgressTracker updates at most every 10s).
+STALE_AFTER_SECONDS = 120
+
+IDLE = {"status": "idle"}
+
+
+def _display_tz():
+    """Resolve the timezone for user-facing timestamps. Dispatcharr pins
+    Django's TIME_ZONE and the container $TZ to UTC, so prefer Dispatcharr's
+    own configured system timezone when available."""
+    if ZoneInfo is None:
+        return None
+    try:
+        from core.models import CoreSettings  # Django-optional local import
+        tz_name = CoreSettings.get_system_time_zone()
+        if tz_name:
+            return ZoneInfo(tz_name)
+    except Exception:
+        pass
+    tz_name = os.environ.get("TZ")
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name)
+        except Exception:
+            pass
+    return None
+
+
+def format_local_timestamp(unix_ts, fmt="%Y-%m-%d %H:%M %Z"):
+    """Format a Unix timestamp in the operator's configured timezone."""
+    tz = _display_tz()
+    if tz is not None:
+        return datetime.fromtimestamp(unix_ts, tz=tz).strftime(fmt).strip()
+    return datetime.fromtimestamp(unix_ts).strftime(fmt).strip()
+
+
+def format_eta(seconds):
+    """Human-readable duration. Negative/zero -> '0s'."""
+    s = int(seconds)
+    if s <= 0:
+        return "0s"
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    if h:
+        return f"{h}h {m}m"
+    if m:
+        return f"{m}m {sec}s"
+    return f"{sec}s"
+
+
+def load_progress(path):
+    """Return the progress dict, or {'status': 'idle'} if missing/corrupt."""
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            return dict(IDLE)
+        return data
+    except (FileNotFoundError, json.JSONDecodeError, ValueError, OSError):
+        return dict(IDLE)
+
+
+def save_progress_atomic(path, data):
+    """Write data as JSON via temp file + os.replace (atomic, no torn reads)."""
+    d = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=".lineuparr_prog_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp, path)
+    except Exception:
+        if os.path.exists(tmp):
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+        raise
+
+
+ACTION_LABELS = {
+    "preview_stream_match": "Preview Stream Match",
+    "full_sync": "Full Sync",
+    "sync_channels": "Sync Channels",
+    "apply_stream_match": "Apply Stream Match",
+    "apply_epg_match": "Apply EPG Match",
+    "apply_logo_match": "Assign Logos",
+    "resort_streams": "Re-sort Streams",
+}
+
+
+def _action_label(action):
+    return ACTION_LABELS.get(action, action or "Operation")
+
+
+def build_status_message(progress, now=None):
+    """Build the user-facing message for the Show Status action.
+
+    - status 'running' -> live progress line with percent and ETA, or a
+      stale warning if progress updates have stopped;
+    - status 'done'    -> completion line plus the operation summary;
+    - anything else    -> a friendly "nothing has run yet" prompt.
+    """
+    if now is None:
+        now = _time.time()
+    status = progress.get("status")
+
+    if status == "running":
+        cur = int(progress.get("current", 0))
+        total = int(progress.get("total", 0))
+        label = _action_label(progress.get("action"))
+        pct = (cur / total * 100) if total > 0 else 0
+        updated = progress.get("updated_at")
+        if updated is not None and (now - updated) > STALE_AFTER_SECONDS:
+            ago = format_eta(now - updated)
+            return (f"⚠️ {label} — {cur}/{total} ({pct:.0f}%), "
+                    f"no progress update in {ago}. The operation may have "
+                    f"stopped — check the container logs.")
+        start = progress.get("start_time")
+        if start is not None and cur > 0:
+            remaining = ((now - start) / cur) * (total - cur)
+            eta = f"ETA {format_eta(remaining)}"
+        else:
+            eta = "ETA calculating…"
+        return f"\U0001f504 {label} — {cur}/{total} ({pct:.0f}%) · {eta}"
+
+    if status == "done":
+        label = _action_label(progress.get("action"))
+        fin = progress.get("finished_at")
+        when = format_local_timestamp(fin) if fin else "recently"
+        msg = f"✅ {label} finished {when}"
+        summary = progress.get("summary")
+        if summary:
+            msg += f"\n{summary}"
+        return msg
+
+    return ("No Lineuparr operation has run yet. Trigger one (e.g. "
+            "\U0001f441️ Preview) and click \U0001f4ca Status to watch it.")


### PR DESCRIPTION
Updates the **lineuparr** plugin to **v1.26.1421711** (from `1.26.1370103`).

### Highlights since the last marketplace release

- **New lineups** — consolidated `US_Combined` and `UK_Combined` de-duplicated lineups, plus community-contributed UK Freeview and Sky TV (Full / Simple) lineups.
- **Matching engine** — US broadcast-callsign anchoring, US↔MX country compatibility for Spanish-language feeds, a trailing-number false-positive guard, and name-normalization fixes (bare country prefixes, `(East)`/`(West)` markers).
- **GUI / UX** — new "📊 Show Status" action for on-demand progress, two settings that previously never rendered are now shown, section-grouped settings, alphabetized dropdowns, and automatic channel-list refresh after a sync.
- **EPG & aliases** — EPG "All" now honors Dispatcharr's per-source priority order; custom-alias parsing hardened.

Full release notes: https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin/releases/tag/v1.26.1421711

`plugins/lineuparr/` mirrors the whole plugin folder (multi-file plugin). `plugin.json` `version` `1.26.1370103` → `1.26.1421711`.
