### PR TITLE
[twitcharr] Add Twitcharr plugin

### DIFF
--- a/plugins/twitcharr/README.md
+++ b/plugins/twitcharr/README.md
@@ -1,0 +1,5 @@
+# Twitcharr
+
+Twitcharr adds Twitch live streams to Dispatcharr as TV channels. It creates channels, streams, XMLTV guide data, and a StreamProfile from Twitch usernames, URLs, or discovery rules.
+
+The plugin uses anonymous Twitch metadata and does not require a Twitch login, OAuth token, Client ID, Client Secret, or Twitch API key. Playback requires Streamlink in the Dispatcharr container.

--- a/plugins/twitcharr/plugin.json
+++ b/plugins/twitcharr/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "Twitcharr",
+  "version": "1.2.25",
+  "description": "Twitch live-TV plugin for Dispatcharr with automatic channels, streams, XMLTV guide data and Streamlink playback.",
+  "author": "eliasbruno124-dev",
+  "maintainers": ["eliasbruno124-dev"],
+  "license": "MIT",
+  "source_type": "external",
+  "source_url": "https://github.com/eliasbruno124-dev/Twitcharr/releases/download/v{version}/twitcharr.zip",
+  "repo_url": "https://github.com/eliasbruno124-dev/Twitcharr"
+}


### PR DESCRIPTION
## About this submission

Adds Twitcharr as a new external plugin for the Dispatcharr plugin catalog.

Twitcharr adds Twitch live streams to Dispatcharr as TV channels. It creates channels, streams, XMLTV guide data, and a StreamProfile from Twitch usernames, URLs, or discovery rules.

Release artifact:
- Source repo: https://github.com/eliasbruno124-dev/Twitcharr
- Release ZIP: https://github.com/eliasbruno124-dev/Twitcharr/releases/download/v1.2.25/twitcharr.zip
- Version: 1.2.25

## Pre-submission checklist

**If this is a new plugin:**
- [x] Plugin folder is named `lowercase-kebab-case`
- [x] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
- [x] My GitHub username is in `author` or `maintainers`
- [x] `license` is a valid OSI-approved SPDX identifier
- [x] I have tested the plugin against a running Dispatcharr instance

**If this is an update to an existing plugin:**
- [ ] `version` in `plugin.json` is incremented
- [ ] I am listed in `author` or `maintainers` of the existing plugin