### PR TITLE
[dispatcharr-ranked-matchups] v1.6.0: Diagnose matching action + verbose log

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Version bump 1.4.0 → 1.5.0 for the external plugin `dispatcharr-ranked-matchups`.

**What's new in 1.5.0:** a "Diagnose matching" action that explains, in one copy-pasteable block, why a curated game did or did not match a channel. It deep-dives the soonest unmatched game, shows the team spellings searched and the head-to-head listings actually airing in that window, so a user can tell "my provider isn't carrying it" from "it's listed under a spelling the plugin doesn't recognize." Built for users who can't read container logs.

Internal cleanups in the same release: a shared keyword-hit helper across matcher tiers, and a single action-dispatch table guarded by a contract test.

- `source_type`: external; release artifact at the resolved `source_url` (v1.5.0) returns 200.
- Only `version` changed in this entry; source lives in the upstream repo.
- Changelog: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/blob/main/CHANGELOG.md