### PR TITLE
[dispatcharr-ranked-matchups] v1.6.0: verbose diagnose log

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Version bump 1.5.0 → 1.6.0. v1.6.0 adds a verbose log companion to the Diagnose matching action: alongside the short result toast, it writes the full detail (every matchup listing in the game's window, all unmatched games, the matched set) to the container logs, so a user can paste the toast AND provide logs for troubleshooting. Only `version` changed in this entry; source lives in the upstream repo. Release artifact v1.6.0 returns 200.