### PR TITLE
fix(embyfin-stream-cleanup): downgrade repeated identifier overlap log from INFO to DEBUG

### DIFF
--- a/plugins/embyfin-stream-cleanup/handler.py
+++ b/plugins/embyfin-stream-cleanup/handler.py
@@ -220,7 +220,7 @@ class StreamMonitor:
                 # Note identifiers shared with lower-numbered servers (allowed — pools are unioned)
                 dupes = idents & seen_idents
                 if dupes:
-                    logger.info(
+                    logger.debug(
                         f"Server {n}: identifier(s) {', '.join(sorted(dupes))} also on a "
                         "lower-numbered server — pools will be combined for those identifiers"
                     )


### PR DESCRIPTION
## Problem

`_get_media_server_configs()` is called **multiple times per poll cycle**: once in `_poll_once()`, once in `_fetch_media_server_sessions()`, and once in `_fetch_active_recording_channels()`. When two configured media servers share any identifier (e.g. the same Jellyfin IP registered for multiple server slots), the message:

```
Server N: identifier(s) <ip> also on a lower-numbered server — pools will be combined for those identifiers
```

fires at `INFO` level on **every single call** — up to 3 times per poll interval (default 10 seconds), generating ~18 identical log lines per minute during normal steady-state operation.

## Fix

Downgrade from `logger.info(...)` to `logger.debug(...)`. The information is still fully available for troubleshooting by enabling DEBUG logging; it just does not appear in normal INFO-level logs.

## Context

Discovered while reviewing log output after updating to v1.2.0 with two Jellyfin servers pointing to the same host (`192.168.1.25`), both sharing that IP as their identifier. Related issue filed in the main Dispatcharr repo: Dispatcharr/Dispatcharr#1297.