### PR TITLE
[event-channel-managarr]: add Pattern 0b/0c for space-separated YYYY MM DD datetime format

### DIFF
--- a/plugins/event-channel-managarr/plugin.py
+++ b/plugins/event-channel-managarr/plugin.py
@@ -7,7 +7,7 @@ Automatically hides channels with no events and shows channels with events
 
 import logging
 import json
-import csvh
+import csv
 try:
     import fcntl
 except ImportError:

--- a/plugins/event-channel-managarr/plugin.py
+++ b/plugins/event-channel-managarr/plugin.py
@@ -7,7 +7,7 @@ Automatically hides channels with no events and shows channels with events
 
 import logging
 import json
-import csv
+import csvh
 try:
     import fcntl
 except ImportError:
@@ -1227,6 +1227,33 @@ class Plugin:
             try:
                 extracted_date = datetime(year, month, day, hour, minute, second)
                 logger.debug(f"Extracted datetime {extracted_date} from pattern (YYYY-MM-DD HH:MM:SS[ AM/PM]) in '{channel_name}'")
+                return extracted_date
+            except ValueError:
+                pass
+
+        # Pattern 0b: (YYYY MM DD HH:MM:SS[ AM/PM]) — space-separated datetime in parentheses.
+        # Matches formats like: Channel Name (2026 06 09 20:00:00) or Channel Name (2026 06 09 08:00:00 AM)
+        pattern0b = re.search(r'\((\d{4})\s+(\d{2})\s+(\d{2})\s+(\d{1,2}):(\d{2}):(\d{2})\s*(?P<ap>[AaPp][Mm])?\)', channel_name)
+        if pattern0b:
+            year, month, day, hour, minute, second = map(int, pattern0b.groups()[:6])
+            hour = _apply_meridiem(hour, pattern0b.group("ap"))
+            try:
+                extracted_date = datetime(year, month, day, hour, minute, second)
+                logger.debug(f"Extracted datetime {extracted_date} from pattern (YYYY MM DD HH:MM:SS[ AM/PM]) in '{channel_name}'")
+                return extracted_date
+            except ValueError:
+                pass
+
+        # Pattern 0c: YYYY MM DD HH:MM:SS[ AM/PM] — space-separated datetime inline (no parentheses).
+        # Matches formats like: Peacock Events 048: Upcoming (France v. England | 2026 05 17 11:45:00 AM) | 2026 04 29 06:01 AM EDT
+        # Uses the first match so the event date (earlier in the name) is preferred over any trailing timestamp.
+        pattern0c = re.search(r'(?<!\d)(\d{4})\s+(\d{2})\s+(\d{2})\s+(\d{1,2}):(\d{2}):(\d{2})\s*(?P<ap>[AaPp][Mm])?(?!\d)', channel_name)
+        if pattern0c:
+            year, month, day, hour, minute, second = map(int, pattern0c.groups()[:6])
+            hour = _apply_meridiem(hour, pattern0c.group("ap"))
+            try:
+                extracted_date = datetime(year, month, day, hour, minute, second)
+                logger.debug(f"Extracted datetime {extracted_date} from pattern YYYY MM DD HH:MM:SS[ AM/PM] in '{channel_name}'")
                 return extracted_date
             except ValueError:
                 pass


### PR DESCRIPTION
## About this submission

Fix for ECM's `_extract_date_from_channel_name` function missing Peacock Events-style space-separated datetime formats.

## What type of change is this?

- [x] Bug fix

## Description

Peacock Events channels (and similar providers) embed event datetimes in their channel names using a space-separated format:

```
Peacock Events 048: Upcoming (France v. England | 2026 05 17 11:45:00 AM) | 2026 04 29 06:01 AM EDT
Channel Name (2026 06 09 20:00:00)
```

None of the existing 7 date patterns in `_extract_date_from_channel_name` matched this format. As a result, the `[PastDate:0]` hide rule was blind to these channels — they stayed visible in the guide indefinitely rather than being hidden when their event date passed.

**Two new patterns added after Pattern 0a:**

- **Pattern 0b** — space-separated datetime *in parentheses*: `(YYYY MM DD HH:MM:SS[ AM/PM])`
- **Pattern 0c** — space-separated datetime *inline* (no parentheses): `YYYY MM DD HH:MM:SS[ AM/PM]`
  - Uses `re.search` so the first match wins (event date earlier in name preferred over trailing timestamp)

Both patterns support optional AM/PM via the existing `_apply_meridiem` helper.

## Testing

Verified against 6 real Peacock Events channel names — all 6 correctly extracted dates (3 past → hide, 3 future → keep).