### PR TITLE
[dispatcharr-ranked-matchups] v1.7.0: field-event sports match channels (#127)

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps **Ranked Matchups (Top Games)** to **1.7.0**.

Supersedes #124 (1.6.0, never merged); 1.7.0 includes all of 1.6.0's changes plus the field-event fix.

### What's new since the listed 1.5.0
- **1.7.0** — Fixes field-event sports (UFC, F1, golf, NASCAR, ATP/WTA) never matching a channel. These single-event sports have no opponent, so they emit a "Field" away sentinel; the matcher's both-teams gate could never be satisfied against it, leaving every such game a streamless placeholder. The matcher and EPG lookup now match on the event name alone for these sports. Two-team sports unchanged.
- **1.6.0** — "Diagnose matching" action logs a verbose report alongside the short toast.

Release artifact: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/download/v1.7.0/plugin.zip (verified reachable, top folder `dispatcharr_ranked_matchups/`, manifest version 1.7.0).