### PR TITLE
[tickarr] Bump version to 0.1.01

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,10 +1,1 @@
-{
-  "name": "Tickarr",
-  "version": "0.1.0",
-  "description": "Dynamic text overlays for IPTV channels — SiriusXM Now Playing, Sports Ticker, Custom Text",
-  "author": "jstevenscl",
-  "license": "MIT",
-  "source_type": "external",
-  "repo_url": "https://github.com/jstevenscl/tickarr",
-  "source_url": "https://github.com/jstevenscl/tickarr/releases/download/v{version}/tickarr-{version}.zip"
-}
+{"name": "Tickarr", "version": "0.1.01", "description": "Dynamic text overlays for IPTV channels - SiriusXM Now Playing, Sports Ticker, Custom Text", "author": "jstevenscl", "license": "MIT", "source_type": "external", "repo_url": "https://github.com/jstevenscl/tickarr", "source_url": "https://github.com/jstevenscl/tickarr/releases/download/v{version}/tickarr-{version}.zip"}


### PR DESCRIPTION
Bumps Tickarr from v0.1.0 to v0.1.01.

## Changes since v0.1.0

- Switched SiriusXM now-playing source from xmplaylist.com to stellartunerlog.com bulk feed (one request, 437 channels, 30s cache)
- Fixed `cut_type` handling: ads (Spot) and promos now show bare **On Air**; talk/experience cuts show the program name
- Fixed channel name matching (lowercase key lookup for EPGeditARR channels.json)
- Fixed `deeplink_id` field name in station cache lookup
- Fixed `API_MIN_INTERVAL` NameError in redis_diag action
- FFmpeg params reverted to proven-working: `-tune stillimage`, `reload=1`

## Release

GitHub Release: https://github.com/jstevenscl/tickarr/releases/tag/v0.1.01
ZIP: `tickarr-0.1.01.zip` attached to the release