### PR TITLE
[vod2mlib] Bump version to 1.15.0

### DIFF
--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "VOD to Media Library",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "description": "Generate .strm files (with optional NFO metadata) from your Dispatcharr VOD catalogue so Jellyfin / Emby / Kodi / ChannelsDVR can index your movies and series. Adds a cron-driven auto-rescan that picks up newly-added episodes nightly. Optional category-nested folder layout for genre-organised libraries.",
   "author": "R3XCHRIS",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Routine version bump for the [vod2mlib](https://github.com/R3XCHRIS/VOD2MLIB) plugin: v1.14.3 → v1.15.0.

## What's new in v1.15.0
- **Folder-name cleanup** — truncate at the first `(YYYY)` and strip quality / encoding tokens (`4K`, `UHD`, `HDR`, `HEVC`, `1080p`, `BluRay`, etc.). Resolves a ChannelsDVR scrape-failure pattern reported by Discord testers.
- **Optional `{tmdb-NNN}` folder suffix** — new boolean setting (default OFF) appends Plex / ChannelsDVR-friendly TMDB IDs to folder names for forced exact metadata matches.
- **NFOs now emit `<thumb aspect="poster">` URLs** — both movie and tvshow NFOs include the poster URL when Dispatcharr knows it, saving media servers a TMDB roundtrip.

143 unit tests pass (was 113). No breaking changes — existing schedules and on-disk libraries carry forward unchanged.

[Full release notes](https://github.com/R3XCHRIS/VOD2MLIB/releases/tag/v1.15.0) · [Release zip](https://github.com/R3XCHRIS/VOD2MLIB/releases/download/v1.15.0/plugin-vod2mlib-v1.15.0.zip) · SHA256 `c4b481de517a71dcb0a17102ab3f37eec7587e991cf1d195a973f3e55ffb6ede`