### PR TITLE
[vod2mlib] Bump version to 1.15.1

### DIFF
--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "VOD to Media Library",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Generate .strm files (with optional NFO metadata) from your Dispatcharr VOD catalogue so Jellyfin / Emby / Kodi / ChannelsDVR can index your movies and series. Adds a cron-driven auto-rescan that picks up newly-added episodes nightly. Optional category-nested folder layout for genre-organised libraries.",
   "author": "R3XCHRIS",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Routine version bump for the [vod2mlib](https://github.com/R3XCHRIS/VOD2MLIB) plugin: v1.15.0 → v1.15.1.

## What's new in v1.15.1
Closes the first community-filed issue against the plugin ([R3XCHRIS/VOD2MLIB#1](https://github.com/R3XCHRIS/VOD2MLIB/issues/1)) — duplicate folders when `Nest * by Category` is ON and the provider tags one title under multiple categories.

Two new opt-in toggles, both default OFF (preserves the existing variant-stream behaviour exactly):

- **`Dedupe Movies Across Categories`** — write each movie's `.strm` under the first category only (alphabetical by category name) instead of duplicating across all of them.
- **`Dedupe Series Across Categories`** — same for series.

Defaults unchanged. No settings migration. 148 unit tests pass (was 143). No backend code changes outside the plugin.

[Full release notes](https://github.com/R3XCHRIS/VOD2MLIB/releases/tag/v1.15.1) · [Release zip](https://github.com/R3XCHRIS/VOD2MLIB/releases/download/v1.15.1/plugin-vod2mlib-v1.15.1.zip) · SHA256 `6bd4e227461f780415e52d88f34de89b8e8c1fce5de9db32c418a74a52eac15a`