### PR TITLE
[lineuparr]: Bump to v1.26.1641222 (US guide dedup, country-aware matching, CA rebrands)

### DIFF
--- a/plugins/lineuparr/CA_Telus-Optik_lineup.json
+++ b/plugins/lineuparr/CA_Telus-Optik_lineup.json
@@ -8,8 +8,7 @@
     "News": [
       { "name": "Al Jazeera English", "number": 825 },
       { "name": "BBC World News", "number": 821 },
-      { "name": "Bloomberg TV Canada", "number": 817 },
-      { "name": "BNN", "number": 815 },
+      { "name": "BNN Bloomberg", "number": 815 },
       { "name": "CBC News Network", "number": 800 },
       { "name": "CCTV News", "number": 834 },
       { "name": "CNBC", "number": 806 },
@@ -23,7 +22,6 @@
     ],
     "Sports": [
       { "name": "beIN SPORTS", "number": 983, "addon": "Premium Sports" },
-      { "name": "ESPN Classic Sports", "number": 951 },
       { "name": "Fight Network", "number": 945 },
       { "name": "FNTSY Sports Network", "number": 921 },
       { "name": "Golf Channel", "number": 922 },
@@ -63,56 +61,46 @@
       { "name": "Hollywood Suite 80", "number": 427, "addon": "Movies & Series" },
       { "name": "Hollywood Suite 90", "number": 428, "addon": "Movies & Series" },
       { "name": "Hollywood Suite 00", "number": 429, "addon": "Movies & Series" },
-      { "name": "IFC", "number": 451 },
       { "name": "MovieTime", "number": 445 },
       { "name": "Rewind", "number": 457 },
       { "name": "Silver Screen Classics", "number": 460 },
-      { "name": "Sundance Channel", "number": 453 },
+      { "name": "SundanceTV", "number": 453 },
       { "name": "Super Channel 1", "number": 417, "addon": "Movies & Series" },
       { "name": "Super Channel 2", "number": 418, "addon": "Movies & Series" },
       { "name": "Super Channel 3", "number": 419, "addon": "Movies & Series" },
       { "name": "Super Channel 4", "number": 420, "addon": "Movies & Series" },
-      { "name": "TMN 1", "number": 406, "addon": "Movies & Series" },
-      { "name": "TMN Encore 1", "number": 431, "addon": "Movies & Series" },
+      { "name": "Crave 1", "number": 406, "addon": "Movies & Series" },
+      { "name": "Crave 2", "number": 431, "addon": "Movies & Series" },
       { "name": "Turner Classic Movies", "number": 462 },
       { "name": "W Movies", "number": 455 }
     ],
     "Kids": [
       { "name": "BabyTV", "number": 639 },
-      { "name": "BBC Kids", "number": 631 },
       { "name": "Cartoon Network", "number": 627 },
-      { "name": "CHRGD", "number": 619 },
       { "name": "Disney Channel", "number": 607 },
       { "name": "Disney Junior", "number": 602 },
       { "name": "Disney XD", "number": 616 },
       { "name": "Family Channel", "number": 604 },
       { "name": "Family Jr", "number": 603 },
       { "name": "Nickelodeon", "number": 614 },
-      { "name": "Teletoon", "number": 623 },
       { "name": "Treehouse", "number": 601 },
       { "name": "TumbleBooks TV", "number": 610 },
       { "name": "YTV", "number": 600 }
     ],
     "Entertainment": [
       { "name": "A&E", "number": 300 },
-      { "name": "ABC Spark", "number": 327 },
       { "name": "AMC", "number": 303 },
-      { "name": "BBC Canada", "number": 376 },
-      { "name": "Bravo", "number": 302 },
-      { "name": "Cosmopolitan TV", "number": 335 },
+      { "name": "CTV Drama Channel", "number": 302 },
       { "name": "DejaView", "number": 506 },
       { "name": "E!", "number": 333 },
-      { "name": "Fashion Television Channel", "number": 345 },
-      { "name": "G4", "number": 374 },
       { "name": "Game Show Network", "number": 370 },
       { "name": "Lifetime", "number": 386 },
       { "name": "One", "number": 349 },
       { "name": "OUTtv", "number": 347 },
       { "name": "OWN", "number": 341 },
       { "name": "Showcase", "number": 301 },
-      { "name": "Space", "number": 392 },
-      { "name": "Spike TV", "number": 390 },
-      { "name": "VICELAND", "number": 397 },
+      { "name": "CTV Sci-Fi Channel", "number": 392 },
+      { "name": "Paramount Network", "number": 390 },
       { "name": "W Network", "number": 329 }
     ],
     "Reality & Lifestyle": [
@@ -123,16 +111,14 @@
       { "name": "Slice", "number": 331 }
     ],
     "Comedy": [
-      { "name": "Comedy Gold", "number": 501 },
       { "name": "Peachtree TV", "number": 511 },
-      { "name": "The Comedy Network", "number": 500 }
+      { "name": "CTV Comedy Channel", "number": 500 }
     ],
     "Discovery": [
-      { "name": "Animal Planet", "number": 721 },
-      { "name": "Book TV", "number": 741 },
-      { "name": "Discovery Channel", "number": 701 },
-      { "name": "Discovery Science", "number": 702 },
-      { "name": "Discovery Velocity", "number": 711 },
+      { "name": "CTV Wild Channel", "number": 721 },
+      { "name": "USA Network", "number": 701 },
+      { "name": "CTV Nature Channel", "number": 702 },
+      { "name": "CTV Speed Channel", "number": 711 },
       { "name": "Documentary", "number": 731 },
       { "name": "H2", "number": 706 },
       { "name": "History", "number": 704 },
@@ -143,7 +129,7 @@
     ],
     "Crime": [
       { "name": "Crime+ Investigation", "number": 380 },
-      { "name": "Investigation Discovery", "number": 378 }
+      { "name": "Oxygen True Crime", "number": 378 }
     ],
     "Faith": [
       { "name": "Daystar Canada", "number": 872 },
@@ -159,10 +145,7 @@
       { "name": "HIFI", "number": 551 },
       { "name": "MTV", "number": 561 },
       { "name": "MTV2", "number": 582 },
-      { "name": "MuchLoud", "number": 581 },
-      { "name": "MuchMusic", "number": 557 },
-      { "name": "Much Retro", "number": 582 },
-      { "name": "MuchVibe", "number": 680 },
+      { "name": "Much", "number": 557 },
       { "name": "Stingray Music", "number": "7500-7962" }
     ],
     "Shopping": [
@@ -179,8 +162,8 @@
     ],
     "Food & Travel": [
       { "name": "Food Network", "number": 313 },
-      { "name": "Gusto TV", "number": 315 },
-      { "name": "Travel + Escape", "number": 717 }
+      { "name": "CTV Life Channel", "number": 315 },
+      { "name": "T+E", "number": 717 }
     ]
   }
 }

