### PR TITLE
[vod2mlib] Bump version to 1.15.2

### DIFF
--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "VOD to Media Library",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Generate .strm files (with optional NFO metadata) from your Dispatcharr VOD catalogue so Jellyfin / Emby / Kodi / ChannelsDVR can index your movies and series. Adds a cron-driven auto-rescan that picks up newly-added episodes nightly. Optional category-nested folder layout for genre-organised libraries.",
   "author": "R3XCHRIS",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Routine version bump for the [vod2mlib](https://github.com/R3XCHRIS/VOD2MLIB) plugin: v1.15.1 → v1.15.2.

## What's new in v1.15.2
Four community-reported fixes, all backwards-compatible, defaults unchanged:

- **Scan & Generate now ignore inactive M3U providers** (`m3u_account__is_active=True`) — previously deactivated providers' content stayed in Scan totals and produced dead `.strm` files.
- **Bare trailing years stripped from folder names** — `Wicked: For Good - 2025` no longer becomes `… - 2025 (2025)/`. Guards real titles (Blade Runner 2049, Room 1408, 1984).
- **Show Status warns on schedule drift** — flags when live settings differ from the cron snapshot taken at the last Apply Schedule.
- **Clearer folder-migration help text** on the TMDB-suffix and dedupe toggles.

165 unit tests pass (was 148). No backend code outside the plugin.

[Full release notes](https://github.com/R3XCHRIS/VOD2MLIB/releases/tag/v1.15.2) · [Release zip](https://github.com/R3XCHRIS/VOD2MLIB/releases/download/v1.15.2/plugin-vod2mlib-v1.15.2.zip) · SHA256 `7207f908af40be565b7d068f0dfc5907d3821b8e8df4d6e7b384fd1fc1f48812`