### PR TITLE
[dispatcharr-ranked-matchups] Update to 1.4.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.2.0",
-  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching.",
+  "version": "1.4.0",
+  "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",
   "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",


### PR DESCRIPTION
Updates the **Ranked Matchups (Top Games)** listing from 1.2.0 to **1.4.0** (external entry; source stays in [Jacob-Lasky/dispatcharr_ranked_matchups](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups), release [v1.4.0](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.4.0)).

Only `version` and `description` change; `source_type`/`source_url`/`author`/`repo_url`/`license` are unchanged. The `source_url` resolves to the v1.4.0 `plugin.zip` (HTTP 200, verified).

### What's new since 1.2.0
- **Kickoff-time channel numbering**: the Top Matchups list sorts by day then start time (soonest first), and each game's number is stable for life, so the EPG binds correctly with no client setup in both the default M3U/EPG output and the **Xtream Codes API**.
- **Per-game channel matching**: binds dedicated tournament channels that carry no EPG, with national-team aliases (USA / Estados Unidos / Spanish exonyms) so marquee games attach all their provider feeds.
- Customizable channel-name template, scoring tuning recipes, widened stream pool.