--- a/plugins/lineuparr/FR_CanalPlus_TNT_lineup.json
+++ b/plugins/lineuparr/FR_CanalPlus_TNT_lineup.json
@@ -1,0 +1,1149 @@
+{
+  "package": "Canal+ France (Numérotation TNT)",
+  "date": "2026-06-01",
+  "description": "Chaînes Canal+ France avec numérotation TNT, en vigueur à compter du 30 mars 2026",
+  "source": "Canal+ Plan de Service TNT 2026",
+  "notes": "Numérotation TNT utilisée sur les décodeurs Canal+ en France métropolitaine. Les chaînes gratuites de la TNT sont aux positions 1-25, les chaînes Canal+ abonnés à partir de 30. Les flux en direct (Canal+ Live, Eurosport 360), les services à la demande (VOD, Netflix, etc.) et les mosaïques ne sont pas inclus.",
+  "categories": {
+    "TNT Gratuite": [
+      {
+        "name": "TF1",
+        "number": 1
+      },
+      {
+        "name": "France 2",
+        "number": 2
+      },
+      {
+        "name": "France 3",
+        "number": 3
+      },
+      {
+        "name": "France 4",
+        "number": 4
+      },
+      {
+        "name": "France 5",
+        "number": 5
+      },
+      {
+        "name": "M6",
+        "number": 6
+      },
+      {
+        "name": "Arte",
+        "number": 7
+      },
+      {
+        "name": "LCP",
+        "number": 8
+      },
+      {
+        "name": "W9",
+        "number": 9
+      },
+      {
+        "name": "TMC",
+        "number": 10
+      },
+      {
+        "name": "TFX",
+        "number": 11
+      },
+      {
+        "name": "Gulli",
+        "number": 12
+      },
+      {
+        "name": "BFM TV",
+        "number": 13
+      },
+      {
+        "name": "CNews",
+        "number": 14
+      },
+      {
+        "name": "LCI",
+        "number": 15
+      },
+      {
+        "name": "France Info",
+        "number": 16
+      },
+      {
+        "name": "CSTAR",
+        "number": 17
+      },
+      {
+        "name": "T18",
+        "number": 18
+      },
+      {
+        "name": "Novo19",
+        "number": 19
+      },
+      {
+        "name": "TF1 Séries Films",
+        "number": 20
+      },
+      {
+        "name": "L'Équipe",
+        "number": 21
+      },
+      {
+        "name": "6ter",
+        "number": 22
+      },
+      {
+        "name": "RMC Story",
+        "number": 23
+      },
+      {
+        "name": "RMC Découverte",
+        "number": 24
+      },
+      {
+        "name": "RMC Life",
+        "number": 25
+      }
+    ],
+    "Canal+": [
+      {
+        "name": "Chaîne Événement",
+        "number": 29
+      },
+      {
+        "name": "Canal+",
+        "number": 30
+      },
+      {
+        "name": "Canal+Sport 360",
+        "number": 31
+      },
+      {
+        "name": "Canal+Foot",
+        "number": 32
+      },
+      {
+        "name": "Canal+Sport",
+        "number": 33
+      },
+      {
+        "name": "Canal+Box Office",
+        "number": 34
+      },
+      {
+        "name": "Canal+Grand Écran",
+        "number": 35
+      },
+      {
+        "name": "Canal+Cinéma(s)",
+        "number": 36
+      },
+      {
+        "name": "Canal+Docs",
+        "number": 38
+      },
+      {
+        "name": "Canal+Kids",
+        "number": 39
+      }
+    ],
+    "UHD": [
+      {
+        "name": "Canal+ UHD",
+        "number": 80
+      },
+      {
+        "name": "Événement Sport UHD",
+        "number": 81
+      },
+      {
+        "name": "France 2 UHD",
+        "number": 82
+      },
+      {
+        "name": "TF1 UHD",
+        "number": 83
+      },
+      {
+        "name": "M6 UHD",
+        "number": 84
+      }
+    ],
+    "Cinéma": [
+      {
+        "name": "OCS",
+        "number": 53
+      },
+      {
+        "name": "Ciné+ Frisson",
+        "number": 54
+      },
+      {
+        "name": "Ciné+ Émotion",
+        "number": 55
+      },
+      {
+        "name": "Ciné+ Family",
+        "number": 56
+      },
+      {
+        "name": "Ciné+ Festival",
+        "number": 57
+      },
+      {
+        "name": "Ciné+ Classic",
+        "number": 58
+      },
+      {
+        "name": "Action",
+        "number": 65
+      },
+      {
+        "name": "TCM Cinéma",
+        "number": 66
+      }
+    ],
+    "Séries": [
+      {
+        "name": "Polar+",
+        "number": 71
+      },
+      {
+        "name": "Serieclub",
+        "number": 72
+      },
+      {
+        "name": "Warner TV",
+        "number": 73
+      },
+      {
+        "name": "TV Breizh",
+        "number": 74
+      },
+      {
+        "name": "RTL9",
+        "number": 75
+      },
+      {
+        "name": "AB1",
+        "number": 76
+      },
+      {
+        "name": "Novelas TV",
+        "number": 77
+      }
+    ],
+    "Sports": [
+      {
+        "name": "Infosport+",
+        "number": 93
+      },
+      {
+        "name": "beIN Sports 1",
+        "number": 96
+      },
+      {
+        "name": "beIN Sports 2",
+        "number": 97
+      },
+      {
+        "name": "beIN Sports 3",
+        "number": 98
+      },
+      {
+        "name": "Eurosport 1",
+        "number": 99
+      },
+      {
+        "name": "Eurosport 2",
+        "number": 100
+      },
+      {
+        "name": "Golf+",
+        "number": 102
+      },
+      {
+        "name": "Automoto",
+        "number": 103
+      },
+      {
+        "name": "Equidia",
+        "number": 104
+      },
+      {
+        "name": "Sport en France",
+        "number": 105
+      },
+      {
+        "name": "Cheval TV",
+        "number": 106
+      }
+    ],
+    "Divertissement": [
+      {
+        "name": "Comédie+",
+        "number": 110
+      },
+      {
+        "name": "Olympia TV",
+        "number": 111
+      },
+      {
+        "name": "Paris Première",
+        "number": 112
+      },
+      {
+        "name": "Teva",
+        "number": 113
+      },
+      {
+        "name": "TLC",
+        "number": 115
+      },
+      {
+        "name": "TV5 Monde",
+        "number": 116
+      }
+    ],
+    "Découverte": [
+      {
+        "name": "Planète+",
+        "number": 121
+      },
+      {
+        "name": "Planète+Crime",
+        "number": 122
+      },
+      {
+        "name": "Planète+Aventure",
+        "number": 123
+      },
+      {
+        "name": "Museum TV",
+        "number": 124
+      },
+      {
+        "name": "Ushuaïa TV",
+        "number": 126
+      },
+      {
+        "name": "Love Nature",
+        "number": 127
+      },
+      {
+        "name": "Histoire TV",
+        "number": 128
+      },
+      {
+        "name": "Toute l'Histoire",
+        "number": 129
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 130
+      },
+      {
+        "name": "Discovery Investigation",
+        "number": 131
+      },
+      {
+        "name": "Dog & Cat TV",
+        "number": 132
+      },
+      {
+        "name": "Seasons",
+        "number": 133
+      },
+      {
+        "name": "Chasse et Pêche",
+        "number": 134
+      },
+      {
+        "name": "Animaux",
+        "number": 135
+      },
+      {
+        "name": "TV Monaco",
+        "number": 136
+      },
+      {
+        "name": "Le Figaro TV",
+        "number": 137
+      },
+      {
+        "name": "8 Mont Blanc",
+        "number": 138
+      },
+      {
+        "name": "Mieux",
+        "number": 139
+      }
+    ],
+    "Jeunesse": [
+      {
+        "name": "Piwi+",
+        "number": 141
+      },
+      {
+        "name": "Nickelodeon Junior",
+        "number": 143
+      },
+      {
+        "name": "Tiji",
+        "number": 144
+      },
+      {
+        "name": "Cartoonito",
+        "number": 145
+      },
+      {
+        "name": "Boomerang",
+        "number": 146
+      },
+      {
+        "name": "Teletoon+",
+        "number": 147
+      },
+      {
+        "name": "Teletoon+1",
+        "number": 148
+      },
+      {
+        "name": "Disney Channel",
+        "number": 149
+      },
+      {
+        "name": "Cartoon Network",
+        "number": 151
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 152
+      },
+      {
+        "name": "Nickelodeon+1",
+        "number": 153
+      },
+      {
+        "name": "Canal J",
+        "number": 154
+      },
+      {
+        "name": "Nicktoons",
+        "number": 156
+      }
+    ],
+    "Nouvelle Génération": [
+      {
+        "name": "MTV",
+        "number": 162
+      },
+      {
+        "name": "MCM",
+        "number": 163
+      },
+      {
+        "name": "Comedy Central",
+        "number": 164
+      },
+      {
+        "name": "Mangas",
+        "number": 166
+      },
+      {
+        "name": "MGG TV",
+        "number": 168
+      },
+      {
+        "name": "Warner TV Next",
+        "number": 169
+      }
+    ],
+    "Information": [
+      {
+        "name": "La Chaîne Météo",
+        "number": 170
+      },
+      {
+        "name": "CNews Prime",
+        "number": 171
+      },
+      {
+        "name": "Europe 1 TV",
+        "number": 172
+      },
+      {
+        "name": "France 24",
+        "number": 173
+      },
+      {
+        "name": "Euronews",
+        "number": 174
+      },
+      {
+        "name": "BBC News",
+        "number": 175
+      },
+      {
+        "name": "CNN",
+        "number": 176
+      },
+      {
+        "name": "BFM Business",
+        "number": 177
+      },
+      {
+        "name": "Bloomberg",
+        "number": 178
+      },
+      {
+        "name": "CNBC",
+        "number": 179
+      },
+      {
+        "name": "i24 News",
+        "number": 180
+      },
+      {
+        "name": "KTO",
+        "number": 181
+      },
+      {
+        "name": "Africa 24",
+        "number": 182
+      }
+    ],
+    "Musique": [
+      {
+        "name": "Europe 2 Pop TV",
+        "number": 190
+      },
+      {
+        "name": "M6 Music",
+        "number": 191
+      },
+      {
+        "name": "NRJ Hits",
+        "number": 193
+      },
+      {
+        "name": "Trace Urban",
+        "number": 194
+      },
+      {
+        "name": "RFM TV",
+        "number": 196
+      },
+      {
+        "name": "Mélody",
+        "number": 198
+      },
+      {
+        "name": "Mezzo",
+        "number": 200
+      },
+      {
+        "name": "Mezzo Live HD",
+        "number": 201
+      },
+      {
+        "name": "Deutsche Grammophon+",
+        "number": 202
+      }
+    ],
+    "Charme": [
+      {
+        "name": "XXL",
+        "number": 222
+      },
+      {
+        "name": "Dorcel TV",
+        "number": 223
+      },
+      {
+        "name": "Dorcel XXX",
+        "number": 224
+      },
+      {
+        "name": "Vixen",
+        "number": 225
+      },
+      {
+        "name": "UnionTV",
+        "number": 226
+      },
+      {
+        "name": "Pink X",
+        "number": 228
+      },
+      {
+        "name": "Man-X",
+        "number": 229
+      }
+    ],
+    "Canal+ Live": [
+      {
+        "name": "Canal+ Live 1",
+        "number": 231
+      },
+      {
+        "name": "Canal+ Live 2",
+        "number": 232
+      },
+      {
+        "name": "Canal+ Live 3",
+        "number": 233
+      },
+      {
+        "name": "Canal+ Live 4",
+        "number": 234
+      },
+      {
+        "name": "Canal+ Live 5",
+        "number": 235
+      },
+      {
+        "name": "Canal+ Live 6",
+        "number": 236
+      },
+      {
+        "name": "Canal+ Live 7",
+        "number": 237
+      },
+      {
+        "name": "Canal+ Live 8",
+        "number": 238
+      },
+      {
+        "name": "Canal+ Live 9",
+        "number": 239
+      },
+      {
+        "name": "Canal+ Live 10",
+        "number": 240
+      },
+      {
+        "name": "Canal+ Live 11",
+        "number": 241
+      },
+      {
+        "name": "Canal+ Live 12",
+        "number": 242
+      },
+      {
+        "name": "Canal+ Live 13",
+        "number": 243
+      },
+      {
+        "name": "Canal+ Live 14",
+        "number": 244
+      },
+      {
+        "name": "Canal+ Live 15",
+        "number": 245
+      },
+      {
+        "name": "Canal+ Live 16",
+        "number": 246
+      },
+      {
+        "name": "Canal+ Live 17",
+        "number": 247
+      },
+      {
+        "name": "Canal+ Live 18",
+        "number": 248
+      },
+      {
+        "name": "Canal+ Live 19",
+        "number": 249
+      },
+      {
+        "name": "Canal+ Premier League",
+        "number": 250
+      }
+    ],
+    "Sports Multi-Diffusion": [
+      {
+        "name": "Eurosport 360 1",
+        "number": 252
+      },
+      {
+        "name": "Eurosport 360 2",
+        "number": 253
+      },
+      {
+        "name": "Eurosport 360 3",
+        "number": 254
+      },
+      {
+        "name": "Eurosport 360 4",
+        "number": 255
+      },
+      {
+        "name": "Eurosport 360 5",
+        "number": 256
+      },
+      {
+        "name": "Eurosport 360 6",
+        "number": 257
+      },
+      {
+        "name": "Eurosport 360 7",
+        "number": 258
+      },
+      {
+        "name": "Eurosport 360 8",
+        "number": 259
+      },
+      {
+        "name": "Eurosport 360 9",
+        "number": 260
+      },
+      {
+        "name": "Eurosport 360 10",
+        "number": 261
+      },
+      {
+        "name": "Eurosport 360 11",
+        "number": 262
+      },
+      {
+        "name": "Eurosport 360 12",
+        "number": 263
+      },
+      {
+        "name": "Eurosport 360 13",
+        "number": 264
+      },
+      {
+        "name": "Eurosport 360 14",
+        "number": 265
+      },
+      {
+        "name": "Eurosport 360 15",
+        "number": 266
+      },
+      {
+        "name": "Eurosport 360 16",
+        "number": 267
+      },
+      {
+        "name": "Eurosport 360 17",
+        "number": 268
+      },
+      {
+        "name": "Eurosport 360 18",
+        "number": 269
+      },
+      {
+        "name": "Eurosport 360 19",
+        "number": 270
+      },
+      {
+        "name": "Eurosport 360 20",
+        "number": 271
+      },
+      {
+        "name": "Eurosport 360 21",
+        "number": 272
+      },
+      {
+        "name": "Eurosport 360 22",
+        "number": 273
+      },
+      {
+        "name": "Eurosport 360 23",
+        "number": 274
+      },
+      {
+        "name": "Eurosport 360 24",
+        "number": 275
+      },
+      {
+        "name": "Eurosport 360 25",
+        "number": 276
+      },
+      {
+        "name": "Eurosport 360 26",
+        "number": 277
+      },
+      {
+        "name": "Eurosport 360 27",
+        "number": 278
+      },
+      {
+        "name": "Eurosport 360 28",
+        "number": 279
+      },
+      {
+        "name": "Eurosport 360 29",
+        "number": 280
+      },
+      {
+        "name": "Eurosport 360 30",
+        "number": 281
+      },
+      {
+        "name": "Eurosport 360 31",
+        "number": 282
+      },
+      {
+        "name": "Eurosport 360 32",
+        "number": 283
+      },
+      {
+        "name": "beIN Sports MAX 4",
+        "number": 284
+      },
+      {
+        "name": "beIN Sports MAX 5",
+        "number": 285
+      },
+      {
+        "name": "beIN Sports MAX 6",
+        "number": 286
+      },
+      {
+        "name": "beIN Sports MAX 7",
+        "number": 287
+      },
+      {
+        "name": "beIN Sports MAX 8",
+        "number": 288
+      },
+      {
+        "name": "beIN Sports MAX 9",
+        "number": 289
+      },
+      {
+        "name": "beIN Sports MAX 10",
+        "number": 290
+      },
+      {
+        "name": "RMC Sport 1",
+        "number": 291
+      },
+      {
+        "name": "Ligue 1+ 1",
+        "number": 292
+      },
+      {
+        "name": "Ligue 1+ 2",
+        "number": 293
+      },
+      {
+        "name": "Ligue 1+ 3",
+        "number": 294
+      },
+      {
+        "name": "Ligue 1+ 4",
+        "number": 295
+      },
+      {
+        "name": "Ligue 1+ 5",
+        "number": 296
+      },
+      {
+        "name": "Ligue 1+ 6",
+        "number": 297
+      },
+      {
+        "name": "Ligue 1+ 7",
+        "number": 298
+      },
+      {
+        "name": "Ligue 1+ 8",
+        "number": 299
+      },
+      {
+        "name": "Ligue 1+ 9",
+        "number": 300
+      },
+      {
+        "name": "Ligue 1+ 10",
+        "number": 301
+      }
+    ],
+    "DOM-TOM": [
+      {
+        "name": "Martinique la 1ère",
+        "number": 337
+      },
+      {
+        "name": "Guadeloupe la 1ère",
+        "number": 338
+      },
+      {
+        "name": "Réunion la 1ère",
+        "number": 339
+      },
+      {
+        "name": "Mayotte la 1ère",
+        "number": 340
+      },
+      {
+        "name": "Guyane la 1ère",
+        "number": 341
+      }
+    ],
+    "BFM Régionales": [
+      {
+        "name": "BFM Paris",
+        "number": 326
+      },
+      {
+        "name": "BFM Grand Lille",
+        "number": 327
+      },
+      {
+        "name": "BFM Grand Littoral",
+        "number": 328
+      },
+      {
+        "name": "BFM Normandie",
+        "number": 329
+      },
+      {
+        "name": "BFM Alsace",
+        "number": 330
+      },
+      {
+        "name": "BFM Lyon",
+        "number": 331
+      },
+      {
+        "name": "BFM Alpes Sud",
+        "number": 332
+      },
+      {
+        "name": "BFM Marseille Provence",
+        "number": 333
+      },
+      {
+        "name": "BFM Toulon Var",
+        "number": 334
+      },
+      {
+        "name": "BFM Côte d'Azur",
+        "number": 335
+      },
+      {
+        "name": "BFM Haute-Provence",
+        "number": 336
+      }
+    ],
+    "Via Occitanie": [
+      {
+        "name": "Via Occitanie Montpellier",
+        "number": 342
+      },
+      {
+        "name": "Via Occitanie Toulouse",
+        "number": 343
+      },
+      {
+        "name": "Via Occitanie Pays Catalan",
+        "number": 344
+      },
+      {
+        "name": "Via Occitanie Pays Gardois",
+        "number": 345
+      }
+    ],
+    "France 3 Régions": [
+      {
+        "name": "France 3 Alpes",
+        "number": 350
+      },
+      {
+        "name": "France 3 Alsace",
+        "number": 351
+      },
+      {
+        "name": "France 3 Aquitaine",
+        "number": 352
+      },
+      {
+        "name": "France 3 Auvergne",
+        "number": 353
+      },
+      {
+        "name": "France 3 Basse-Normandie",
+        "number": 354
+      },
+      {
+        "name": "France 3 Bourgogne",
+        "number": 355
+      },
+      {
+        "name": "France 3 Bretagne",
+        "number": 356
+      },
+      {
+        "name": "France 3 Centre-Val de Loire",
+        "number": 357
+      },
+      {
+        "name": "France 3 Champagne-Ardenne",
+        "number": 358
+      },
+      {
+        "name": "France 3 Via Stella",
+        "number": 359
+      },
+      {
+        "name": "France 3 Côte d'Azur",
+        "number": 360
+      },
+      {
+        "name": "France 3 Franche-Comté",
+        "number": 361
+      },
+      {
+        "name": "France 3 Haute-Normandie",
+        "number": 362
+      },
+      {
+        "name": "France 3 Languedoc-Roussillon",
+        "number": 363
+      },
+      {
+        "name": "France 3 Limousin",
+        "number": 364
+      },
+      {
+        "name": "France 3 Lorraine",
+        "number": 365
+      },
+      {
+        "name": "France 3 Midi-Pyrénées",
+        "number": 366
+      },
+      {
+        "name": "France 3 Nord-Pas-de-Calais",
+        "number": 367
+      },
+      {
+        "name": "France 3 Paris Île-de-France",
+        "number": 368
+      },
+      {
+        "name": "France 3 Pays de la Loire",
+        "number": 369
+      },
+      {
+        "name": "France 3 Picardie",
+        "number": 370
+      },
+      {
+        "name": "France 3 Poitou-Charentes",
+        "number": 371
+      },
+      {
+        "name": "France 3 Provence-Alpes",
+        "number": 372
+      },
+      {
+        "name": "France 3 Rhône-Alpes",
+        "number": 373
+      },
+      {
+        "name": "France 3 NoA",
+        "number": 374
+      }
+    ],
+    "International": [
+      {
+        "name": "A+",
+        "number": 378
+      },
+      {
+        "name": "A+ Bénin",
+        "number": 379
+      },
+      {
+        "name": "A+ Ivoire",
+        "number": 380
+      },
+      {
+        "name": "Nollywood TV",
+        "number": 381
+      },
+      {
+        "name": "Nollywood TV Epic",
+        "number": 382
+      },
+      {
+        "name": "Sunu Yeuf",
+        "number": 383
+      },
+      {
+        "name": "Pulaagu",
+        "number": 384
+      },
+      {
+        "name": "Mandeka",
+        "number": 385
+      },
+      {
+        "name": "Maboke TV",
+        "number": 386
+      },
+      {
+        "name": "Canal+ Magic",
+        "number": 387
+      },
+      {
+        "name": "2M Monde",
+        "number": 388
+      },
+      {
+        "name": "Echorouk News",
+        "number": 389
+      },
+      {
+        "name": "Echourouk TV",
+        "number": 390
+      },
+      {
+        "name": "Nessma TV",
+        "number": 391
+      },
+      {
+        "name": "Samira TV",
+        "number": 392
+      },
+      {
+        "name": "El Hiwar Ettounsi",
+        "number": 393
+      },
+      {
+        "name": "Sky News Arabia",
+        "number": 394
+      },
+      {
+        "name": "MBC 5",
+        "number": 395
+      },
+      {
+        "name": "MBC Drama",
+        "number": 396
+      },
+      {
+        "name": "Rotana Cinéma FR",
+        "number": 397
+      },
+      {
+        "name": "Rotana Cinéma",
+        "number": 398
+      },
+      {
+        "name": "Rotana Kids",
+        "number": 399
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/FR_CanalPlus_lineup.json
+++ b/plugins/lineuparr/FR_CanalPlus_lineup.json
@@ -1,0 +1,1147 @@
+{
+  "package": "Canal+ France (Numérotation Canal+)",
+  "date": "2026-06-01",
+  "description": "Chaînes Canal+ France avec numérotation Canal+, en vigueur à compter du 30 mars 2026",
+  "source": "Canal+ Plan de Service Canal+ 2026",
+  "notes": "Numérotation Canal+ utilisée sur les décodeurs Canal+ en France métropolitaine. Les flux en direct (Canal+ Live, Eurosport 360), les services à la demande (VOD, Netflix, etc.) et les mosaïques ne sont pas inclus.",
+  "categories": {
+    "Canal+ & Grandes Chaînes": [
+      {
+        "name": "Chaîne Événement",
+        "number": 29
+      },
+      {
+        "name": "TF1",
+        "number": 1
+      },
+      {
+        "name": "France 2",
+        "number": 2
+      },
+      {
+        "name": "France 3",
+        "number": 3
+      },
+      {
+        "name": "Canal+",
+        "number": 4
+      },
+      {
+        "name": "France 5",
+        "number": 5
+      },
+      {
+        "name": "M6",
+        "number": 6
+      },
+      {
+        "name": "Arte",
+        "number": 7
+      },
+      {
+        "name": "Canal+Sport 360",
+        "number": 10
+      },
+      {
+        "name": "Canal+Foot",
+        "number": 11
+      },
+      {
+        "name": "Canal+Sport",
+        "number": 12
+      },
+      {
+        "name": "Canal+Box Office",
+        "number": 13
+      },
+      {
+        "name": "Canal+Grand Écran",
+        "number": 14
+      },
+      {
+        "name": "Canal+Cinéma(s)",
+        "number": 15
+      },
+      {
+        "name": "Canal+Docs",
+        "number": 17
+      },
+      {
+        "name": "Canal+Kids",
+        "number": 18
+      }
+    ],
+    "UHD": [
+      {
+        "name": "Canal+ UHD",
+        "number": 100
+      },
+      {
+        "name": "Événement Sport UHD",
+        "number": 101
+      },
+      {
+        "name": "France 2 UHD",
+        "number": 102
+      },
+      {
+        "name": "TF1 UHD",
+        "number": 103
+      },
+      {
+        "name": "M6 UHD",
+        "number": 104
+      }
+    ],
+    "Cinéma": [
+      {
+        "name": "OCS",
+        "number": 33
+      },
+      {
+        "name": "Ciné+ Frisson",
+        "number": 34
+      },
+      {
+        "name": "Ciné+ Émotion",
+        "number": 35
+      },
+      {
+        "name": "Ciné+ Family",
+        "number": 36
+      },
+      {
+        "name": "Ciné+ Festival",
+        "number": 37
+      },
+      {
+        "name": "Ciné+ Classic",
+        "number": 38
+      },
+      {
+        "name": "Action",
+        "number": 44
+      },
+      {
+        "name": "TCM Cinéma",
+        "number": 45
+      }
+    ],
+    "Séries": [
+      {
+        "name": "Polar+",
+        "number": 51
+      },
+      {
+        "name": "Serieclub",
+        "number": 52
+      },
+      {
+        "name": "Warner TV",
+        "number": 53
+      },
+      {
+        "name": "TV Breizh",
+        "number": 54
+      },
+      {
+        "name": "RTL9",
+        "number": 55
+      },
+      {
+        "name": "AB1",
+        "number": 56
+      },
+      {
+        "name": "Novelas TV",
+        "number": 57
+      },
+      {
+        "name": "TF1 Séries Films",
+        "number": 59
+      }
+    ],
+    "Sports": [
+      {
+        "name": "Infosport+",
+        "number": 63
+      },
+      {
+        "name": "beIN Sports 1",
+        "number": 66
+      },
+      {
+        "name": "beIN Sports 2",
+        "number": 67
+      },
+      {
+        "name": "beIN Sports 3",
+        "number": 68
+      },
+      {
+        "name": "Eurosport 1",
+        "number": 69
+      },
+      {
+        "name": "Eurosport 2",
+        "number": 70
+      },
+      {
+        "name": "Golf+",
+        "number": 72
+      },
+      {
+        "name": "Automoto",
+        "number": 73
+      },
+      {
+        "name": "Equidia",
+        "number": 74
+      },
+      {
+        "name": "Sport en France",
+        "number": 75
+      },
+      {
+        "name": "Cheval TV",
+        "number": 76
+      },
+      {
+        "name": "L'Équipe",
+        "number": 79
+      }
+    ],
+    "Divertissement": [
+      {
+        "name": "Comédie+",
+        "number": 80
+      },
+      {
+        "name": "Olympia TV",
+        "number": 81
+      },
+      {
+        "name": "Paris Première",
+        "number": 83
+      },
+      {
+        "name": "Teva",
+        "number": 84
+      },
+      {
+        "name": "TLC",
+        "number": 86
+      },
+      {
+        "name": "W9",
+        "number": 89
+      },
+      {
+        "name": "TMC",
+        "number": 90
+      },
+      {
+        "name": "TFX",
+        "number": 91
+      },
+      {
+        "name": "CSTAR",
+        "number": 92
+      },
+      {
+        "name": "T18",
+        "number": 93
+      },
+      {
+        "name": "Novo19",
+        "number": 94
+      },
+      {
+        "name": "6ter",
+        "number": 95
+      },
+      {
+        "name": "RMC Story",
+        "number": 96
+      },
+      {
+        "name": "RMC Life",
+        "number": 97
+      },
+      {
+        "name": "TV5 Monde",
+        "number": 98
+      }
+    ],
+    "Découverte": [
+      {
+        "name": "Planète+",
+        "number": 111
+      },
+      {
+        "name": "Planète+Crime",
+        "number": 112
+      },
+      {
+        "name": "Planète+Aventure",
+        "number": 113
+      },
+      {
+        "name": "Museum TV",
+        "number": 114
+      },
+      {
+        "name": "Ushuaïa TV",
+        "number": 115
+      },
+      {
+        "name": "Love Nature",
+        "number": 116
+      },
+      {
+        "name": "Histoire TV",
+        "number": 117
+      },
+      {
+        "name": "Toute l'Histoire",
+        "number": 118
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 119
+      },
+      {
+        "name": "Discovery Investigation",
+        "number": 120
+      },
+      {
+        "name": "Dog & Cat TV",
+        "number": 121
+      },
+      {
+        "name": "Seasons",
+        "number": 122
+      },
+      {
+        "name": "Chasse et Pêche",
+        "number": 123
+      },
+      {
+        "name": "Animaux",
+        "number": 124
+      },
+      {
+        "name": "TV Monaco",
+        "number": 125
+      },
+      {
+        "name": "Le Figaro TV",
+        "number": 126
+      },
+      {
+        "name": "8 Mont Blanc",
+        "number": 127
+      },
+      {
+        "name": "Mieux",
+        "number": 128
+      },
+      {
+        "name": "RMC Découverte",
+        "number": 129
+      }
+    ],
+    "Jeunesse": [
+      {
+        "name": "Piwi+",
+        "number": 131
+      },
+      {
+        "name": "Nickelodeon Junior",
+        "number": 133
+      },
+      {
+        "name": "Tiji",
+        "number": 134
+      },
+      {
+        "name": "Cartoonito",
+        "number": 135
+      },
+      {
+        "name": "Boomerang",
+        "number": 136
+      },
+      {
+        "name": "Teletoon+",
+        "number": 137
+      },
+      {
+        "name": "Teletoon+1",
+        "number": 138
+      },
+      {
+        "name": "Disney Channel",
+        "number": 139
+      },
+      {
+        "name": "Cartoon Network",
+        "number": 141
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 142
+      },
+      {
+        "name": "Nickelodeon+1",
+        "number": 143
+      },
+      {
+        "name": "Canal J",
+        "number": 144
+      },
+      {
+        "name": "Nicktoons",
+        "number": 146
+      },
+      {
+        "name": "France 4",
+        "number": 147
+      },
+      {
+        "name": "Gulli",
+        "number": 148
+      }
+    ],
+    "Nouvelle Génération": [
+      {
+        "name": "MTV",
+        "number": 152
+      },
+      {
+        "name": "MCM",
+        "number": 153
+      },
+      {
+        "name": "Comedy Central",
+        "number": 154
+      },
+      {
+        "name": "Mangas",
+        "number": 156
+      },
+      {
+        "name": "MGG TV",
+        "number": 158
+      },
+      {
+        "name": "Warner TV Next",
+        "number": 159
+      }
+    ],
+    "Information": [
+      {
+        "name": "La Chaîne Météo",
+        "number": 160
+      },
+      {
+        "name": "CNews",
+        "number": 161
+      },
+      {
+        "name": "BFM TV",
+        "number": 162
+      },
+      {
+        "name": "LCI",
+        "number": 163
+      },
+      {
+        "name": "France Info",
+        "number": 164
+      },
+      {
+        "name": "LCP",
+        "number": 165
+      },
+      {
+        "name": "CNews Prime",
+        "number": 166
+      },
+      {
+        "name": "Europe 1 TV",
+        "number": 167
+      },
+      {
+        "name": "France 24",
+        "number": 168
+      },
+      {
+        "name": "Euronews",
+        "number": 169
+      },
+      {
+        "name": "BBC News",
+        "number": 170
+      },
+      {
+        "name": "CNN",
+        "number": 171
+      },
+      {
+        "name": "BFM Business",
+        "number": 172
+      },
+      {
+        "name": "Bloomberg",
+        "number": 173
+      },
+      {
+        "name": "CNBC",
+        "number": 174
+      },
+      {
+        "name": "i24 News",
+        "number": 175
+      },
+      {
+        "name": "KTO",
+        "number": 176
+      },
+      {
+        "name": "Africa 24",
+        "number": 177
+      }
+    ],
+    "Musique": [
+      {
+        "name": "Europe 2 Pop TV",
+        "number": 180
+      },
+      {
+        "name": "M6 Music",
+        "number": 181
+      },
+      {
+        "name": "NRJ Hits",
+        "number": 183
+      },
+      {
+        "name": "Trace Urban",
+        "number": 184
+      },
+      {
+        "name": "RFM TV",
+        "number": 186
+      },
+      {
+        "name": "Mélody",
+        "number": 188
+      },
+      {
+        "name": "Mezzo",
+        "number": 200
+      },
+      {
+        "name": "Mezzo Live HD",
+        "number": 201
+      },
+      {
+        "name": "Deutsche Grammophon+",
+        "number": 202
+      }
+    ],
+    "Charme": [
+      {
+        "name": "XXL",
+        "number": 222
+      },
+      {
+        "name": "Dorcel TV",
+        "number": 223
+      },
+      {
+        "name": "Dorcel XXX",
+        "number": 224
+      },
+      {
+        "name": "Vixen",
+        "number": 225
+      },
+      {
+        "name": "UnionTV",
+        "number": 226
+      },
+      {
+        "name": "Pink X",
+        "number": 228
+      },
+      {
+        "name": "Man-X",
+        "number": 229
+      }
+    ],
+    "Canal+ Live": [
+      {
+        "name": "Canal+ Live 1",
+        "number": 231
+      },
+      {
+        "name": "Canal+ Live 2",
+        "number": 232
+      },
+      {
+        "name": "Canal+ Live 3",
+        "number": 233
+      },
+      {
+        "name": "Canal+ Live 4",
+        "number": 234
+      },
+      {
+        "name": "Canal+ Live 5",
+        "number": 235
+      },
+      {
+        "name": "Canal+ Live 6",
+        "number": 236
+      },
+      {
+        "name": "Canal+ Live 7",
+        "number": 237
+      },
+      {
+        "name": "Canal+ Live 8",
+        "number": 238
+      },
+      {
+        "name": "Canal+ Live 9",
+        "number": 239
+      },
+      {
+        "name": "Canal+ Live 10",
+        "number": 240
+      },
+      {
+        "name": "Canal+ Live 11",
+        "number": 241
+      },
+      {
+        "name": "Canal+ Live 12",
+        "number": 242
+      },
+      {
+        "name": "Canal+ Live 13",
+        "number": 243
+      },
+      {
+        "name": "Canal+ Live 14",
+        "number": 244
+      },
+      {
+        "name": "Canal+ Live 15",
+        "number": 245
+      },
+      {
+        "name": "Canal+ Live 16",
+        "number": 246
+      },
+      {
+        "name": "Canal+ Live 17",
+        "number": 247
+      },
+      {
+        "name": "Canal+ Live 18",
+        "number": 248
+      },
+      {
+        "name": "Canal+ Live 19",
+        "number": 249
+      },
+      {
+        "name": "Canal+ Premier League",
+        "number": 250
+      }
+    ],
+    "Sports Multi-Diffusion": [
+      {
+        "name": "Eurosport 360 1",
+        "number": 252
+      },
+      {
+        "name": "Eurosport 360 2",
+        "number": 253
+      },
+      {
+        "name": "Eurosport 360 3",
+        "number": 254
+      },
+      {
+        "name": "Eurosport 360 4",
+        "number": 255
+      },
+      {
+        "name": "Eurosport 360 5",
+        "number": 256
+      },
+      {
+        "name": "Eurosport 360 6",
+        "number": 257
+      },
+      {
+        "name": "Eurosport 360 7",
+        "number": 258
+      },
+      {
+        "name": "Eurosport 360 8",
+        "number": 259
+      },
+      {
+        "name": "Eurosport 360 9",
+        "number": 260
+      },
+      {
+        "name": "Eurosport 360 10",
+        "number": 261
+      },
+      {
+        "name": "Eurosport 360 11",
+        "number": 262
+      },
+      {
+        "name": "Eurosport 360 12",
+        "number": 263
+      },
+      {
+        "name": "Eurosport 360 13",
+        "number": 264
+      },
+      {
+        "name": "Eurosport 360 14",
+        "number": 265
+      },
+      {
+        "name": "Eurosport 360 15",
+        "number": 266
+      },
+      {
+        "name": "Eurosport 360 16",
+        "number": 267
+      },
+      {
+        "name": "Eurosport 360 17",
+        "number": 268
+      },
+      {
+        "name": "Eurosport 360 18",
+        "number": 269
+      },
+      {
+        "name": "Eurosport 360 19",
+        "number": 270
+      },
+      {
+        "name": "Eurosport 360 20",
+        "number": 271
+      },
+      {
+        "name": "Eurosport 360 21",
+        "number": 272
+      },
+      {
+        "name": "Eurosport 360 22",
+        "number": 273
+      },
+      {
+        "name": "Eurosport 360 23",
+        "number": 274
+      },
+      {
+        "name": "Eurosport 360 24",
+        "number": 275
+      },
+      {
+        "name": "Eurosport 360 25",
+        "number": 276
+      },
+      {
+        "name": "Eurosport 360 26",
+        "number": 277
+      },
+      {
+        "name": "Eurosport 360 27",
+        "number": 278
+      },
+      {
+        "name": "Eurosport 360 28",
+        "number": 279
+      },
+      {
+        "name": "Eurosport 360 29",
+        "number": 280
+      },
+      {
+        "name": "Eurosport 360 30",
+        "number": 281
+      },
+      {
+        "name": "Eurosport 360 31",
+        "number": 282
+      },
+      {
+        "name": "Eurosport 360 32",
+        "number": 283
+      },
+      {
+        "name": "beIN Sports MAX 4",
+        "number": 284
+      },
+      {
+        "name": "beIN Sports MAX 5",
+        "number": 285
+      },
+      {
+        "name": "beIN Sports MAX 6",
+        "number": 286
+      },
+      {
+        "name": "beIN Sports MAX 7",
+        "number": 287
+      },
+      {
+        "name": "beIN Sports MAX 8",
+        "number": 288
+      },
+      {
+        "name": "beIN Sports MAX 9",
+        "number": 289
+      },
+      {
+        "name": "beIN Sports MAX 10",
+        "number": 290
+      },
+      {
+        "name": "RMC Sport 1",
+        "number": 291
+      },
+      {
+        "name": "Ligue 1+ 1",
+        "number": 292
+      },
+      {
+        "name": "Ligue 1+ 2",
+        "number": 293
+      },
+      {
+        "name": "Ligue 1+ 3",
+        "number": 294
+      },
+      {
+        "name": "Ligue 1+ 4",
+        "number": 295
+      },
+      {
+        "name": "Ligue 1+ 5",
+        "number": 296
+      },
+      {
+        "name": "Ligue 1+ 6",
+        "number": 297
+      },
+      {
+        "name": "Ligue 1+ 7",
+        "number": 298
+      },
+      {
+        "name": "Ligue 1+ 8",
+        "number": 299
+      },
+      {
+        "name": "Ligue 1+ 9",
+        "number": 300
+      },
+      {
+        "name": "Ligue 1+ 10",
+        "number": 301
+      }
+    ],
+    "DOM-TOM": [
+      {
+        "name": "Martinique la 1ère",
+        "number": 337
+      },
+      {
+        "name": "Guadeloupe la 1ère",
+        "number": 338
+      },
+      {
+        "name": "Réunion la 1ère",
+        "number": 339
+      },
+      {
+        "name": "Mayotte la 1ère",
+        "number": 340
+      },
+      {
+        "name": "Guyane la 1ère",
+        "number": 341
+      }
+    ],
+    "BFM Régionales": [
+      {
+        "name": "BFM Paris",
+        "number": 326
+      },
+      {
+        "name": "BFM Grand Lille",
+        "number": 327
+      },
+      {
+        "name": "BFM Grand Littoral",
+        "number": 328
+      },
+      {
+        "name": "BFM Normandie",
+        "number": 329
+      },
+      {
+        "name": "BFM Alsace",
+        "number": 330
+      },
+      {
+        "name": "BFM Lyon",
+        "number": 331
+      },
+      {
+        "name": "BFM Alpes Sud",
+        "number": 332
+      },
+      {
+        "name": "BFM Marseille Provence",
+        "number": 333
+      },
+      {
+        "name": "BFM Toulon Var",
+        "number": 334
+      },
+      {
+        "name": "BFM Côte d'Azur",
+        "number": 335
+      },
+      {
+        "name": "BFM Haute-Provence",
+        "number": 336
+      }
+    ],
+    "Via Occitanie": [
+      {
+        "name": "Via Occitanie Montpellier",
+        "number": 342
+      },
+      {
+        "name": "Via Occitanie Toulouse",
+        "number": 343
+      },
+      {
+        "name": "Via Occitanie Pays Catalan",
+        "number": 344
+      },
+      {
+        "name": "Via Occitanie Pays Gardois",
+        "number": 345
+      }
+    ],
+    "France 3 Régions": [
+      {
+        "name": "France 3 Alpes",
+        "number": 350
+      },
+      {
+        "name": "France 3 Alsace",
+        "number": 351
+      },
+      {
+        "name": "France 3 Aquitaine",
+        "number": 352
+      },
+      {
+        "name": "France 3 Auvergne",
+        "number": 353
+      },
+      {
+        "name": "France 3 Basse-Normandie",
+        "number": 354
+      },
+      {
+        "name": "France 3 Bourgogne",
+        "number": 355
+      },
+      {
+        "name": "France 3 Bretagne",
+        "number": 356
+      },
+      {
+        "name": "France 3 Centre-Val de Loire",
+        "number": 357
+      },
+      {
+        "name": "France 3 Champagne-Ardenne",
+        "number": 358
+      },
+      {
+        "name": "France 3 Via Stella",
+        "number": 359
+      },
+      {
+        "name": "France 3 Côte d'Azur",
+        "number": 360
+      },
+      {
+        "name": "France 3 Franche-Comté",
+        "number": 361
+      },
+      {
+        "name": "France 3 Haute-Normandie",
+        "number": 362
+      },
+      {
+        "name": "France 3 Languedoc-Roussillon",
+        "number": 363
+      },
+      {
+        "name": "France 3 Limousin",
+        "number": 364
+      },
+      {
+        "name": "France 3 Lorraine",
+        "number": 365
+      },
+      {
+        "name": "France 3 Midi-Pyrénées",
+        "number": 366
+      },
+      {
+        "name": "France 3 Nord-Pas-de-Calais",
+        "number": 367
+      },
+      {
+        "name": "France 3 Paris Île-de-France",
+        "number": 368
+      },
+      {
+        "name": "France 3 Pays de la Loire",
+        "number": 369
+      },
+      {
+        "name": "France 3 Picardie",
+        "number": 370
+      },
+      {
+        "name": "France 3 Poitou-Charentes",
+        "number": 371
+      },
+      {
+        "name": "France 3 Provence-Alpes",
+        "number": 372
+      },
+      {
+        "name": "France 3 Rhône-Alpes",
+        "number": 373
+      },
+      {
+        "name": "France 3 NoA",
+        "number": 374
+      }
+    ],
+    "International": [
+      {
+        "name": "A+",
+        "number": 378
+      },
+      {
+        "name": "A+ Bénin",
+        "number": 379
+      },
+      {
+        "name": "A+ Ivoire",
+        "number": 380
+      },
+      {
+        "name": "Nollywood TV",
+        "number": 381
+      },
+      {
+        "name": "Nollywood TV Epic",
+        "number": 382
+      },
+      {
+        "name": "Sunu Yeuf",
+        "number": 383
+      },
+      {
+        "name": "Pulaagu",
+        "number": 384
+      },
+      {
+        "name": "Mandeka",
+        "number": 385
+      },
+      {
+        "name": "Maboke TV",
+        "number": 386
+      },
+      {
+        "name": "Canal+ Magic",
+        "number": 387
+      },
+      {
+        "name": "2M Monde",
+        "number": 388
+      },
+      {
+        "name": "Echorouk News",
+        "number": 389
+      },
+      {
+        "name": "Echourouk TV",
+        "number": 390
+      },
+      {
+        "name": "Nessma TV",
+        "number": 391
+      },
+      {
+        "name": "Samira TV",
+        "number": 392
+      },
+      {
+        "name": "El Hiwar Ettounsi",
+        "number": 393
+      },
+      {
+        "name": "Sky News Arabia",
+        "number": 394
+      },
+      {
+        "name": "MBC 5",
+        "number": 395
+      },
+      {
+        "name": "MBC Drama",
+        "number": 396
+      },
+      {
+        "name": "Rotana Cinéma FR",
+        "number": 397
+      },
+      {
+        "name": "Rotana Cinéma",
+        "number": 398
+      },
+      {
+        "name": "Rotana Kids",
+        "number": 399
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/UK_SkyTV_lineup.json
+++ b/plugins/lineuparr/UK_SkyTV_lineup.json
@@ -121,7 +121,6 @@
       { "name": "Sky Mix", "number": 151 },
       { "name": "Sky One", "number": 106 },
       { "name": "Sky Sci-Fi", "number": 145 },
-      { "name": "Sky Showcase", "number": 106 },
       { "name": "Sky Witness", "number": 107 },
       { "name": "That's TV", "number": 171 },
       { "name": "Together", "number": 170 },

--- a/plugins/lineuparr/US_Combined_lineup.json
+++ b/plugins/lineuparr/US_Combined_lineup.json
@@ -3,7 +3,7 @@
   "date": "2026-05-22",
   "description": "Consolidated US channel lineup merged and de-duplicated from DIRECTV Premier, DISH Top 250, and Verizon FiOS.",
   "source": "DIRECTV Premier + DISH Top 250 + Verizon FiOS",
-  "notes": "This lineup is a de-duplicated union of three US packages, renumbered with category-blocked numbering (News 100s, Sports 200s, and so on through Food & Travel 1600s). 509 channels after collapsing duplicate names and HD/SD variants.",
+  "notes": "This lineup is a de-duplicated union of three US packages, renumbered with category-blocked numbering (News 100s, Sports 200s, and so on through Food & Travel 1600s). 477 channels after collapsing duplicate names and HD/SD variants, removing discontinued channels (NBCSN, Olympic Channel, Pac-12 Network, Longhorn Network, HBO Family, Movie Max, Outer Max, Thriller Max), and deduping post-rebrand pairs where both old and new names were present (WGN America→NewsNation, Hallmark Movies & Mysteries→Hallmark Mystery, HBO 2→HBO Hits, HBO Signature→HBO Drama, HBO Zone→HBO Movies, EPIX Hits→MGM+ Hits, Action Max→Cinemax Action, Five Star Max→Cinemax Classics, More Max→Cinemax Hits).",
   "categories": {
     "News": [
       {
@@ -83,10 +83,6 @@
         "number": 123
       },
       {
-        "name": "HLN Headline News Network",
-        "number": 124
-      },
-      {
         "name": "i24NEWS",
         "number": 125
       },
@@ -109,10 +105,6 @@
       {
         "name": "NewsNation",
         "number": 131
-      },
-      {
-        "name": "Russia Today",
-        "number": 132
       },
       {
         "name": "Scripps News",
@@ -285,10 +277,6 @@
         "number": 243
       },
       {
-        "name": "NBCSN",
-        "number": 244
-      },
-      {
         "name": "NFL Network",
         "number": 245
       },
@@ -301,16 +289,8 @@
         "number": 248
       },
       {
-        "name": "Olympic Channel",
-        "number": 249
-      },
-      {
         "name": "Outside TV",
         "number": 250
-      },
-      {
-        "name": "Pac-12 Network",
-        "number": 251
       },
       {
         "name": "Pickleball TV",
@@ -479,10 +459,6 @@
         "number": 317
       },
       {
-        "name": "Longhorn Network",
-        "number": 318
-      },
-      {
         "name": "Marquee Sports Network",
         "number": 319
       },
@@ -559,19 +535,11 @@
         "number": 338
       },
       {
-        "name": "YES National",
-        "number": 339
-      },
-      {
         "name": "YES Network",
         "number": 340
       }
     ],
     "Movies": [
-      {
-        "name": "Action Max",
-        "number": 401
-      },
       {
         "name": "Cinemax",
         "number": 402
@@ -597,16 +565,8 @@
         "number": 409
       },
       {
-        "name": "EPIX Hits",
-        "number": 410
-      },
-      {
         "name": "Family Movie Classics (FMC)",
         "number": 411
-      },
-      {
-        "name": "Five Star Max",
-        "number": 412
       },
       {
         "name": "FLIX",
@@ -617,14 +577,6 @@
         "number": 414
       },
       {
-        "name": "FXM",
-        "number": 415
-      },
-      {
-        "name": "Hallmark Movies & Mysteries",
-        "number": 416
-      },
-      {
         "name": "Hallmark Mystery",
         "number": 417
       },
@@ -633,20 +585,12 @@
         "number": 418
       },
       {
-        "name": "HBO 2",
-        "number": 419
-      },
-      {
         "name": "HBO Comedy",
         "number": 420
       },
       {
         "name": "HBO Drama HD East",
         "number": 422
-      },
-      {
-        "name": "HBO Family",
-        "number": 424
       },
       {
         "name": "HBO Hits HD East",
@@ -659,14 +603,6 @@
       {
         "name": "HBO Movies HD",
         "number": 427
-      },
-      {
-        "name": "HBO Signature",
-        "number": 428
-      },
-      {
-        "name": "HBO Zone",
-        "number": 429
       },
       {
         "name": "HDNet Movies",
@@ -689,16 +625,8 @@
         "number": 435
       },
       {
-        "name": "More Max",
-        "number": 436
-      },
-      {
         "name": "Movie Favorites by Lifetime",
         "number": 437
-      },
-      {
-        "name": "Movie Max",
-        "number": 438
       },
       {
         "name": "MoviePlex",
@@ -711,10 +639,6 @@
       {
         "name": "MovieSphere Gold",
         "number": 441
-      },
-      {
-        "name": "Outer Max",
-        "number": 442
       },
       {
         "name": "Paramount+ with SHOWTIME",
@@ -853,16 +777,8 @@
         "number": 488
       },
       {
-        "name": "Thriller Max",
-        "number": 490
-      },
-      {
         "name": "Tribeca Festival+",
         "number": 491
-      },
-      {
-        "name": "Turner Classic Movies",
-        "number": 492
       }
     ],
     "Kids": [
@@ -921,10 +837,6 @@
       {
         "name": "Nick Jr.",
         "number": 520
-      },
-      {
-        "name": "Nick/Nick at Nite (E)",
-        "number": 522
       },
       {
         "name": "Nick/Nick at Nite (W)",
@@ -1033,10 +945,6 @@
         "number": 622
       },
       {
-        "name": "GET",
-        "number": 623
-      },
-      {
         "name": "getTV",
         "number": 624
       },
@@ -1091,10 +999,6 @@
       {
         "name": "OWN: Oprah Winfrey Network",
         "number": 642
-      },
-      {
-        "name": "Oxygen",
-        "number": 643
       },
       {
         "name": "Paramount Network",
@@ -1169,16 +1073,8 @@
         "number": 665
       },
       {
-        "name": "Viceland",
-        "number": 666
-      },
-      {
         "name": "WE tv",
         "number": 667
-      },
-      {
-        "name": "WGN America",
-        "number": 668
       }
     ],
     "Reality & Lifestyle": [
@@ -1533,10 +1429,6 @@
         "number": 1010
       },
       {
-        "name": "Justice Network",
-        "number": 1012
-      },
-      {
         "name": "JusticeCentral.TV",
         "number": 1013
       },
@@ -1883,10 +1775,6 @@
         "number": 1506
       },
       {
-        "name": "Great American Country",
-        "number": 1507
-      },
-      {
         "name": "Great American Family",
         "number": 1508
       },
@@ -1943,10 +1831,6 @@
         "number": 1523
       },
       {
-        "name": "Speedvision",
-        "number": 1524
-      },
-      {
         "name": "Sweet Escapes",
         "number": 1525
       },
@@ -2001,16 +1885,8 @@
         "number": 1607
       },
       {
-        "name": "Tastemade Home",
-        "number": 1608
-      },
-      {
         "name": "Tastemade Travel",
         "number": 1609
-      },
-      {
-        "name": "Z Living",
-        "number": 1610
       }
     ]
   }

--- a/plugins/lineuparr/US_DISH-Top250_lineup.json
+++ b/plugins/lineuparr/US_DISH-Top250_lineup.json
@@ -19,7 +19,6 @@
       { "name": "MSNBC", "number": 209 },
       { "name": "NASA", "number": 286 },
       { "name": "Newsmax", "number": 216 },
-      { "name": "Russia Today", "number": 280 },
       { "name": "Weather Channel", "number": 214 },
       { "name": "WeatherNation", "number": 215 }
     ],
@@ -38,13 +37,10 @@
       { "name": "MLB Network", "number": 152, "addon": "Multi-Sport Pack" },
       { "name": "MLB Strike Zone", "number": 153, "addon": "Multi-Sport Pack" },
       { "name": "NBA TV", "number": 156, "addon": "Multi-Sport Pack" },
-      { "name": "NBCSN", "number": 159 },
       { "name": "NFL Network", "number": 154, "addon": "Multi-Sport Pack" },
       { "name": "NFL RedZone", "number": 155, "addon": "Multi-Sport Pack" },
       { "name": "NHL Network", "number": 157, "addon": "Multi-Sport Pack" },
-      { "name": "Olympic Channel", "number": 389 },
       { "name": "Outside TV", "number": 390, "addon": "Multi-Sport Pack" },
-      { "name": "Pac-12 Network", "number": 406, "addon": "Multi-Sport Pack" },
       { "name": "SEC Network", "number": 404, "addon": "Multi-Sport Pack" },
       { "name": "Tennis Channel", "number": 400 },
       { "name": "TV Games Network", "number": 399, "addon": "National Action Pack" },
@@ -52,8 +48,7 @@
     ],
     "Regional Sports": [
       { "name": "Regional Sports Networks (market-based)", "number": 412, "addon": "Multi-Sport Pack", "notes": "Varies by ZIP code. Hopper receivers only. All other receivers 409-437." },
-      { "name": "Big 10 Network", "number": 405, "addon": "Multi-Sport Pack" },
-      { "name": "Longhorn Network", "number": 407, "addon": "Multi-Sport Pack" }
+      { "name": "Big 10 Network", "number": 405, "addon": "Multi-Sport Pack" }
     ],
     "Movies": [
       { "name": "EPIX Drive-In", "number": 292 },
@@ -157,7 +152,6 @@
       { "name": "TV Land", "number": 106 },
       { "name": "Uplifting Entertainment", "number": 188 },
       { "name": "USA", "number": 105 },
-      { "name": "Viceland", "number": 121 },
       { "name": "WE tv", "number": 128 },
       { "name": "WGN America", "number": 239 }
     ],
@@ -185,8 +179,7 @@
     "Crime": [
       { "name": "Crime & Investigation", "number": 249, "addon": "Movie Pack" },
       { "name": "Investigation Discovery", "number": 192 },
-      { "name": "Justice Central", "number": 240 },
-      { "name": "Justice Network", "number": 252 }
+      { "name": "Justice Central", "number": 240 }
     ],
     "Faith": [
       { "name": "Christian Television Network", "number": 267 },
@@ -263,8 +256,7 @@
     ],
     "Food & Travel": [
       { "name": "Cooking Channel", "number": 113 },
-      { "name": "Food Network", "number": 110 },
-      { "name": "Z Living", "number": 191 }
+      { "name": "Food Network", "number": 110 }
     ]
   }
 }

