### PR TITLE
[dispatcharr-ranked-matchups] Add Ranked Matchups (Top Games)

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/README.md
+++ b/plugins/dispatcharr-ranked-matchups/README.md
@@ -1,0 +1,25 @@
+# Ranked Matchups (Top Games)
+
+A cross-sport "interestingness" curator for Dispatcharr. It pulls upcoming games for each sport you enable, scores every matchup on how interesting it is (rankings, standings, rivalries, betting lines, playoff/knockout stakes), matches the worthwhile games to your existing Dispatcharr channels via EPG, and renames + groups them into a dedicated **Top Matchups** channel profile. Your guide ends up showing the games worth watching instead of the full firehose.
+
+## What it does
+
+- Per-sport adapters (college football/basketball, NFL, NBA, MLB, NHL, WNBA, NWSL, MLS, top-flight soccer leagues, internationals/friendlies, World Cup, and more), each toggleable.
+- Scores matchups with a transparent model (see `SCORING.md` in the source repo): ranked-vs-ranked, standings importance, rivalries, and betting-line signal where available.
+- Matches scored games to your channels through EPG and builds a curated **Top Matchups** profile with clean, renamed entries.
+- Runs on demand from the plugin UI or on a schedule.
+
+## Requirements
+
+- Most sources need a free API key (e.g. CollegeFootballData / CollegeBasketballData, Football-Data.org, The Odds API). Each sport's setting documents which key it needs; sports you do not enable need no key.
+- Off-season sports simply produce no rows.
+
+## Source, docs, and issues
+
+Full source, scoring methodology, changelog, and issue tracker live in the upstream repository:
+
+https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups
+
+## License
+
+MIT

--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "Ranked Matchups (Top Games)",
+  "version": "1.2.0",
+  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching.",
+  "author": "Jacob-Lasky",
+  "license": "MIT",
+  "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",
+  "help_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups#readme",
+  "source_type": "external",
+  "source_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/download/v{version}/plugin.zip"
+}


### PR DESCRIPTION
## Plugin: Ranked Matchups (Top Games)

A cross-sport "interestingness" curator. It pulls upcoming games for each enabled sport, scores them on how interesting they are (rankings, standings, rivalries, betting lines, playoff/knockout stakes), matches the worthwhile ones to existing Dispatcharr channels via EPG, and renames + groups them into a dedicated **Top Matchups** channel profile, so the guide surfaces the games worth watching instead of the full firehose.

- **Submission type:** external plugin (`source_type: "external"`)
- **Source repo:** https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups
- **Release artifact:** https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.2.0
- **License:** MIT

### Notes for review
- `source_url` resolves to the v1.2.0 release `plugin.zip` (verified reachable, HTTP 200). The zip's top-level folder is `dispatcharr_ranked_matchups/` so the loader's module alias resolves correctly on install.
- v1.2.0 runs the heavy scoring pipeline in an isolated subprocess, which keeps it from freezing the gevent uWSGI worker on Dispatcharr 0.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)