--- a/plugins/lineuparr/US_DirecTV-Premier_lineup.json
+++ b/plugins/lineuparr/US_DirecTV-Premier_lineup.json
@@ -371,7 +371,6 @@
       { "name": "RFD-TV", "number": 345 },
       { "name": "Rig TV", "number": 4265 },
       { "name": "RVTV", "number": 4366 },
-      { "name": "Speedvision", "number": 4194 },
       { "name": "Sweet Escapes", "number": 4378 },
       { "name": "Travel Channel", "number": 277 },
       { "name": "Waypoint TV", "number": 4175 },

--- a/plugins/lineuparr/US_Verizon-FIOS_lineup.json
+++ b/plugins/lineuparr/US_Verizon-FIOS_lineup.json
@@ -68,7 +68,6 @@
       { "name": "HBO", "number": 899, "addon": "HBO" },
       { "name": "HBO 2", "number": 902, "addon": "HBO" },
       { "name": "HBO Comedy", "number": 908, "addon": "HBO" },
-      { "name": "HBO Family", "number": 906, "addon": "HBO" },
       { "name": "HBO Signature", "number": 904, "addon": "HBO" },
       { "name": "HBO Zone", "number": 910, "addon": "HBO" },
       { "name": "IFC", "number": 734 },
@@ -76,8 +75,6 @@
       { "name": "MGM+", "number": 895, "addon": "MGM+" },
       { "name": "MGM+ Hits", "number": 896, "addon": "MGM+" },
       { "name": "More Max", "number": 922, "addon": "Cinemax" },
-      { "name": "Movie Max", "number": 928, "addon": "Cinemax" },
-      { "name": "Outer Max", "number": 931, "addon": "Cinemax" },
       { "name": "Paramount+ with SHOWTIME", "number": 865, "addon": "Movie Package" },
       { "name": "RetroPlex", "number": 849, "addon": "Movie Package" },
       { "name": "Showtime 2", "number": 869, "addon": "Movie Package" },
@@ -93,7 +90,6 @@
       { "name": "Starz Kids & Family", "number": 845, "addon": "Movie Package" },
       { "name": "Sundance TV", "number": 735 },
       { "name": "The Movie Channel", "number": 885, "addon": "Movie Package" },
-      { "name": "Thriller Max", "number": 926, "addon": "Cinemax" },
       { "name": "Turner Classic Movies", "number": 730 }
     ],
     "Kids": [

--- a/plugins/lineuparr/aliases.py
+++ b/plugins/lineuparr/aliases.py
@@ -27,7 +27,7 @@ CHANNEL_ALIASES = {
     "MS Now": ["MSNBC", "MSNBC Now", "MS Now"],
     "MSNBC": ["MSNBC", "MS Now", "MSNBC Now"],
     "Newsmax": ["Newsmax", "Newsmax TV"],
-    "NewsNation": ["NewsNation", "News Nation"],
+    "NewsNation": ["NewsNation", "News Nation", "WGN America", "WGN"],
     "Weather Channel": ["Weather Channel", "TWC", "The Weather Channel"],
 
     # --- Sports ---
@@ -44,7 +44,7 @@ CHANNEL_ALIASES = {
     # Florida, Midwest, North, Ohio, Oklahoma, SoCal, South, Southeast,
     # Southwest, Sun, West, Wisconsin) to "FanDuel TV Extra". That fallback
     # gave every regional sports channel the same generic FanDuel EPG when
-    # no regional EPG existed — worse than NO MATCH. Regions with a real
+    # no regional EPG existed - worse than NO MATCH. Regions with a real
     # regional EPG (e.g. Midwest, Southwest, West) match by direct name.
     "FS1": ["Fox Sports 1", "FS1", "FS 1", "Fox Sport 1"],
     "Fox Sports 1": ["Fox Sports 1", "FS1", "FS 1", "Fox Sport 1"],
@@ -64,12 +64,16 @@ CHANNEL_ALIASES = {
 
     # --- Movies ---
     "Cinemax": ["Cinemax", "Cinemax US"],
+    # FXM is the former Fox Movie Channel; fully rebranded FX Movie Channel (FXM)
+    # in 2013. The classic-films block carries the "FXM Retro" name.
+    "FXM": ["FXM", "FX Movie Channel", "FXMovie", "Fox Movie Channel", "FXM Retro"],
+    "FX Movie Channel": ["FXM", "FX Movie Channel", "FXMovie", "Fox Movie Channel", "FXM Retro"],
     "HBO East": ["HBO East", "HBO (East)", "HBO"],
     "HBO Comedy East HD": ["HBO Comedy East", "HBO Comedy (East)", "HBO Comedy"],
-    "HBO Drama HD East": ["HBO Drama East", "HBO Drama (East)", "HBO Drama"],
-    "HBO Hits HD East": ["HBO Hits East", "HBO Hits (East)", "HBO Hits"],
+    "HBO Drama HD East": ["HBO Drama East", "HBO Drama (East)", "HBO Drama", "HBO Signature"],
+    "HBO Hits HD East": ["HBO Hits East", "HBO Hits (East)", "HBO Hits", "HBO 2", "HBO2"],
     "HBO Latino": ["HBO Latino"],
-    "HBO Movies HD": ["HBO Movies", "HBO Movies HD", "HBO Movies East", "HBO Movies (East)"],
+    "HBO Movies HD": ["HBO Movies", "HBO Movies HD", "HBO Movies East", "HBO Movies (East)", "HBO Zone"],
     "Paramount+ with SHOWTIME EAST": ["Showtime East", "Showtime (East)", "SHOWTIME EAST", "Showtime"],
     "Showtime (E)": ["Paramount+ with Showtime", "Paramount+ with Showtime HD", "Showtime East", "Showtime"],
     "Showtime (W)": ["Paramount+ with Showtime (Pacific)", "Paramount+ with Showtime HD (Pacific)", "Showtime West"],
@@ -95,7 +99,7 @@ CHANNEL_ALIASES = {
     "Disney Junior": ["Disney Junior", "Disney Jr"],
     "Disney Jr HD": ["Disney Junior HD", "Disney Junior", "Disney Jr"],
     "Nick Jr.": ["Nick Jr", "Nick Junior"],
-    "Nick/Nick at Nite (E)": ["Nickelodeon", "Nickelodeon East", "Nick", "Nick at Nite"],
+    "Nickelodeon": ["Nickelodeon", "Nickelodeon East", "Nick", "Nick at Nite"],
     "Nick/Nick at Nite (W)": ["Nickelodeon West", "Nick West", "Nick at Nite West"],
     "Nickelodeon East": ["Nickelodeon", "Nickelodeon East", "Nick", "Nickelodeon US"],
 
@@ -153,10 +157,15 @@ CHANNEL_ALIASES = {
     "Oxygen": ["Oxygen True Crime", "Oxygen True Crime HD"],
     "Oxygen True Crime": ["Oxygen", "Oxygen True Crime"],
     "Oxygen True Crime Archives": ["Oxygen True Crime Archives"],
+    # Justice Network relaunched as True Crime Network in 2020; "Justice
+    # Central.TV" was its companion streaming brand. Match all three names.
+    "Justice Network": ["Justice Network", "Justice Central.TV", "Justice Central TV", "Justice Central", "True Crime Network"],
+    "True Crime Network": ["True Crime Network", "Justice Network", "Justice Central.TV", "Justice Central TV", "Justice Central"],
+    "Justice Central.TV": ["Justice Central.TV", "Justice Central TV", "Justice Central", "Justice Network", "True Crime Network"],
 
     # --- Music ---
     "CMT": ["CMT", "Country Music Television"],
-    "MTV": ["MTV", "MTV US"],
+    "MTV": ["MTV", "MTV US", "MTV - Music Television", "MTV Music Television"],
     "MTV2": ["MTV2", "MTV 2", "MTV2: Music Television", "MTV2: Music Television HD"],
     "VH1": ["VH1", "VH 1"],
 
@@ -180,7 +189,14 @@ CHANNEL_ALIASES = {
     # --- Additional aliases for DISH lineup ---
     "American Heroes Channel": ["AHC", "American Heroes Channel", "American Heroes"],
     "BabyFirstTV": ["Baby First", "BabyFirst", "BabyFirstTV", "Baby First TV"],
-    "getTV": ["Get TV", "getTV"],
+    # getTV is owned by Sony; rebranded to "Great Entertainment Television" in
+    # 2023. Match the old and new branding. Bare "GET"/"get."/"great." are NOT
+    # used as alias VALUES: they normalize to "get"/"great" and would force a
+    # false score-100 match against any stream that happens to normalize the
+    # same way. "Get TV"/"getTV"/"GETTV" all normalize to "gettv" (unambiguous).
+    "getTV": ["Get TV", "getTV", "GETTV", "Great Entertainment Television"],
+    "GET": ["getTV", "Get TV", "GETTV", "Great Entertainment Television"],
+    "Great Entertainment Television": ["getTV", "Get TV", "GETTV", "Great Entertainment Television"],
     "GSN": ["GSN", "Game Show Network"],
     "Pop": ["Pop TV", "Pop TV East"],
     "ReelzChannel": ["Reelz", "ReelzChannel"],
@@ -251,7 +267,7 @@ CHANNEL_ALIASES = {
     "U&YESTERDAY": ["U and YESTERDAY", "UK FHD YESTERDAY", "Yesterday"],
     "U&alibi": ["U and alibi HD", "alibi+1", "UK: alibi", "Alibi"],
     "U&Drama": ["U and Drama", "U and Drama HD", "U and Drama +1"],
-    # Reverse aliases — lineup uses pre-rebrand short name, EPG has U& prefix.
+    # Reverse aliases - lineup uses pre-rebrand short name, EPG has U& prefix.
     "Dave": ["U&Dave", "U&Dave HD", "Dave"],
     "Drama": ["U&Drama", "U&Drama HD", "Drama"],
     "Drama +1": ["U&Drama+1", "U&Drama +1", "Drama +1"],
@@ -265,9 +281,194 @@ CHANNEL_ALIASES = {
     "Home": ["U&Home", "U&Home HD", "Home"],
     "Dave ja vu": ["Dave ja vu", "U&Dave ja vu"],
 
+    # --- FR: Free DTT (TNT) ---
+    # 4K full-schedule variants that should match the standard channel when
+    # Quality-Aware Stream Matching is enabled (bypass by normalized name).
+    "France 2": ["FRANCE 2 4K HDR", "FRANCE 2 4K", "FRANCE 2 ᵁᴴᴰ"],
+    "BFM TV": ["BFMTV"],
+    "CNews": ["i>TELE", "iTELE", "i-Tele"],
+    "TFX": ["NT1"],
+    "T18": ["C8"],
+    "RMC Life": ["Chérie 25"],
+    "L'Équipe": ["La Chaîne L'Équipe", "L'Equipe 21"],
+    "TF1 Séries Films": ["TF1SF"],
+    "LCP": ["LCP AN", "LCP Assemblée nationale"],
+
+    # --- FR: Canal+ Channels ---
+    "Canal+": ["Canal Plus"],
+    "Canal+Sport 360": ["Canal+ 360"],
+
+    # --- FR: Movies ---
+    "OCS": ["Ciné+ OCS", "Ciné+ Premier"],
+    "Ciné+ Festival": ["Ciné+ Club"],
+    "Ciné+ Family": ["Cine+ Famiz", "Cine+ Familly"],
+
+    # --- FR: Sports ---
+    "Equidia": ["Equidia Live"],
+    "beIN Sports 1": ["beIN Sports 1 French"],
+    "beIN Sports 2": ["beIN Sports 2 French"],
+    "beIN Sports 3": ["beIN Sports 3 French"],
+
+    # --- FR: beIN Sports MAX ---
+    "beIN Sports MAX 4": ["beIN MAX 4"],
+    "beIN Sports MAX 5": ["beIN MAX 5"],
+    "beIN Sports MAX 6": ["beIN MAX 6"],
+    "beIN Sports MAX 7": ["beIN MAX 7"],
+    "beIN Sports MAX 8": ["beIN MAX 8"],
+    "beIN Sports MAX 9": ["beIN MAX 9"],
+    "beIN Sports MAX 10": ["beIN MAX 10"],
+
+    # --- FR: RMC Sport ---
+    "RMC Sport 1": ["RMC Sport"],
+
+    # --- FR: Kids ---
+    "Cartoonito": ["Boing"],
+    "Nicktoons": ["Nickelodeon 4 Teen"],
+    "Teletoon+": ["Teletoon Plus", "Télétoon+"],
+
+    # --- FR: News ---
+    "France 24": ["FR24"],
+
+    # --- FR: Music ---
+    "Europe 2 Pop TV": ["CSTAR Hits France", "C Star Hits France"],
+
+    # --- FR: France 3 Régions ---
+    "France 3 Champagne-Ardenne": ["France 3 Champ Ardenne", "F3 Champ Ardenne"],
+    "France 3 Paris Île-de-France": ["France 3 Paris IDF", "France 3 Paris Ile de France"],
+    "France 3 Nord-Pas-de-Calais": ["France 3 Nord PDC", "France 3 Nord Pas de Calais", "France 3 Nord - Pas-de-Calais"],
+    "France 3 Côte d'Azur": ["France 3 Cote d'Azur", "F3 Cote d'Azur", "France 3 Cote D Azur"],
+    "France 3 Via Stella": ["France 3 Corse Via Stella", "France 3 Corse"],
+    "France 3 Centre-Val de Loire": ["France 3 Centre"],
+
+    # --- FR: BFM Régionales ---
+    "BFM Haute-Provence": ["BFM Haute Province", "BFM DICI Haute-Provence", "BFM Dici Haute Province"],
+    "BFM Alpes Sud": ["BFM DICI Alpes du Sud", "BFM Alpes du Sud"],
+    "BFM Marseille Provence": ["BFM Marseille", "BFM Marseille Provence"],
+    "BFM Côte d'Azur": ["BFM Cote d'Azur", "BFM Cote D Azur"],
+
+    # --- FR: Via Occitanie ---
+    "Via Occitanie Montpellier": ["Via Occitanie Monpellier"],
+
+    # --- FR: DOM-TOM 1ères ---
+    "Martinique la 1ère": ["Martinique 1ere"],
+    "Guadeloupe la 1ère": ["Guadeloupe 1ere"],
+    "Réunion la 1ère": ["Reunion 1ere"],
+    "Mayotte la 1ère": ["Mayotte 1ere"],
+    "Guyane la 1ère": ["Guyane 1ere"],
+
+    # --- FR: International ---
+    "2M Monde": ["2M"],
+
     # --- UK: Factual ---
     "Discovery History": ["Disc.History", "Disc.History+1", "UK: Discovery History"],
     "Discovery Turbo": ["Disc.Turbo", "Disc.Turbo+1", "UK: DISCOVERY TURBO", "DISCOVERY TURBO"],
     "Discovery Science": ["Disc.Science", "Disc.Sci+1", "Discovery Science", "UK: DISCOVERY SCIENCE"],
     "Crime+Investigation": ["Crime+Inv HD", "Crime+Inv+1", "Crime + Investigation", "Crime+Investigation"],
+
+    # --- US rebrands (old broadcast names <-> current names) ----------------
+    # Provider lineups were captured at different times, so a channel may carry
+    # either its pre- or post-rebrand name. These aliases let a lineup channel
+    # match streams/EPG under EITHER name. US_Combined has been de-duped so the
+    # old and new names never coexist there; per-provider lineups (DISH/Verizon)
+    # keep whatever name the provider used, hence both directions are covered.
+    # NOTE: deliberately NOT aliasing regional Bally/FanDuel/Fox Sports Net
+    # feeds (see the FanDuel TV note above) - that catch-all was harmful.
+    #
+    # Sports
+    "SportsNet Pittsburgh": ["SportsNet Pittsburgh", "AT&T SportsNet Pittsburgh", "ATT SportsNet Pittsburgh", "Root Sports Pittsburgh"],
+    # Premium movies - current names also matching the old multiplex names
+    "MGM+": ["MGM+", "MGM Plus", "MGM+ East", "EPIX", "Epix", "EPIX 1"],
+    "MGM+ Hits": ["MGM+ Hits", "MGM Hits", "EPIX Hits"],
+    "Cinemax Action": ["Cinemax Action", "ActionMax", "Action Max"],
+    "Cinemax Classics": ["Cinemax Classics", "5StarMax", "5 Star Max", "Five Star Max"],
+    "Cinemax Hits HD": ["Cinemax Hits HD", "Cinemax Hits", "MoreMax", "More Max"],
+    # Premium movies - lineups still using the pre-rebrand multiplex names
+    "Action Max": ["Action Max", "ActionMax", "Cinemax Action"],
+    "Five Star Max": ["Five Star Max", "5StarMax", "5 Star Max", "Cinemax Classics"],
+    "More Max": ["More Max", "MoreMax", "Cinemax Hits"],
+    "HBO Signature": ["HBO Signature", "HBO Drama", "HBO Drama HD"],
+    "HBO Zone": ["HBO Zone", "HBO Movies", "HBO Movies HD"],
+    "HBO 2": ["HBO 2", "HBO2", "HBO Hits"],
+    # Entertainment / lifestyle
+    "Magnolia Network": ["Magnolia Network", "Magnolia", "DIY Network", "DIY"],
+    "Great American Family": ["Great American Family", "Great American Country", "GAC", "GAC Family"],
+    "Great American Country": ["Great American Country", "Great American Family", "GAC"],
+    # Tastemade Home/Travel are sibling FAST channels; the lineup carries one
+    # Tastemade entry and folds the Home variant in (shared EPG row upstream).
+    "Tastemade": ["Tastemade", "Tastemade Home"],
+    "Hallmark Drama": ["Hallmark Drama", "Hallmark Family"],
+    # News - DISH lineup still carries the pre-rebrand "WGN America" name.
+    "WGN America": ["WGN America", "WGN", "NewsNation", "News Nation"],
+
+    # --- US: EPG guide-name bridges ---------------------------------------
+    # Some US EPG sources list channels under their full legal/broadcast name
+    # (e.g. "Daystar Television Network" instead of "Daystar"). At Exact match
+    # sensitivity the short lineup name never reaches those entries, so the
+    # channel gets no guide. These aliases bridge the lineup name to the EPG
+    # entry name. NOTE: "TBN" maps to Trinity Broadcasting, NOT "TBN Inspire"
+    # (the Hillsong rebrand, a separate channel - see "Hillsong Channel").
+    "Daystar": ["Daystar", "Daystar Television Network", "Daystar Television Network HD"],
+    "TBN": ["TBN", "Trinity Broadcasting Network", "Trinity Broadcasting Network HD (TBN)"],
+    # Lineup channel "UP" maps to UPtv. Bare "UP" is intentionally NOT a value
+    # (it would 100-match any stream normalizing to "up").
+    "UP": ["UPtv", "UPTV", "UP TV"],
+    "Cheddar News": ["Cheddar News", "Cheddar"],
+    "Galavisión": ["Galavision", "Galavision Cable Network", "Galavision Cable Network HD"],
+    "UniMás": ["UniMas", "UniMas East HD (UNIMAS)", "UniMas East", "Unimas"],
+    "NBC Universo": ["NBC Universo", "Universo", "UNIVERSO"],
+    # Reverse/abbreviation bridges: lineup uses the full name, streams use the
+    # short form (or vice versa). normalize_name() strips a standalone "Channel"
+    # token but NOT a glued one, so the glued "REELZCHANNEL" form is listed
+    # explicitly (the spaced "Reelz Channel" would fold to "Reelz").
+    "Turner Classic Movies": ["Turner Classic Movies", "TCM"],
+    "REELZ": ["REELZ", "Reelz", "ReelzChannel", "REELZCHANNEL"],
+    # More full-name / rebrand / abbreviation bridges confirmed against real US
+    # streams (provider uses a fuller or rebranded name than the lineup).
+    "YES Network": ["YES Network", "YES National"],
+    "Sportsnet New York National": ["Sportsnet New York National", "SNY", "Sportsnet New York", "Sportsnet NY"],
+    "CCTV News": ["CCTV News", "CGTN"],  # CCTV News rebranded to CGTN
+    "Antena 3": ["Antena 3", "Antena 3 Internacional"],
+    "Univision tINovelas": ["Univision tINovelas", "Univision tlnovelas", "Univision tlNovelas", "tlnovelas"],
+    "TV Games Network": ["TV Games Network", "TVG Network"],
+    "Christian Television Network": ["Christian Television Network", "CTN"],
+
+    # --- CA: Bell 2025 Discovery -> CTV rebrands -------------------------
+    # On 2025-01-01 Bell rebranded the Canadian feeds: Animal Planet -> CTV Wild
+    # Channel, Discovery Science -> CTV Nature Channel, Discovery Velocity -> CTV
+    # Speed Channel. The lineup now uses the current names; these aliases let
+    # them still match streams/EPG carrying the old Discovery names.
+    "CTV Wild Channel": ["CTV Wild Channel", "CTV Wild", "Animal Planet"],
+    "CTV Nature Channel": ["CTV Nature Channel", "CTV Nature", "Discovery Science"],
+    "CTV Speed Channel": ["CTV Speed Channel", "CTV Speed", "Discovery Velocity"],
+}
+
+
+# Country-scoped alias overrides.
+#
+# Some channel NAMES exist in more than one country with DIFFERENT stream-name
+# variants. Because CHANNEL_ALIASES is keyed only by channel name, putting a
+# country-specific variant there silently collided with (and clobbered) the
+# entry for the same name in another market - e.g. a France-only "TLC" ->
+# "Discovery Science" mapping overrode the US "TLC" -> "TLC US" entry AND
+# leaked into US/UK/NL/CA lineups, where TLC and Discovery Science are
+# SEPARATE channels (bug-063).
+#
+# These overrides are merged on top of CHANNEL_ALIASES by _build_alias_map()
+# only for the lineup's own country, so they never leak across markets.
+COUNTRY_ALIASES = {
+    "FR": {
+        # TLC France airs on the former Discovery Science feed; some French
+        # IPTV sources still label the stream "Discovery Science".
+        "TLC": ["Discovery Science"],
+        "MTV": ["MTV France"],
+    },
+    "CA": {
+        # Bell rebranded its Canadian Discovery and Investigation Discovery
+        # feeds on 2025-01-01: Discovery Channel -> USA Network, Investigation
+        # Discovery -> Oxygen True Crime. These names collide with the genuine
+        # US channels, so the old-name bridges are CA-scoped (merged only for
+        # CA lineups) to avoid leaking into US "USA Network"/"Oxygen True Crime".
+        "USA Network": ["Discovery Channel"],
+        "Oxygen True Crime": ["Investigation Discovery"],
+    },
 }

--- a/plugins/lineuparr/fuzzy_matcher.py
+++ b/plugins/lineuparr/fuzzy_matcher.py
@@ -10,7 +10,7 @@ import re
 import logging
 import unicodedata
 
-__version__ = "1.3.1"
+__version__ = "1.3.4"
 
 LOGGER = logging.getLogger("plugins.lineuparr.fuzzy_matcher")
 if not LOGGER.handlers:
@@ -21,16 +21,48 @@ LOGGER.setLevel(logging.DEBUG)
 
 # --- Pattern categories for normalization ---
 
+# Unicode categories considered decorative/badge characters by IPTV providers.
+# So = Other Symbol (◉), No = Other Number (², ³), Lm = Modifier Letter
+# (ᴿᴬᵂ, ᴴᴰ, ⱽᴵᴾ superscripts), Sk = Modifier Symbol.
+# Accented letters (é, î, ü…) are Ll/Lu and are NOT in this set.
+# Sm (Math Symbol) is intentionally EXCLUDED: it contains "+", which is a
+# meaningful, channel-distinguishing character (Canal+, Three Stooges+,
+# Comedy Central+). Stripping it regresses those matches.
+_DECORATOR_CATS = frozenset({'So', 'No', 'Lm', 'Sk'})
+
+# Tokens that are non-distinctive stream-label variants (e.g. "ABC News Live"
+# should still match "ABC News"). Used by the subset/divergent guards.
+_NON_DISTINCTIVE_TOKENS = frozenset({"live", "now", "new"})
+
+def _is_distinctive(t):
+    """Return True if token t is distinctive enough to matter in subset/divergent guards."""
+    return t not in _NON_DISTINCTIVE_TOKENS and (len(t) >= 4 or (t.isdigit() and len(t) >= 2))
+
+# Matches "+1" / "+2" time-shift suffixes in the ORIGINAL (pre-normalization)
+# channel name. Must be checked before normalization because "+" is in the Sm
+# category and gets stripped, making "+1" indistinguishable from "1" afterward.
+_PLUS_SHIFT_RE = re.compile(r'\+\s{0,2}\d{1,2}\b')
+
 QUALITY_PATTERNS = [
-    r'\s*\[(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead|Backup)\]\s*',
-    r'\s*\((4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead|Backup)\)\s*',
-    r'^\s*(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)\b\s*',
-    r'\s*\b(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)$',
-    r'\s+\b(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)\b\s+',
+    r'\s*\[(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead|Backup)\]\s*',
+    r'\s*\((4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead|Backup)\)\s*',
+    r'^\s*(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead)\b\s*',
+    r'\s*\b(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead)$',
+    r'\s+\b(4K|8K|UHD|FHD|HD|HDR|HEVC|SD|FD|Unknown|Unk|Slow|Dead)\b\s+',
 ]
 
+# Quality markers that distinguish an upgrade-tier channel from its standard twin.
+# HD/FHD/HEVC are intentionally excluded - they don't create a separate twin channel.
+_UPGRADE_QUALITY_RE = re.compile(r'\b(?:4K|8K|UHD|HDR)\b|ᵁᴴᴰ', re.IGNORECASE)
+
+
+def has_upgrade_quality(name: str) -> bool:
+    """Return True if name contains an upgrade quality marker (4K/8K/UHD/HDR)."""
+    return bool(_UPGRADE_QUALITY_RE.search(name))
+
+
 REGIONAL_PATTERNS = [
-    # East/West are intentionally NOT stripped — they distinguish separate channel feeds
+    # East/West are intentionally NOT stripped - they distinguish separate channel feeds
     # (e.g., "HBO East" and "HBO West" are different channels)
     r'\s[Pp][Aa][Cc][Ii][Ff][Ii][Cc]',
     r'\s[Cc][Ee][Nn][Tt][Rr][Aa][Ll]',
@@ -52,13 +84,32 @@ GEOGRAPHIC_PATTERNS = [
 # Enhanced provider prefix patterns for IPTV-specific naming
 PROVIDER_PREFIX_PATTERNS = [
     r'^(?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\s*[:\-\|]\s*',
-    # Bare country tag + whitespace, no separator (e.g. "US Racer Network").
-    # Restricted to the 2-letter US/UK/CA/AU codes so it cannot eat a real
-    # channel name: "USA Network" (USA != US + space) and "In Country
-    # Television" ("IN") are both safe from this pattern.
-    r'^(?:US|UK|CA|AU)\s+',
+    # Bare country tag + whitespace, no separator (e.g. "US Racer Network",
+    # "FR beIN SPORTS MAX", "MEX Bein Sports"). Restricted to a curated set so
+    # it cannot eat a real channel name: "USA Network" (USA != US + space),
+    # "In Country Television" ("IN") and "IT Crowd" ("IT") are all safe too.
+    # Keep this set in sync with detect_stream_country()'s bare-space branch.
+    r'^(?:US|UK|CA|AU|FR|DE|MX|MEX|FRA|GER)\s+',
+    # "USA " space prefix as a US country tag ("USA  ABC", "USA BET"). A
+    # negative lookahead for NETWORK protects the real channel "USA Network"
+    # (these feeds tag that one as "US ..."/"US: ...", never bare "USA ").
+    # Keep in sync with detect_stream_country()'s USA branch.
+    r'^USA\s+(?!NETWORK\b)',
+    # Country code glued directly to a quality tag with no separator
+    # ("UKSD: Sky Sports", "UKHD ESPN", "USFHD ..."). Detection mirrors this
+    # in detect_stream_country() so these can't leak as wildcards.
+    r'^(?:US|UK)(?:SD|HD|FHD|UHD|FD|HEVC|4K|8K)\b\s*[:\-\|]?\s*',
     r'^\s*\((?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\)\s*',
     r'\s*\|\s*(?:US|USA|UK|CA|AU|FR|DE|ES|IT|NL|BR|MX|IN)\s*$',
+    # Content-category group prefixes used by some IPTV providers.
+    r'^(?:ADULT|EROTIC|PRIME|GOLD)\s*[:\-\|]\s*',
+    # FAST streaming-platform source tags (Roku, Tubi, Pluto, etc.). These mark
+    # the distribution platform, not the channel or its country, so strip them
+    # for matching ("RK: beIN Sports Xtra" -> "beIN Sports Xtra"). A separator
+    # is required so this can't eat real names like "GOLF" or "PLEX TV Movies".
+    # NOT a country signal: detect_stream_country() ignores these (correctly,
+    # since a platform like Roku spans US/CA/UK).
+    r'^(?:RK|GO|TUBI|PLUTO|XUMO|PLEX|STIRR|FREEVEE|GLANCE)\s*[:\-\|]\s*',
 ]
 
 MISC_PATTERNS = [
@@ -70,12 +121,35 @@ MISC_PATTERNS = [
 _KNOWN_COUNTRY_CODES = {
     "US", "UK", "CA", "AU", "DE", "FR", "IT", "ES", "NL", "BR", "MX", "IN",
     "IE", "SE", "NO", "DK", "PT", "PL", "AT", "CH", "BE", "FI",
+    # Codes seen as colon-prefixes in provider feeds (e.g. "TR: 24 TV",
+    # "GR: ...", "IR: IRIB ...", "AL: DigitalB"). normalize_name() already
+    # strips a 2-3 letter colon prefix via GEOGRAPHIC_PATTERNS, so detection
+    # must recognize these too or the streams match cleanly yet evade the
+    # country filter and leak as wildcards (the bug-064 asymmetry). "AR" is
+    # deliberately excluded: in these feeds it tags Arabic-language channels,
+    # not Argentina, so mapping it to a country would be wrong.
+    "TR", "GR", "IR", "AL",
+    # Second batch (2026-06-07): foreign feeds that were leaking in as BACKUP
+    # streams on globally-named channels (CNN, BBC) in a US lineup preview.
+    # Each was confirmed against real stream content (e.g. RO=Acasa, RU=2X2,
+    # AZ=Baku TV, MK=24 Vesti, IL=Kan 11/13/14, CO=Cable Noticias, CR=FUTV).
+    # Provider tags (HUB/AMP/STC/OSN/MEO/MXC) and regions (LA/AFR/AF) are NOT
+    # added: HUB/AMP carry US channels, the rest are not single countries.
+    "BG", "RO", "RU", "AZ", "HR", "TH", "RS", "MK", "IL", "CO", "CR", "CY",
+    # Lower-volume but unambiguous ISO-2 countries also seen as colon-prefixes
+    # (JP=Animax/BS, KR=Arirang, CZ/HU=European feeds, PH=GMA/Manila, NZ).
+    "JP", "KR", "CZ", "HU", "NZ", "PH",
+    # Singletons confirmed from feed content (VN=Vietnam, PK=92 News/8XM,
+    # SI=Arena Sport, ET=Ethiopia via "ETH: Addis TV"). "MT" is NOT added: in
+    # these feeds it tags theme channels (Cooking/Clubbing 4K), not Malta.
+    "VN", "PK", "SI", "ET",
 }
 
 # ISO-3 or colloquial codes seen in M3U streams → ISO-2.
 _ISO3_TO_ISO2 = {
     "USA": "US", "MEX": "MX", "IRE": "IE", "GER": "DE", "FRA": "FR",
     "ITA": "IT", "ESP": "ES", "NLD": "NL", "BRA": "BR", "IND": "IN",
+    "ETH": "ET",
 }
 
 # (PLUTO <COUNTRY>) full-name variants seen in the M3U.
@@ -85,19 +159,43 @@ _PLUTO_COUNTRY_MAP = {
     "GERMANY": "DE", "SPAIN": "ES", "FRANCE": "FR", "ITALY": "IT",
     "CANADA": "CA", "MEXICO": "MX", "INDIA": "IN", "IRELAND": "IE",
     "AUSTRALIA": "AU", "NETHERLANDS": "NL",
-    # "LATIN"/"EUROPE" etc. intentionally omitted — ambiguous region.
+    # "LATIN"/"EUROPE" etc. intentionally omitted - ambiguous region.
 }
 
-# Country pairs that share enough cross-border channels that users consider
-# them interchangeable. US<->CA share CBS/ABC/ESPN/A&E/TSN etc.; US<->MX share
-# the US Spanish-language networks (Univision, Telemundo, Galavision, NBC
-# Universo), whose M3U feeds are frequently tagged MEX. A US lineup should
-# accept a `(CA) ESPN` or `MEX: Galavision` stream, and vice versa.
-_COMPATIBLE_COUNTRIES = {
-    "US": {"CA", "MX"},
-    "CA": {"US"},
-    "MX": {"US"},
+# Cross-border country matching is STRICT by default: a lineup accepts only
+# streams tagged with its own country (plus untagged streams, which can't be
+# proven wrong). Blanket compatibility was removed - it wrongly merged
+# channels that merely share a name across a border (Food Network US != Food
+# Network CA; ESPN US != ESPN MX).
+#
+# The ONLY cross-border exceptions are specific channels that are genuinely the
+# SAME feed on both sides. Keyed by the unordered country pair (frozenset), so
+# the rule applies in both directions. Values are comparison keys produced by
+# _fold_key() (accent-folded, lowercased, alphanumerics only).
+#
+# US<->MX: the US Spanish-language networks, whose M3U feeds are frequently
+# tagged MEX/(MX) even though they are the US feed. To add a genuinely-shared
+# channel, fold its name the same way (e.g. "NBC Universo" -> "nbcuniverso").
+_CROSS_BORDER_SHARED = {
+    frozenset({"US", "MX"}): frozenset({
+        "univision", "unimas", "telemundo", "galavision", "universo",
+        "nbcuniverso", "tudn", "telexitos", "bandamax", "tlnovelas",
+        "univisiontlnovelas", "telemundodeportes", "universonbc",
+    }),
 }
+
+
+def _fold_key(name):
+    """Accent-fold, lowercase, and strip to alphanumerics for set membership.
+
+    "Univisión" -> "univision", "NBC Universo" -> "nbcuniverso". Used to test a
+    channel name against _CROSS_BORDER_SHARED regardless of accents/spacing.
+    """
+    if not name:
+        return ""
+    name = unicodedata.normalize('NFD', name)
+    name = ''.join(c for c in name if unicodedata.category(c) != 'Mn')
+    return re.sub(r'[^a-z0-9]', '', name.lower())
 
 
 def _normalize_country_token(tok):
@@ -132,11 +230,103 @@ def detect_stream_country(name):
     if m:
         return _normalize_country_token(m.group(1))
 
-    m = re.match(r'^\s*([A-Za-z]{2,3})\s*[:|]', name)
+    m = re.match(r'^\s*([A-Za-z]{2,3})\s*[-:|]', name)
+    if m:
+        return _normalize_country_token(m.group(1))
+
+    # Bare country tag + whitespace, no separator (e.g. "US beIN SPORTS (S)",
+    # "CA TSN 1 HD", "FR beIN SPORTS MAX", "MEX Bein Sports"). normalize_name()
+    # strips this exact prefix via PROVIDER_PREFIX_PATTERNS, so the country
+    # filter must recognize it too, otherwise these match a foreign lineup
+    # cleanly but can't be proven wrong-country, and leak in as backup streams.
+    # Restricted to a curated set of unambiguous codes (same set as the prefix
+    # stripper) so it can't eat "USA Network" (USA, not US+space), "IN Country
+    # Television" (IN), or "IT Crowd" (IT). MEX/FRA/GER 3-letter aliases are
+    # included and folded to ISO-2 via _normalize_country_token.
+    m = re.match(r'^\s*(US|UK|CA|AU|FR|DE|MX|MEX|FRA|GER)\s+', name, re.IGNORECASE)
+    if m:
+        return _normalize_country_token(m.group(1))
+
+    # Country code glued directly to a quality tag, no separator ("UKSD: Sky
+    # Sports", "UKHD ESPN", "USFHD ..."). normalize_name() strips this via
+    # PROVIDER_PREFIX_PATTERNS, so detection must match it too, otherwise these
+    # match a foreign lineup cleanly but can't be proven wrong-country and leak
+    # in as backup streams (same asymmetry as bug-064).
+    m = re.match(r'^\s*(US|UK)(?:SD|HD|FHD|UHD|FD|HEVC|4K|8K)\b', name, re.IGNORECASE)
+    if m:
+        return _normalize_country_token(m.group(1))
+
+    # "USA " as a US country tag ("USA  ABC", "USA BET"). The real channel
+    # "USA Network" is tagged "US ..."/"US: ..." in these feeds, never bare
+    # "USA ", so a NETWORK lookahead keeps it from being misread as country=US.
+    m = re.match(r'^\s*USA\s+(?!NETWORK\b)', name, re.IGNORECASE)
+    if m:
+        return "US"
+
+    return None
+
+
+def detect_category_country(category_name):
+    """Detect an ISO-2 country code from a lineup category-name prefix.
+
+    Single-country lineups carry one country code in the filename and use plain
+    theme categories ("News", "Sports", "Movies"). Mixed-country lineups instead
+    encode each channel's country in the category name, e.g. "AU| AUSTRALIA VIP",
+    "UK: Sports", "NZ Movies", "US News". This lets the country filter run
+    per-category when the filename has no single country (e.g.
+    "AU-NZ-UK_Test_Mixed_lineup.json").
+
+    Returns a whitelisted ISO-2 code, or None for ordinary theme categories so
+    the caller falls back to the lineup-level code. Only the curated
+    _KNOWN_COUNTRY_CODES are accepted, so a category like "Sci-Fi" (token "SCI")
+    or "On-Demand" (token "ON") is not misread as a country.
+
+    Two branches with deliberately different breadth:
+      - delimiter branch ("XX:"/"XX-"/"XX|"): accepts ANY code in the full
+        _KNOWN_COUNTRY_CODES set, so a mixed lineup can prefix categories with
+        ES/IT/etc. A theme category that happens to start "XX<delim>" where XX
+        is a real country code (e.g. "IT: ...") IS read as that country - this
+        is intended for the mixed-lineup use case, and such category names do
+        not occur in single-country theme lineups.
+      - bare-space branch ("XX Movies"): restricted to a small curated set so a
+        plain word cannot be eaten by a space-separated token.
+    """
+    if not category_name:
+        return None
+
+    # Country code followed by a delimiter: "AU| ...", "UK: ...", "US-...".
+    m = re.match(r'^\s*([A-Za-z]{2,3})\s*[-:|]', category_name)
+    if m:
+        return _normalize_country_token(m.group(1))
+
+    # Bare country tag + whitespace ("NZ Movies", "US News"). Restricted to a
+    # curated set so an ordinary theme word can't be eaten.
+    m = re.match(r'^\s*(US|UK|CA|AU|NZ|FR|DE|MX|MEX|FRA|GER)\s+', category_name, re.IGNORECASE)
     if m:
         return _normalize_country_token(m.group(1))
 
     return None
+
+
+def country_codes_in_text(text):
+    """Return the set of whitelisted ISO-2 country codes that appear as whole
+    tokens anywhere in `text`.
+
+    A "token" is a maximal run of letters bounded by anything non-alpha (start,
+    end, whitespace, separators like - : |, or wildcards * ?). Only 2-3 letter
+    tokens are considered, and only those that resolve to a known country code
+    (via _normalize_country_token, which folds ISO-3 like USA->US). This is used
+    to warn when a group prefix or EPG source filter targets a country other
+    than the lineup's, e.g. "UK*", "UK-*", "*-UK", "UK Jesmann" all yield {"UK"};
+    "AU:" / "AU " yield {"AU"}; "EPG Share", "Jessman", "DTV-" yield set().
+    """
+    codes = set()
+    for tok in re.split(r'[^A-Za-z]+', text or ""):
+        if 2 <= len(tok) <= 3:
+            cc = _normalize_country_token(tok)
+            if cc:
+                codes.add(cc)
+    return codes
 
 
 class FuzzyMatcher:
@@ -168,6 +358,8 @@ class FuzzyMatcher:
         self._callsign_cache.clear()
 
         for name in names:
+            if self._is_group_header(name):
+                continue
             norm = self.normalize_name(name, user_ignored_tags)
             if norm and len(norm) >= 2:
                 norm_lower = norm.lower()
@@ -206,10 +398,22 @@ class FuzzyMatcher:
 
         original_name = name
 
-        # Quality patterns FIRST (before space normalization)
+        # Strip IPTV provider prefixes BEFORE hyphen normalization so that
+        # "FR - Canal+ FHD" loses its "FR - " while the hyphen is still a
+        # hyphen. After hyphen normalization the separator would become a space
+        # and the pattern would fail to match, leaving "FR" as a stray token.
+        for pattern in PROVIDER_PREFIX_PATTERNS:
+            name = re.sub(pattern, '', name, flags=re.IGNORECASE)
+
+        # Quality patterns (before space normalization). Loop until stable so
+        # chained suffixes like "4K HDR" or "UHD HDR" are fully stripped in
+        # successive passes (each pass may expose a token for the next).
         if ignore_quality:
-            for pattern in QUALITY_PATTERNS:
-                name = re.sub(pattern, '', name, flags=re.IGNORECASE)
+            prev = None
+            while prev != name:
+                prev = name
+                for pattern in QUALITY_PATTERNS:
+                    name = re.sub(pattern, '', name, flags=re.IGNORECASE)
 
         # Normalize spacing around numbers
         name = re.sub(r'([a-zA-Z])(\d)', r'\1 \2', name)
@@ -249,16 +453,19 @@ class FuzzyMatcher:
         name = re.sub(r'([a-z])([A-Z][a-z])', r'\1 \2', name)
         name = re.sub(r'([a-z]{4,})([A-Z]{2,})\b', r'\1 \2', name)
 
-        # Preserve parenthesized East/West -- and the (E)/(W) abbreviations --
-        # as bare words so they survive both the leading-parenthetical strip
-        # below and the generic parenthetical strip (MISC_PATTERNS). Bare
-        # "East"/"West" are intentionally kept (they distinguish separate
-        # feeds); the parenthesized forms must be kept too, or a zoned lineup
-        # channel cannot match a zoned stream (e.g. "Cartoon Network (W)" vs
-        # "US: Cartoon Network West"). Only E/W are converted -- the other
-        # single letters (A/S/H/F/X/D) are stream source/quality tags.
-        name = re.sub(r'\(\s*(?:east|e)\s*\)', ' East ', name, flags=re.IGNORECASE)
-        name = re.sub(r'\(\s*(?:west|w)\s*\)', ' West ', name, flags=re.IGNORECASE)
+        # Strip region tokens (East / Eastern / West and the (E)/(W)
+        # abbreviations) for SCORING. Region CORRECTNESS - East vs West vs
+        # Pacific - is enforced separately by the post-match region filter in
+        # match_all_streams, which reads the ORIGINAL un-normalized names, not
+        # this output. Stripping here lets a regionless lineup channel
+        # ("Food Network") still score-match a region-tagged stream
+        # ("Food Network Eastern" / "... East") instead of being dragged below
+        # threshold by the extra token; the filter then accepts it (regionless
+        # defaults to East). "Western"/"Westerns" is a movie genre, NOT a
+        # region, so bare "west" is stripped only on a word boundary (\bwest\b
+        # does not match inside "western") and "western" is never touched.
+        name = re.sub(r'\(\s*(?:eastern|east|e|west|w)\s*\)', ' ', name, flags=re.IGNORECASE)
+        name = re.sub(r'\b(?:eastern|east|west)\b', ' ', name, flags=re.IGNORECASE)
 
         # Remove leading parenthetical prefixes
         while name.lstrip().startswith('('):
@@ -266,10 +473,6 @@ class FuzzyMatcher:
             if new_name == name:
                 break
             name = new_name
-
-        # Remove IPTV provider prefixes (enhanced for Lineuparr)
-        for pattern in PROVIDER_PREFIX_PATTERNS:
-            name = re.sub(pattern, '', name, flags=re.IGNORECASE)
 
         # Build pattern list based on flags
         patterns_to_apply = []
@@ -308,6 +511,15 @@ class FuzzyMatcher:
         name = re.sub(r'\s+Network\s*$', '', name, flags=re.IGNORECASE)
         name = re.sub(r'\s+Channel\s*$', '', name, flags=re.IGNORECASE)
         name = re.sub(r'\s+TV\s*$', '', name, flags=re.IGNORECASE)
+
+        # Strip decorative Unicode markers (◉, ², superscript letters ᴿᴬᵂ…)
+        # that some IPTV providers append as quality/status badges. Only
+        # characters in decorator categories are removed; accented letters
+        # (é, î, ü…) are in Ll/Lu and are preserved.
+        name = ''.join(
+            ' ' if unicodedata.category(c) in _DECORATOR_CATS else c
+            for c in name
+        )
 
         # Clean up whitespace
         name = re.sub(r'\s+', ' ', name).strip()
@@ -372,7 +584,7 @@ class FuzzyMatcher:
         "america racing" vs "america bbc" while allowing single-token matches.
         """
         # "network"/"channel"/"television" are generic brand-suffix words, not
-        # distinctive — treat as common so the subset guard does not reject
+        # distinctive - treat as common so the subset guard does not reject
         # cases like "FanDuel Sports Cincinnati" vs "FanDuel Sports Network
         # Cincinnati". (They're already stripped from end-of-string by
         # normalize_name; this catches mid-string occurrences.)
@@ -405,18 +617,19 @@ class FuzzyMatcher:
             unique_b = tokens_b - tokens_a
 
             # Subset guard: when one side is a strict subset of the other and
-            # the larger side has a distinctive (>=5 char) token the smaller
-            # lacks, the candidate is a more specific channel than the query
-            # and the high fuzzy score is a false positive. Catches e.g.
-            # "In Country Television" {country, television} vs "Country Music
-            # Television" {country, music, television} — "music" distinguishes
-            # them. Short extras like "live"/"two" do not trigger this guard,
-            # preserving legitimate matches like "ABC News" → "ABC News Live".
+            # the larger side has a distinctive token the smaller lacks, the
+            # candidate is a more specific channel than the query and the high
+            # fuzzy score is a false positive. Catches e.g. "Nickelodeon" vs
+            # "Nickelodeon Teen". Threshold is >=4 chars; "live"/"now" are
+            # explicitly non-distinctive (stream label variants) so "ABC News"
+            # still matches "ABC News Live". Pure-digit tokens >=2 chars
+            # (e.g. "360") are also distinctive: "Canal+Sport" must not match
+            # "Canal+Sport 360".
             if not unique_a:
-                if any(len(t) >= 5 for t in unique_b):
+                if any(_is_distinctive(t) for t in unique_b):
                     return False
             elif not unique_b:
-                if any(len(t) >= 5 for t in unique_a):
+                if any(_is_distinctive(t) for t in unique_a):
                     return False
 
             # Divergent guard: when BOTH sides have unique tokens AND at least
@@ -471,6 +684,15 @@ class FuzzyMatcher:
         return " ".join(tokens)
 
     @staticmethod
+    def _is_group_header(name):
+        """Return True for M3U playlist group/section separators like '##### EUROSPORT #####'
+        or '## 24/7 COMEDY ##'. These are not real stream names and must be
+        excluded from matching. A run of 2+ #/=/* is decorative (no real channel
+        name contains "##"/"=="/"**"); pipes need a run of 3+ since a single "|"
+        is a common in-name separator ("001 | Team A vs Team B")."""
+        return bool(re.search(r'[#=*]{2,}|\|{3,}', name or ""))
+
+    @staticmethod
     def _trailing_number(name):
         """Return the integer value of a space-separated, purely-numeric
         trailing token, or None. 'HBO 2' -> 2, 'DIRECTV 4K Live 1' -> 1,
@@ -499,7 +721,7 @@ class FuzzyMatcher:
 
     # Words that match the callsign regex shape but are never US broadcast
     # callsigns. A US callsign (K/W + 2-4 letters) is shape-identical to many
-    # common English words, so the loose Priority-4 pattern mis-extracts them —
+    # common English words, so the loose Priority-4 pattern mis-extracts them -
     # e.g. "with" in "Bizarre Foods with Andrew Zimmern" becomes callsign
     # "WITH". Regex alone cannot tell "WITH" from "WABC"; frequent K/W-initial
     # words are denied explicitly so they never extract as a callsign. WWE/WWF/
@@ -561,7 +783,7 @@ class FuzzyMatcher:
         """
         Cached wrapper around _compute_callsign_with_confidence.
 
-        Extraction is pure in channel_name, so results are memoized — the
+        Extraction is pure in channel_name, so results are memoized - the
         anchor calls this once per stream over a fixed candidate list, which
         is otherwise massively redundant across the per-channel matching
         loop. Cache is cleared by precompute_normalizations.
@@ -612,7 +834,7 @@ class FuzzyMatcher:
 
         matches = []
 
-        # Normalize all aliases — track spaced and nospace versions separately
+        # Normalize all aliases - track spaced and nospace versions separately
         alias_lookup = {}  # normalized_lower -> alias (for exact matching, includes both forms)
         alias_spaced = []  # only the spaced (original) normalized forms (for similarity matching)
         for alias in aliases:
@@ -630,6 +852,8 @@ class FuzzyMatcher:
             return []
 
         for candidate in candidate_names:
+            if self._is_group_header(candidate):
+                continue
             candidate_lower, candidate_nospace = self._get_cached_norm(candidate, user_ignored_tags)
             if not candidate_lower:
                 continue
@@ -655,12 +879,18 @@ class FuzzyMatcher:
             effective_threshold = self._length_scaled_threshold(self.match_threshold, best_alias_len)
 
             if score >= effective_threshold and score < 100:
-                # Aliases are short/curated — a fuzzy alias match must share a
+                # Aliases are short/curated - a fuzzy alias match must share a
                 # majority of tokens, not just one. This rejects false positives
                 # like alias "ABC News" vs stream "BBC News" (93%, shares only
                 # "news"; the 3-char call sign "abc"/"bbc" is below the basic
                 # overlap guard's 4-char token floor).
-                if not self._has_token_overlap(best_alias_norm, candidate_lower, require_majority=True):
+                # Use process_string_for_matching (NFD) so accented tokens like
+                # "chérie" match their unaccented stream form "cherie".
+                if not self._has_token_overlap(
+                    self.process_string_for_matching(best_alias_norm),
+                    self.process_string_for_matching(candidate_lower),
+                    require_majority=True,
+                ):
                     continue
 
             if score >= effective_threshold:
@@ -768,7 +998,7 @@ class FuzzyMatcher:
         return None, 0, None
 
     def match_all_streams(self, lineup_name, candidate_names, alias_map, channel_number=None,
-                          user_ignored_tags=None, lineup_country=None):
+                          user_ignored_tags=None, lineup_country=None, quality_aware=False):
         """
         Full matching pipeline for Lineuparr: alias → exact → substring → fuzzy, with number boost.
         Returns ALL matching streams sorted by score.
@@ -779,6 +1009,9 @@ class FuzzyMatcher:
             alias_map: Alias dict
             channel_number: Expected channel number for boost
             user_ignored_tags: Tags to strip
+            quality_aware: When True, upgrade streams (4K/8K/UHD/HDR) are excluded
+                from standard channels. Streams listed in alias_map for this channel bypass
+                the filter (e.g. "France 2": ["FRANCE 2 4K HDR"] allows that specific stream).
 
         Returns:
             List of (stream_name, score, match_type) tuples sorted by score desc.
@@ -788,6 +1021,32 @@ class FuzzyMatcher:
 
         if user_ignored_tags is None:
             user_ignored_tags = []
+
+        # Quality-aware pre-filtering (opt-in via quality_aware).
+        # Both tiers are gated: upgrade channels only match upgrade streams,
+        # standard channels only match standard streams. Streams listed in
+        # alias_map for either tier bypass the filter.
+        if quality_aware:
+            lineup_is_upgrade = has_upgrade_quality(lineup_name or "")
+            explicit_bypass = set()
+            if alias_map:
+                raw = alias_map.get(lineup_name, [])
+                alias_list = [raw] if isinstance(raw, str) else list(raw)
+                norm_aliases = {
+                    self.normalize_name(a, ignore_quality=False).lower()
+                    for a in alias_list
+                    if self.normalize_name(a, ignore_quality=False)
+                }
+                for c in candidate_names:
+                    norm_c = self.normalize_name(c, ignore_quality=False)
+                    if norm_c and norm_c.lower() in norm_aliases:
+                        explicit_bypass.add(c)
+            candidate_names = [
+                c for c in candidate_names
+                if has_upgrade_quality(c) == lineup_is_upgrade or c in explicit_bypass
+            ]
+            if not candidate_names:
+                return []
 
         # Callsign anchor (asymmetric): extract the lineup channel's US
         # broadcast callsign up front. Used after the fuzzy stages to floor
@@ -815,15 +1074,26 @@ class FuzzyMatcher:
             # channel ("DIRECTV 4K Live 1" vs "... Live 2") -- used to skip
             # those near-identical false positives in the fuzzy stages below.
             query_trailing_num = self._trailing_number(normalized_query_lower)
+            # Detect "+1"/"+2" time-shift suffix so shift channels never match
+            # non-shift streams and vice versa ("Nickelodeon+1" vs "Nickelodeon").
+            # Must check the ORIGINAL name: normalize_name strips "+" (Sm category)
+            # so "+1" becomes "1" post-normalization and would be undetectable.
+            query_is_shift = bool(_PLUS_SHIFT_RE.search(lineup_name or ""))
 
             for candidate in candidate_names:
                 if candidate in all_matches:
                     continue  # Already matched via alias
+                if self._is_group_header(candidate):
+                    continue  # Skip M3U group/section separators
 
                 # Use cached normalizations for performance
                 candidate_lower, candidate_nospace = self._get_cached_norm(candidate, user_ignored_tags)
                 if not candidate_lower:
                     continue
+
+                cand_is_shift = bool(_PLUS_SHIFT_RE.search(candidate))
+                if query_is_shift != cand_is_shift:
+                    continue  # Shift channel (+1/+2) must only match shift streams
 
                 if query_trailing_num is not None:
                     cand_trailing_num = self._trailing_number(candidate_lower)
@@ -896,42 +1166,48 @@ class FuzzyMatcher:
         # Filter out wrong-country matches. A stream whose name carries a
         # recognized country marker (e.g. "UK: Discovery Channel", "(IN) Bloomberg",
         # "(PLUTO Brazil) MTV") and that marker differs from the lineup's country
-        # is dropped. Streams without a country marker are kept — we can't prove
+        # is dropped. Streams without a country marker are kept - we can't prove
         # they're wrong and over-filtering breaks lineups whose M3U sources don't
-        # tag country at all. Countries in _COMPATIBLE_COUNTRIES (US↔CA) are
-        # treated as a single compatibility class.
+        # tag country at all.
+        #
+        # Matching is STRICT by default: only the lineup's own country passes.
+        # The single exception is a channel that is genuinely the same feed
+        # across a border (e.g. US Spanish networks tagged MEX) - see
+        # _CROSS_BORDER_SHARED. This deliberately rejects same-name-different-
+        # channel cases like "(CA) Food Network" or "(MX) ESPN" for a US lineup.
         if lineup_country:
             lc = lineup_country.upper()
             # Defensive: if caller passes an unrecognized code, skip filtering
             # rather than drop every country-marked candidate.
             if lc in _KNOWN_COUNTRY_CODES:
-                accepted = _COMPATIBLE_COUNTRIES.get(lc, set()) | {lc}
+                nq_fold = _fold_key(normalized_query)
                 kept = {}
                 for name, val in all_matches.items():
                     sc = detect_stream_country(name)
-                    if sc is None or sc in accepted:
+                    if sc is None or sc == lc:
                         kept[name] = val
-                    else:
-                        self.country_filter_drops += 1
+                        continue
+                    shared = _CROSS_BORDER_SHARED.get(frozenset({lc, sc}))
+                    if shared and nq_fold in shared:
+                        kept[name] = val  # genuinely-shared cross-border feed
+                        continue
+                    self.country_filter_drops += 1
                 all_matches = kept
 
-        # Filter out wrong-region matches (East vs West vs Pacific)
-        # Check both normalized query AND original name for regional indicators.
-        # normalize_name converts (E)/(W) to bare East/West and strips other
-        # parentheticals, so detect abbreviated regional suffixes (incl. the
-        # Pacific (P) abbreviation it does drop) from the original name.
-        query_lower = (normalized_query or "").lower()
+        # Filter out wrong-region matches (East vs West vs Pacific).
+        # Detect the lineup channel's region from the ORIGINAL un-normalized
+        # name: normalize_name now strips East/West/Eastern (and Pacific via
+        # REGIONAL_PATTERNS) for scoring, so the normalized form no longer
+        # carries the region word. "east" as a substring also catches the
+        # adjective "Eastern"; for west we require the word but exclude the
+        # "western"/"westerns" genre.
         original_lower = (lineup_name or "").lower()
         # Detect (e)/(w)/(p) abbreviations in the original name
         _has_abbrev_east = bool(re.search(r'\(\s*e\s*\)', original_lower))
         _has_abbrev_west = bool(re.search(r'\(\s*w\s*\)', original_lower))
         _has_abbrev_pacific = bool(re.search(r'\(\s*p\s*\)', original_lower))
-        query_has_east = "east" in query_lower or _has_abbrev_east
-        query_has_west = ("west" in query_lower and "western" not in query_lower) or _has_abbrev_west
-        # REGIONAL_PATTERNS strips the full word "pacific" during normalize_name
-        # (unlike east/west which are preserved), so we must detect it from the
-        # original lineup name. Without this, "Sportsnet Pacific" normalizes to
-        # "Sportsnet" and wrongly matches a regionless "Sportsnet" stream.
+        query_has_east = "east" in original_lower or _has_abbrev_east
+        query_has_west = ("west" in original_lower and "western" not in original_lower) or _has_abbrev_west
         query_has_pacific = ("pacific" in original_lower) or _has_abbrev_pacific
 
         if query_has_east or query_has_west or query_has_pacific:
@@ -991,7 +1267,7 @@ class FuzzyMatcher:
         # the overlap between the candidate's ORIGINAL tokens and the lineup
         # channel's ORIGINAL tokens. The secondary key disambiguates ties caused
         # by normalize_name collapsing brand-name timezones (e.g. "Comedy TV"
-        # and "Comedy Central" both normalize to "comedy") — without it, the
+        # and "Comedy Central" both normalize to "comedy") - without it, the
         # winner is whichever candidate happened to appear first in the EPG
         # source list. The original-token overlap correctly prefers
         # "USA: Comedy TV" over "(US) Comedy Central (S)" when matching
@@ -1002,7 +1278,26 @@ class FuzzyMatcher:
             cand_tokens = set(re.findall(r'[a-z0-9]+', candidate_name.lower()))
             return len(lineup_tokens & cand_tokens)
 
+        # Secondary sort key: prefer streams whose country marker matches the
+        # lineup country (score 1) over streams with an unrecognized prefix like
+        # AF:, TS:, MEO: that pass the hard country filter but should rank below
+        # FR: streams (score 0). Streams with a recognized but wrong country
+        # (already dropped by the filter) would score -1.
+        _sort_lc = lineup_country.upper() if lineup_country else None
+        _sort_active = bool(_sort_lc and _sort_lc in _KNOWN_COUNTRY_CODES)
+
+        def _country_key(candidate_name):
+            if _sort_active:
+                sc = detect_stream_country(candidate_name)
+                # Streams tagged with the lineup's own country rank first; any
+                # surviving cross-border-shared or untagged stream ranks below.
+                return 1 if sc == _sort_lc else 0
+            return 0
+
         results = [(name, score, mtype) for name, (score, mtype) in all_matches.items()]
-        results.sort(key=lambda x: (x[1], _orig_overlap(x[0])), reverse=True)
+        results.sort(
+            key=lambda x: (x[1], _country_key(x[0]), _orig_overlap(x[0])),
+            reverse=True,
+        )
         return results
 

--- a/plugins/lineuparr/plugin.json
+++ b/plugins/lineuparr/plugin.json
@@ -1,10 +1,11 @@
 {
   "name": "Lineuparr",
-  "version": "1.26.1431300",
+  "version": "1.26.1641222",
   "description": "Mirror real-world provider channel lineups by creating channel groups, channels, and fuzzy-matching IPTV streams to them.",
   "author": "PiratesIRC",
   "license": "MIT",
   "repo_url": "https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin",
+  "help_url": "https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin",
   "min_dispatcharr_version": "v0.20.0",
   "_fields_note": "Settings fields are defined dynamically by the Plugin.fields property in plugin.py (the single source of truth \u2014 it builds live dropdowns for lineups, M3U/EPG sources and profiles). Dispatcharr only falls back to a manifest 'fields' array when the plugin provides none, so it is intentionally omitted here to prevent drift.",
   "fields": [],

--- a/plugins/lineuparr/plugin.py
+++ b/plugins/lineuparr/plugin.py
@@ -11,28 +11,29 @@ import csv
 import os
 import re
 import time
+import fnmatch
 import threading
 from datetime import datetime, timedelta
 from glob import glob
 
 from django.db import transaction
 
-from .fuzzy_matcher import FuzzyMatcher
-from .aliases import CHANNEL_ALIASES
+from .fuzzy_matcher import FuzzyMatcher, has_upgrade_quality, detect_category_country, country_codes_in_text
+from .aliases import CHANNEL_ALIASES, COUNTRY_ALIASES
 from .progress_status import save_progress_atomic, load_progress, build_status_message
 
 from apps.channels.models import Channel, ChannelGroup, ChannelProfile, ChannelProfileMembership, ChannelStream, Stream
 from apps.m3u.models import M3UAccount
 from core.utils import send_websocket_update
 
-# EPG models (optional — EPG matching disabled if not available)
+# EPG models (optional - EPG matching disabled if not available)
 try:
     from apps.epg.models import EPGData, EPGSource, ProgramData
     _EPG_AVAILABLE = True
 except ImportError:
     _EPG_AVAILABLE = False
 
-# Logo model (optional — logo assignment disabled if not available)
+# Logo model (optional - logo assignment disabled if not available)
 try:
     from apps.channels.models import Logo
     _LOGO_AVAILABLE = True
@@ -63,10 +64,11 @@ def _clean_json_text(s):
 
 
 class PluginConfig:
-    PLUGIN_VERSION = "1.26.1431300"
+    PLUGIN_VERSION = "1.26.1641222"
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True
+    DEFAULT_QUALITY_AWARE_STREAM_MATCHING = False
     DEFAULT_RATE_LIMITING = "none"
     DEFAULT_CHANNEL_NUMBERING = "lineup"
 
@@ -186,7 +188,7 @@ class ProgressTracker:
         self._publish("done", summary=summary)
 
     def _publish(self, status, summary=None):
-        """Write the progress state file (best-effort — a write failure is
+        """Write the progress state file (best-effort - a write failure is
         logged but never interrupts the operation)."""
         record = {
             "status": status,
@@ -316,6 +318,11 @@ class Plugin:
                 pass
         # Alphabetize (case-insensitive), keeping "All EPG sources" pinned first
         epg_source_options[1:] = sorted(epg_source_options[1:], key=lambda o: o["label"].lower())
+        # Readable list of discovered EPG source names for the free-text field's
+        # help (the field is no longer a single-select, so the dropdown options
+        # are surfaced here instead).
+        epg_source_names = [o["label"] for o in epg_source_options[1:]]
+        epg_sources_hint = ", ".join(epg_source_names) if epg_source_names else "(none discovered)"
 
         # Discover channel profiles
         profile_options = [{"value": "_none", "label": "None (don't enable in profiles)"}]
@@ -354,10 +361,16 @@ class Plugin:
             {
                 "id": "epg_sources",
                 "label": "EPG Sources for Matching",
-                "type": "select",
-                "default": "_all",
-                "options": epg_source_options,
-                "help_text": "Which EPG source to match against. 'All' uses every source, ordered by the priority configured in Dispatcharr.",
+                "type": "string",
+                "default": "",
+                "placeholder": "blank = All  |  UK*, EPG Share  |  Jessman",
+                "help_text": (
+                    "Which EPG source(s) to match against. Leave blank for All (every source, "
+                    "ordered by the priority configured in Dispatcharr). Otherwise list one or "
+                    "more source names separated by commas; shell wildcards * and ? are allowed "
+                    "(e.g. 'UK*' matches every source whose name starts with UK). Earlier names "
+                    "win on priority. Available sources: " + epg_sources_hint
+                ),
             },
             {
                 "id": "channel_profiles",
@@ -437,11 +450,31 @@ class Plugin:
                 "help_text": "How closely stream and EPG names must match channel names. Lower = more matches but more errors.",
             },
             {
+                "id": "refresh_epg_after_match",
+                "label": "Refresh EPG After Matching",
+                "type": "boolean",
+                "default": True,
+                "help_text": "After EPG matching, trigger a Dispatcharr EPG refresh so newly matched channels get program info. Only the sources listed in 'EPG Sources for Matching' that were actually matched to lineup channels are refreshed.",
+            },
+            {
                 "id": "prioritize_quality",
                 "label": "Order Matched Streams by Quality",
                 "type": "boolean",
                 "default": True,
                 "help_text": "Sort attached streams by quality (4K > UHD > FHD > HD > SD). Uses probed resolution if available.",
+            },
+            {
+                "id": "quality_aware_stream_matching",
+                "label": "Quality-Aware Stream Matching",
+                "type": "boolean",
+                "default": False,
+                "help_text": (
+                    "When on, if the lineup contains both TF1 and TF1 UHD, each is restricted "
+                    "to streams of its own quality tier: TF1 only matches standard streams, "
+                    "TF1 UHD only matches upgrade streams (4K/8K/UHD/HDR). "
+                    "Channels with no twin in the lineup are unaffected. "
+                    "Streams listed in a channel's aliases bypass this filter."
+                ),
             },
             {
                 "id": "preserve_existing_streams",
@@ -652,6 +685,41 @@ class Plugin:
         return None, None
 
     @staticmethod
+    def _resolve_category_country(category_name, lineup_cc, logger=None):
+        """Country code to enforce for a category's channels.
+
+        Mixed-country lineups (filename like "AU-NZ-UK_Test_Mixed_lineup.json")
+        do not match the single {CC}_ filename pattern, so lineup_cc is None and
+        the country filter would otherwise be disabled, letting foreign streams
+        (e.g. a Canadian beIN feed) attach to an Australian channel as backups.
+        For those lineups the country is encoded in the category name
+        ("AU| AUSTRALIA VIP"). Prefer the per-category code when present; fall
+        back to the lineup-level code for ordinary single-country lineups whose
+        categories are plain themes ("News", "Sports").
+
+        When a logger is supplied and the category overrides the lineup code,
+        the override is logged (so the three matching loops stay consistent).
+        """
+        cat_cc = detect_category_country(category_name) or lineup_cc
+        if logger is not None and cat_cc and cat_cc != lineup_cc:
+            logger.info(f"{LOG_PREFIX} Category '{category_name}' country: {cat_cc} (from category name)")
+        return cat_cc
+
+    @staticmethod
+    def _parse_source_filter(raw):
+        """Tokenize a comma-separated source filter into (tokens, is_all).
+
+        Tokens are comma-split and individually stripped (each may carry shell
+        wildcards). is_all is True when the filter means "every source": a blank
+        value, or any token equal to "_all", "all", or "*". Single source of
+        truth for the EPG-source "all" test used across filtering, validation,
+        and the CSV header.
+        """
+        tokens = [t.strip() for t in (raw or "").split(",") if t.strip()]
+        is_all = (not tokens) or any(t.lower() in ("_all", "all", "*") for t in tokens)
+        return tokens, is_all
+
+    @staticmethod
     def _extract_epg_country(tvg_id):
         """Extract 2-letter country code from a tvg_id like 'CNN.us' or 'CNN.US_source1'.
         Returns lowercase country code or None."""
@@ -821,8 +889,23 @@ class Plugin:
         return streams
 
     def _build_alias_map(self, settings, logger):
-        """Merge built-in aliases with user custom aliases."""
+        """Merge built-in aliases with user custom aliases.
+
+        Built-in aliases are global (keyed by channel name). Country-scoped
+        overrides from COUNTRY_ALIASES are merged on top for THIS lineup's
+        country only, so a name that exists in multiple markets (e.g. "TLC",
+        "MTV") doesn't leak one country's stream-name variants into another
+        (bug-063). Custom user aliases are merged last and win.
+        """
         alias_map = dict(CHANNEL_ALIASES)
+
+        try:
+            lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
+        except Exception:
+            lineup_cc = None
+        if lineup_cc:
+            for k, v in COUNTRY_ALIASES.get(lineup_cc.upper(), {}).items():
+                alias_map[k] = list(dict.fromkeys(alias_map.get(k, []) + list(v)))
 
         custom_str = _clean_json_text(settings.get("custom_aliases") or "")
         if custom_str:
@@ -836,7 +919,7 @@ class Plugin:
                 merged = 0
                 for k, v in custom.items():
                     # Accept a list of aliases, or a bare string as a single
-                    # alias. Anything else is a mistake — warn instead of
+                    # alias. Anything else is a mistake - warn instead of
                     # silently dropping it (silent drops were a known
                     # source of "my aliases don't work" complaints).
                     if isinstance(v, str):
@@ -845,7 +928,7 @@ class Plugin:
                         aliases = v
                     else:
                         logger.warning(
-                            f"{LOG_PREFIX} custom_aliases: ignoring '{k}' — value "
+                            f"{LOG_PREFIX} custom_aliases: ignoring '{k}' - value "
                             f"must be a string or list, got {type(v).__name__}"
                         )
                         continue
@@ -854,7 +937,7 @@ class Plugin:
                              if isinstance(a, str) and a.strip()]
                     if not clean:
                         logger.warning(
-                            f"{LOG_PREFIX} custom_aliases: ignoring '{k}' — no "
+                            f"{LOG_PREFIX} custom_aliases: ignoring '{k}' - no "
                             f"usable (non-empty string) aliases"
                         )
                         continue
@@ -870,10 +953,47 @@ class Plugin:
             elif custom is not None:
                 logger.warning(
                     f"{LOG_PREFIX} custom_aliases must be a JSON object mapping "
-                    f"channel names to aliases, got {type(custom).__name__} — ignored"
+                    f"channel names to aliases, got {type(custom).__name__} - ignored"
                 )
 
         return alias_map
+
+    def _build_upgrade_twin_set(self, lineup, matcher):
+        """Return lineup channel names (both tiers) that have a twin in the other tier.
+
+        Example: if the lineup contains both "France 2" and "France 2 UHD", both
+        are returned. The matcher then restricts each to streams of its own quality
+        tier (standard streams for "France 2", upgrade streams for "France 2 UHD").
+        """
+        all_names = [ch["name"] for cat in lineup["categories"].values() for ch in cat]
+        upgrade_bases = set()
+        standard_bases = set()
+        for name in all_names:
+            base = matcher.normalize_name(name, ignore_quality=True)
+            if base:
+                if has_upgrade_quality(name):
+                    upgrade_bases.add(base.lower())
+                else:
+                    standard_bases.add(base.lower())
+        twin_set = set()
+        for name in all_names:
+            base = matcher.normalize_name(name, ignore_quality=True)
+            if base:
+                if has_upgrade_quality(name) and base.lower() in standard_bases:
+                    twin_set.add(name)
+                elif not has_upgrade_quality(name) and base.lower() in upgrade_bases:
+                    twin_set.add(name)
+        return twin_set
+
+    def _get_upgrade_twin_set(self, settings, lineup, matcher, logger=None):
+        """Return the upgrade twin set if quality_aware_stream_matching is enabled, else empty set."""
+        if not settings.get("quality_aware_stream_matching", PluginConfig.DEFAULT_QUALITY_AWARE_STREAM_MATCHING):
+            return set()
+        twin_set = self._build_upgrade_twin_set(lineup, matcher)
+        if logger and twin_set:
+            logger.info(f"{LOG_PREFIX} Quality-aware matching active for {len(twin_set)} channel(s)")
+            logger.debug(f"{LOG_PREFIX} Quality-aware twins: {sorted(twin_set)}")
+        return twin_set
 
     def _get_filtered_epg_data(self, settings, logger):
         """Fetch EPG data, optionally filtered and prioritized by selected sources."""
@@ -884,12 +1004,15 @@ class Plugin:
         all_epg = list(EPGData.objects.all().values('id', 'name', 'tvg_id', 'epg_source'))
         logger.info(f"{LOG_PREFIX} Fetched {len(all_epg)} EPG data entries")
 
-        epg_sources_str = (settings.get("epg_sources") or "").strip()
-        if not epg_sources_str or epg_sources_str == "_all":
-            # "All" selected: order EPG entries by Dispatcharr's per-source
-            # priority (EPGSource.priority — higher number = higher priority)
-            # so downstream consumers that take the first match honor the
-            # priority the user configured in Dispatcharr.
+        # Comma-separated source names, each of which may carry shell wildcards
+        # (* and ?). Blank / "_all" / "all" / "*" mean "every source".
+        tokens, select_all = self._parse_source_filter(settings.get("epg_sources"))
+
+        if select_all:
+            # "All": order EPG entries by Dispatcharr's per-source priority
+            # (EPGSource.priority - higher number = higher priority) so
+            # downstream consumers that take the first match honor the priority
+            # the user configured in Dispatcharr.
             priority_by_id = {
                 src['id']: (src['priority'] or 0)
                 for src in EPGSource.objects.all().values('id', 'priority')
@@ -904,30 +1027,33 @@ class Plugin:
             )
             return all_epg
 
-        # Map source names to IDs (case-insensitive)
-        available = {}
-        for src in EPGSource.objects.all().values('id', 'name'):
-            available[src['name'].strip().upper()] = src['id']
-
-        source_names = [s.strip() for s in epg_sources_str.split(",") if s.strip()]
-        valid_ids = []
+        # Match each token against available source names (case-insensitive,
+        # wildcards via fnmatch). A plain name with no wildcard is an exact
+        # match. Sources keep the order their first matching token appeared in,
+        # so earlier tokens win on priority.
+        available = [
+            (src['name'], src['id'])
+            for src in EPGSource.objects.all().values('id', 'name')
+        ]
+        # src_id -> priority index (insertion order = first matching token wins).
         priority_map = {}
+        for token in tokens:
+            tk = token.upper()
+            matched_any = False
+            for name, src_id in available:
+                if fnmatch.fnmatch((name or "").upper(), tk):
+                    matched_any = True
+                    priority_map.setdefault(src_id, len(priority_map))
+            if not matched_any:
+                logger.warning(f"{LOG_PREFIX} EPG source pattern matched nothing: '{token}'")
 
-        for idx, name in enumerate(source_names):
-            src_id = available.get(name.upper())
-            if src_id:
-                valid_ids.append(src_id)
-                priority_map[src_id] = idx
-            else:
-                logger.warning(f"{LOG_PREFIX} EPG source not found: '{name}'")
-
-        if not valid_ids:
+        if not priority_map:
             logger.warning(f"{LOG_PREFIX} No valid EPG sources matched. Using all EPG data.")
             return all_epg
 
-        filtered = [e for e in all_epg if e.get('epg_source') in valid_ids]
+        filtered = [e for e in all_epg if e.get('epg_source') in priority_map]
         filtered.sort(key=lambda e: priority_map.get(e.get('epg_source'), 999))
-        logger.info(f"{LOG_PREFIX} Filtered to {len(filtered)} EPG entries from {len(valid_ids)} source(s)")
+        logger.info(f"{LOG_PREFIX} Filtered to {len(filtered)} EPG entries from {len(priority_map)} source(s)")
         return filtered
 
     def _get_epg_ids_with_programs(self, epg_ids, logger):
@@ -1134,7 +1260,8 @@ class Plugin:
                     epg_val = settings.get('epg_sources', '_all')
                     try:
                         if _EPG_AVAILABLE:
-                            if epg_val == '_all':
+                            _, _epg_all = self._parse_source_filter(epg_val)
+                            if _epg_all:
                                 epg_names = [src['name'] for src in EPGSource.objects.all().values('name')]
                                 f.write(f"# EPG Sources: {', '.join(epg_names) or '(none)'} (all)\n")
                             else:
@@ -1305,7 +1432,8 @@ class Plugin:
                 results.append({"Setting": "EPG Data", "Value": f"{epg_count} entries from {source_count} sources", "Status": "OK"})
 
                 epg_sources_str = (settings.get("epg_sources") or "").strip()
-                if epg_sources_str and epg_sources_str != "_all":
+                _, epg_all = self._parse_source_filter(epg_sources_str)
+                if not epg_all:
                     filtered = self._get_filtered_epg_data(settings, logger)
                     results.append({"Setting": "EPG Sources Filter", "Value": epg_sources_str, "Status": f"OK ({len(filtered)} entries after filtering)"})
                 else:
@@ -1315,6 +1443,39 @@ class Plugin:
                 errors += 1
         else:
             results.append({"Setting": "EPG Data", "Value": "EPG models not available", "Status": "SKIP"})
+
+        # Country mismatch warnings: when the selected lineup has a single
+        # country code (e.g. US_Combined -> US), warn if the Channel Group Prefix
+        # or the EPG Sources filter targets a DIFFERENT country code. This
+        # catches setups like a US lineup with prefix "AU " or EPG filter "UK*",
+        # which silently group/label or guide-match the wrong country.
+        lineup_cc, _ = self._parse_lineup_filename(os.path.basename(lineup_file or ""))
+        if lineup_cc:
+            lineup_cc = lineup_cc.upper()
+
+            gp_raw = (settings.get("group_prefix") or "")
+            if gp_raw.strip().lower() != "none":
+                gp_foreign = sorted(c for c in country_codes_in_text(gp_raw) if c != lineup_cc)
+                if gp_foreign:
+                    results.append({
+                        "Setting": "Country Check: Group Prefix",
+                        "Value": gp_raw.strip(),
+                        "Status": (f"WARNING: prefix country {', '.join(gp_foreign)} does not match "
+                                   f"lineup country {lineup_cc}. Channels may be grouped/labeled for "
+                                   f"the wrong country."),
+                    })
+
+            epg_raw = (settings.get("epg_sources") or "")
+            _, epg_is_all = self._parse_source_filter(epg_raw)
+            if not epg_is_all:
+                epg_foreign = sorted(c for c in country_codes_in_text(epg_raw) if c != lineup_cc)
+                if epg_foreign:
+                    results.append({
+                        "Setting": "Country Check: EPG Sources",
+                        "Value": epg_raw.strip(),
+                        "Status": (f"WARNING: EPG source filter targets country {', '.join(epg_foreign)} "
+                                   f"but the lineup is {lineup_cc}. EPG may match the wrong country's guide."),
+                    })
 
         # DB connectivity
         try:
@@ -1326,12 +1487,15 @@ class Plugin:
             results.append({"Setting": "Database", "Value": "", "Status": f"ERROR: {e}"})
             errors += 1
 
+        warn_details = [r["Setting"] + ": " + r["Status"] for r in results if "WARNING" in r.get("Status", "")]
         status = "ok" if errors == 0 else "error"
         if errors == 0:
             msg = "✅ All settings valid."
         else:
             error_details = [r["Setting"] + ": " + r["Status"] for r in results if "ERROR" in r.get("Status", "")]
             msg = f"❌ {errors} error(s) found.\n" + "\n".join(error_details)
+        if warn_details:
+            msg += f"\n\n⚠️ {len(warn_details)} warning(s):\n" + "\n".join(warn_details)
         return {"status": status, "message": msg, "data": results}
 
     def _scan_lineups(self, settings, logger):
@@ -1479,6 +1643,7 @@ class Plugin:
                 return lineup
             matcher = self._init_fuzzy_matcher(settings, logger)
             alias_map = self._build_alias_map(settings, logger)
+            upgrade_twin_set = self._get_upgrade_twin_set(settings, lineup, matcher)
             streams = self._get_all_streams(settings, logger)
             assigner = self._init_assigner_state(settings)
             lineup_cc, _ = self._parse_lineup_filename(settings.get("lineup_file", ""))
@@ -1513,6 +1678,7 @@ class Plugin:
             )
 
             for category, channels in lineup["categories"].items():
+                cat_cc = self._resolve_category_country(category, lineup_cc, logger)
                 for entry in channels:
                     if self._stop_event.is_set():
                         logger.info(f"{LOG_PREFIX} Preview cancelled.")
@@ -1525,7 +1691,8 @@ class Plugin:
                     matches = matcher.match_all_streams(
                         ch_name, unique_stream_names, alias_map,
                         channel_number=boost_number,
-                        lineup_country=lineup_cc,
+                        lineup_country=cat_cc,
+                        quality_aware=(ch_name in upgrade_twin_set),
                     )
 
                     if matches:
@@ -1562,7 +1729,7 @@ class Plugin:
 
                     progress.update()
 
-            if lineup_cc and matcher.country_filter_drops:
+            if matcher.country_filter_drops:
                 logger.info(
                     f"{LOG_PREFIX} Country filter dropped "
                     f"{matcher.country_filter_drops} cross-country candidate(s)"
@@ -2169,6 +2336,8 @@ class Plugin:
             matcher.precompute_normalizations(unique_stream_names)
             matcher.country_filter_drops = 0
 
+            upgrade_twin_set = self._get_upgrade_twin_set(settings, lineup, matcher, logger)
+
             # Get existing groups and channels
             existing_groups = {g['name']: g['id'] for g in ChannelGroup.objects.all().values('id', 'name')}
             existing_channels = {}
@@ -2194,6 +2363,8 @@ class Plugin:
                         progress.update()
                     continue
 
+                cat_cc = self._resolve_category_country(category, lineup_cc, logger)
+
                 for entry in channels:
                     if self._stop_event.is_set():
                         logger.info(f"{LOG_PREFIX} Stream matching cancelled.")
@@ -2213,7 +2384,8 @@ class Plugin:
                     matches = matcher.match_all_streams(
                         ch_name, unique_stream_names, alias_map,
                         channel_number=ch_number,
-                        lineup_country=lineup_cc,
+                        lineup_country=cat_cc,
+                        quality_aware=(ch_name in upgrade_twin_set),
                     )
 
                     if matches:
@@ -2314,7 +2486,7 @@ class Plugin:
 
             progress.finish()
 
-            if lineup_cc and matcher.country_filter_drops:
+            if matcher.country_filter_drops:
                 logger.info(
                     f"{LOG_PREFIX} Country filter dropped "
                     f"{matcher.country_filter_drops} cross-country candidate(s)"
@@ -2378,6 +2550,44 @@ class Plugin:
         msg += " CSV exported."
         logger.info(f"{LOG_PREFIX} {msg}")
         return {"status": "ok", "message": msg}
+
+    def _refresh_epg_sources(self, source_ids, logger):
+        """Trigger a Dispatcharr EPG refresh for the given EPGSource IDs.
+
+        Called after EPG matching so newly matched channels pick up program
+        info. source_ids are the sources that were actually matched to lineup
+        channels (and, by construction, are within the user's "EPG Sources for
+        Matching" selection). Each refresh is dispatched as an async Celery task
+        so it does not block the matching operation. Returns the count of
+        sources for which a refresh was dispatched.
+        """
+        if not _EPG_AVAILABLE:
+            return 0
+        ids = sorted({sid for sid in source_ids if sid})
+        if not ids:
+            return 0
+        try:
+            from apps.epg.tasks import refresh_epg_data
+        except Exception as e:
+            logger.warning(f"{LOG_PREFIX} EPG refresh task unavailable, skipping EPG refresh: {e}")
+            return 0
+        # Map IDs to names for readable logging.
+        names = {}
+        try:
+            for src in EPGSource.objects.filter(id__in=ids).values('id', 'name'):
+                names[src['id']] = src['name']
+        except Exception:
+            pass
+        triggered = 0
+        for sid in ids:
+            try:
+                refresh_epg_data.delay(sid)
+                triggered += 1
+                logger.info(f"{LOG_PREFIX} Triggered EPG refresh for source '{names.get(sid, sid)}' (id={sid})")
+            except Exception as e:
+                logger.warning(f"{LOG_PREFIX} Failed to trigger EPG refresh for source id={sid}: {e}")
+        logger.info(f"{LOG_PREFIX} EPG refresh dispatched for {triggered}/{len(ids)} matched source(s)")
+        return triggered
 
     def _do_apply_epg_match_bg(self, settings, logger):
         """Background wrapper for EPG matching."""
@@ -2475,6 +2685,11 @@ class Plugin:
             skipped_existing = 0
             csv_rows = []
             epg_assignments = []
+            # EPGSource IDs that were actually matched to a lineup channel. These
+            # already come only from the selected "EPG Sources for Matching"
+            # (see _get_filtered_epg_data), so they are exactly the sources to
+            # refresh: matched AND user-selected.
+            matched_epg_source_ids = set()
 
             for category, channels in lineup["categories"].items():
                 group_name = self._make_group_name(prefix, category)
@@ -2485,6 +2700,8 @@ class Plugin:
                         skipped_no_match += 1
                         progress.update()
                     continue
+
+                cat_cc = self._resolve_category_country(category, lineup_cc, logger)
 
                 for entry in channels:
                     if self._stop_event.is_set():
@@ -2509,10 +2726,11 @@ class Plugin:
                         continue
 
                     # Fuzzy match channel name against EPG names
-                    # (all candidates already have program data — pre-filtered above)
+                    # (all candidates already have program data - pre-filtered above)
                     matches = matcher.match_all_streams(
                         ch_name, unique_epg_names, alias_map,
-                        channel_number=ch_number
+                        channel_number=ch_number,
+                        lineup_country=cat_cc,
                     )
 
                     # Take best match (all candidates have program data)
@@ -2525,7 +2743,7 @@ class Plugin:
                         top_name, top_score, top_method = matches[0]
                         top_entries = epg_by_name.get(top_name, [])
                         if top_entries:
-                            best_epg = self._pick_epg_by_country(top_entries, lineup_cc)
+                            best_epg = self._pick_epg_by_country(top_entries, cat_cc)
                             best_score = top_score
                             best_method = top_method
 
@@ -2533,13 +2751,14 @@ class Plugin:
                     if not best_epg and unique_epg_names_all:
                         fallback_matches = matcher.match_all_streams(
                             ch_name, unique_epg_names_all, alias_map,
-                            channel_number=ch_number
+                            channel_number=ch_number,
+                            lineup_country=cat_cc,
                         )
                         if fallback_matches:
                             top_name, top_score, top_method = fallback_matches[0]
                             top_entries = epg_by_name_all.get(top_name, [])
                             if top_entries:
-                                best_epg = self._pick_epg_by_country(top_entries, lineup_cc)
+                                best_epg = self._pick_epg_by_country(top_entries, cat_cc)
                                 best_score = top_score
                                 best_method = top_method
                                 has_program_data = False
@@ -2560,6 +2779,8 @@ class Plugin:
 
                     if best_epg:
                         epg_assignments.append((channel_id, best_epg['id']))
+                        if best_epg.get('epg_source'):
+                            matched_epg_source_ids.add(best_epg.get('epg_source'))
                         matched += 1
                         if not has_program_data:
                             matched_fallback += 1
@@ -2587,6 +2808,14 @@ class Plugin:
                         Channel.objects.bulk_update(channels_to_update, ['epg_data_id'])
                     logger.info(f"{LOG_PREFIX} Bulk-updated EPG for {len(channels_to_update)} channels")
 
+            # Optionally refresh the EPG sources we matched against, so the newly
+            # matched channels pick up program info. Defaults on.
+            refresh_note = ""
+            if settings.get("refresh_epg_after_match", True) and matched_epg_source_ids:
+                refreshed = self._refresh_epg_sources(matched_epg_source_ids, logger)
+                if refreshed:
+                    refresh_note = f", refreshing EPG for {refreshed} source(s)"
+
             # Export CSV
             if csv_rows:
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -2603,7 +2832,7 @@ class Plugin:
 
             fallback_note = f" ({matched_fallback} via fallback without program data)" if matched_fallback else ""
             existing_note = f", {skipped_existing} skipped (already assigned)" if skipped_existing else ""
-            msg = f"EPG matching complete: {matched} matched{fallback_note}, {skipped_no_match} no match{existing_note} (from {len(epg_data_with_programs)} EPG entries with program data)"
+            msg = f"EPG matching complete: {matched} matched{fallback_note}, {skipped_no_match} no match{existing_note} (from {len(epg_data_with_programs)} EPG entries with program data){refresh_note}"
             logger.info(f"{LOG_PREFIX} {msg}")
             return {"status": "ok", "message": msg}
 

--- a/plugins/lineuparr/progress_status.py
+++ b/plugins/lineuparr/progress_status.py
@@ -134,16 +134,16 @@ def build_status_message(progress, now=None):
         updated = progress.get("updated_at")
         if updated is not None and (now - updated) > STALE_AFTER_SECONDS:
             ago = format_eta(now - updated)
-            return (f"⚠️ {label} — {cur}/{total} ({pct:.0f}%), "
+            return (f"⚠️ {label} - {cur}/{total} ({pct:.0f}%), "
                     f"no progress update in {ago}. The operation may have "
-                    f"stopped — check the container logs.")
+                    f"stopped - check the container logs.")
         start = progress.get("start_time")
         if start is not None and cur > 0:
             remaining = ((now - start) / cur) * (total - cur)
             eta = f"ETA {format_eta(remaining)}"
         else:
             eta = "ETA calculating…"
-        return f"\U0001f504 {label} — {cur}/{total} ({pct:.0f}%) · {eta}"
+        return f"\U0001f504 {label} - {cur}/{total} ({pct:.0f}%) · {eta}"
 
     if status == "done":
         label = _action_label(progress.get("action"))


### PR DESCRIPTION
### Lineuparr v1.26.1641222

**Fixed**
- Cross-country stream leaks in mixed lineups: channels now detect their country from the category-name prefix (e.g. `AU| AUSTRALIA VIP`), so an AU channel no longer grabs a `US:` backup stream.
- Removed 9 duplicate US channels that rendered identical TV-guide data (two names for one channel coexisting).
- Settings validation warns when the group prefix or EPG-source filter targets a different country than the lineup.

**Improved**
- Many new channel aliases for stream/EPG matching (getTV, FXM, Justice/True Crime Network, Daystar, TBN, UPtv, Galavision, UniMas, NBC Universo, REELZ, YES Network, SNY, CGTN, and more).
- Canadian TELUS Optik lineup modernized with Bell 2025 CTV rebrands; defunct channels removed.
- Removed discontinued US channels (Russia Today, Viceland, Speedvision, Z Living).
- Added FR Canal+ lineups.

Tested: 422 unit tests passing. Mirrors release v1.26.1641222 of PiratesIRC/Dispatcharr-Lineuparr-Plugin.
