### PR TITLE
[channel-mapparr] Bump to 1.26.1651015 — matcher hardening, dedup, Norwegian channels, manifest fix

### DIFF
--- a/plugins/channel-mapparr/BR_channels.json
+++ b/plugins/channel-mapparr/BR_channels.json
@@ -24,11 +24,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Adult Swim",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "AgroBrasil TV",
       "category": "Brazil",
       "type": "Regional"
@@ -55,16 +50,6 @@
     },
     {
       "channel_name": "AMC",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "AMC",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Animal Planet",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -474,11 +459,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Cartoonito",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "CazéTV",
       "category": "Brazil",
       "type": "Regional"
@@ -524,11 +504,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "CGTN",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ChefTV+",
       "category": "Brazil",
       "type": "Regional"
@@ -540,21 +515,6 @@
     },
     {
       "channel_name": "Cinemax",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinemax",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Claro Sports",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Claro Sports",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -575,16 +535,6 @@
     },
     {
       "channel_name": "CNN Brasil",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CNN Brasil",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CNN en Español",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -639,11 +589,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Comedy Central",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Cultura",
       "category": "Brazil",
       "type": "Regional"
@@ -669,22 +614,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Discovery Channel",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Discovery Home & Health",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Home & Health",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Kids",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -719,17 +649,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Discovery Turbo",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Discovery World HD",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Channel",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -789,16 +709,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ESPN",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 2",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ESPN 2",
       "category": "Brazil",
       "type": "Regional"
@@ -809,22 +719,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ESPN 3",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ESPN 4",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 4",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 5",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -860,11 +755,6 @@
     },
     {
       "channel_name": "FashionTV Brazil HD",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Film & Arts",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -1049,16 +939,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HBO",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Family",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HBO Family",
       "category": "Brazil",
       "type": "Regional"
@@ -1124,11 +1004,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HBO Plus",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HBO Plus Brasil",
       "category": "Brazil",
       "type": "Regional"
@@ -1154,22 +1029,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HBO Signature",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HBO Xtreme",
       "category": "Brazil",
       "type": "Regional"
     },
     {
       "channel_name": "HBO Xtreme SD",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO2",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -1244,11 +1109,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Investigação Discovery",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Joga nas 11",
       "category": "Brazil",
       "type": "Regional"
@@ -1314,17 +1174,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Modo Viagem",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Mosaico Big Brother Brasil",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MTV",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -1340,11 +1190,6 @@
     },
     {
       "channel_name": "MTV Live",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MTV Live HD",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -1410,16 +1255,6 @@
     },
     {
       "channel_name": "Nick Jr.",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nick Jr.",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nickelodeon",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -1530,11 +1365,6 @@
     },
     {
       "channel_name": "Premiere 3",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Premiere 3 HD",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -1705,11 +1535,6 @@
     },
     {
       "channel_name": "RECORD Goiás (RREC)",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RECORD Guaíba (RREC)",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -2384,11 +2209,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Space",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "sportv",
       "category": "Brazil",
       "type": "Regional"
@@ -2400,11 +2220,6 @@
     },
     {
       "channel_name": "SporTV 5",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "sportv HD",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -2570,16 +2385,6 @@
     },
     {
       "channel_name": "TNT",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT Novelas",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -2900,11 +2705,6 @@
     },
     {
       "channel_name": "TV Cidadania",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TV Cidade (RREC)",
       "category": "Brazil",
       "type": "Regional"
     },
@@ -3384,11 +3184,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TV Tribuna (BAND)",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TV Tribuna (REDEGL)",
       "category": "Brazil",
       "type": "Regional"
@@ -3499,11 +3294,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TVE",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TVE Bahia",
       "category": "Brazil",
       "type": "Regional"
@@ -3520,11 +3310,6 @@
     },
     {
       "channel_name": "Univesp TV",
-      "category": "Brazil",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "USA",
       "category": "Brazil",
       "type": "Regional"
     },

--- a/plugins/channel-mapparr/CA_channels.json
+++ b/plugins/channel-mapparr/CA_channels.json
@@ -649,11 +649,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ATN DD Bharati",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ATN DD India",
       "category": "Canada",
       "type": "Regional"
@@ -669,17 +664,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ATN DD News",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ATN Food Food",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ATN Gujarati",
       "category": "Canada",
       "type": "Regional"
     },
@@ -1374,16 +1359,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Cartoon Network HD Canada (Pacific)",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoon Network On Demand",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Cartoon Network On Demand",
       "category": "Canada",
       "type": "Regional"
@@ -1480,11 +1455,6 @@
     },
     {
       "channel_name": "CBC News Network",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CBC News Network HD",
       "category": "Canada",
       "type": "Regional"
     },
@@ -2170,11 +2140,6 @@
     },
     {
       "channel_name": "Channel 299",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Channel I",
       "category": "Canada",
       "type": "Regional"
     },
@@ -3589,11 +3554,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "CNN",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "CNN HD",
       "category": "Canada",
       "type": "Regional"
@@ -4029,17 +3989,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "CTV Two - Ottawa (CTV2)",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "CTV Two - Toronto (CTV2)",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CTV Two - Vancouver/Victoria (CTV2)",
       "category": "Canada",
       "type": "Regional"
     },
@@ -4345,11 +4295,6 @@
     },
     {
       "channel_name": "DirecTV - NHL Center Ice - NHLCI9",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
       "category": "Canada",
       "type": "Regional"
     },
@@ -4984,11 +4929,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Food Network",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Food Network On Demand",
       "category": "Canada",
       "type": "Regional"
@@ -5025,11 +4965,6 @@
     },
     {
       "channel_name": "France 24",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "France 24 HD",
       "category": "Canada",
       "type": "Regional"
     },
@@ -5614,11 +5549,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HLN",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HLN HD",
       "category": "Canada",
       "type": "Regional"
@@ -5645,11 +5575,6 @@
     },
     {
       "channel_name": "Hollywood Suite On Demand",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Home & Garden Television",
       "category": "Canada",
       "type": "Regional"
     },
@@ -5829,11 +5754,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Ici Radio-Canada Première",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ICI Radio-Canada Première Toronto (CJBC-AM)",
       "category": "Canada",
       "type": "Regional"
@@ -5900,11 +5820,6 @@
     },
     {
       "channel_name": "Investigation",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Investigation Discovery",
       "category": "Canada",
       "type": "Regional"
     },
@@ -6565,11 +6480,6 @@
     },
     {
       "channel_name": "La7",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Las Estrellas Internacional",
       "category": "Canada",
       "type": "Regional"
     },
@@ -7299,11 +7209,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "MuseumTV",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Music On Demand",
       "category": "Canada",
       "type": "Regional"
@@ -7455,31 +7360,6 @@
     },
     {
       "channel_name": "NBA TV Canada HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NCAA College Sports Package",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NCAA College Sports Package",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NCAA College Sports Package",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NCAA College Sports Package",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NCAA College Sports Package",
       "category": "Canada",
       "type": "Regional"
     },
@@ -7854,22 +7734,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "NHL Centre Ice HD 1",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "NHL Centre Ice HD 10",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 10",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 11",
       "category": "Canada",
       "type": "Regional"
     },
@@ -7884,22 +7749,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "NHL Centre Ice HD 12",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "NHL Centre Ice HD 2",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 2",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 3",
       "category": "Canada",
       "type": "Regional"
     },
@@ -7914,22 +7764,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "NHL Centre Ice HD 4",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "NHL Centre Ice HD 5",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 5",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 6",
       "category": "Canada",
       "type": "Regional"
     },
@@ -7944,22 +7779,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "NHL Centre Ice HD 7",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "NHL Centre Ice HD 8",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 8",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NHL Centre Ice HD 9",
       "category": "Canada",
       "type": "Regional"
     },
@@ -8580,11 +8400,6 @@
     },
     {
       "channel_name": "Q Country 91.5FM",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Qello Concerts by Stingray",
       "category": "Canada",
       "type": "Regional"
     },
@@ -10029,11 +9844,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Réseau des Sports Info HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "SAB Canada",
       "category": "Canada",
       "type": "Regional"
@@ -11314,11 +11124,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sportsnet 4K",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sportsnet East",
       "category": "Canada",
       "type": "Regional"
@@ -11335,11 +11140,6 @@
     },
     {
       "channel_name": "Sportsnet One",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sportsnet One 4K",
       "category": "Canada",
       "type": "Regional"
     },
@@ -11674,17 +11474,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Stingray Classic R'n'B & Soul",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Stingray Classic Rock",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Stingray Classica",
       "category": "Canada",
       "type": "Regional"
     },
@@ -11720,11 +11510,6 @@
     },
     {
       "channel_name": "Stingray Cool Jazz",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Stingray Country",
       "category": "Canada",
       "type": "Regional"
     },
@@ -11919,11 +11704,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Stingray Kids' Stuff",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Stingray Kuschelsongs",
       "category": "Canada",
       "type": "Regional"
@@ -11985,11 +11765,6 @@
     },
     {
       "channel_name": "Stingray Nature",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Stingray Naturescape",
       "category": "Canada",
       "type": "Regional"
     },
@@ -12149,11 +11924,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Stingray Smooth Jazz",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Stingray Soho '70s",
       "category": "Canada",
       "type": "Regional"
@@ -12180,11 +11950,6 @@
     },
     {
       "channel_name": "Stingray Souvenirs",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Stingray Special",
       "category": "Canada",
       "type": "Regional"
     },
@@ -12539,11 +12304,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Telehit Música",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Telelatino HD",
       "category": "Canada",
       "type": "Regional"
@@ -12570,11 +12330,6 @@
     },
     {
       "channel_name": "TeleNinos HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Teleritmo",
       "category": "Canada",
       "type": "Regional"
     },
@@ -12650,46 +12405,6 @@
     },
     {
       "channel_name": "Telus MLB Extra Innings HD 9",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telus NBA League Pass HD",
       "category": "Canada",
       "type": "Regional"
     },
@@ -13159,22 +12874,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TLNovelas",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TLNovelas",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Too Much for TV - TMFTV",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Toon-A-Vision",
       "category": "Canada",
       "type": "Regional"
     },
@@ -16144,11 +15844,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Zee Marathi",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Zee Punjab Haryana Himachal",
       "category": "Canada",
       "type": "Regional"
@@ -16165,11 +15860,6 @@
     },
     {
       "channel_name": "Zee Talkies",
-      "category": "Canada",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Zee Tamil",
       "category": "Canada",
       "type": "Regional"
     },

--- a/plugins/channel-mapparr/DE_channels.json
+++ b/plugins/channel-mapparr/DE_channels.json
@@ -314,11 +314,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Al Jazeera",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Al Jazeera (Arabic)",
       "category": "Germany",
       "type": "Regional"
@@ -330,11 +325,6 @@
     },
     {
       "channel_name": "Al Jazeera English",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Al Jazeera HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -389,11 +379,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "allgäu.tv",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "AllgäuHIT",
       "category": "Germany",
       "type": "Regional"
@@ -420,11 +405,6 @@
     },
     {
       "channel_name": "Anewz",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Animal Planet",
       "category": "Germany",
       "type": "Regional"
     },
@@ -684,16 +664,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ARTE",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ARTE HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ARTE HD",
       "category": "Germany",
       "type": "Regional"
@@ -720,11 +690,6 @@
     },
     {
       "channel_name": "ATN Bangla UK",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ATV",
       "category": "Germany",
       "type": "Regional"
     },
@@ -800,11 +765,6 @@
     },
     {
       "channel_name": "AXN",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "AXN Black",
       "category": "Germany",
       "type": "Regional"
     },
@@ -974,11 +934,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC Earth",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC Food",
       "category": "Germany",
       "type": "Regional"
@@ -990,11 +945,6 @@
     },
     {
       "channel_name": "BBC History",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC News",
       "category": "Germany",
       "type": "Regional"
     },
@@ -1524,21 +1474,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Cartoon Network",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoon Network",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoon Network",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Cartoon Network (KD)",
       "category": "Germany",
       "type": "Regional"
@@ -1550,16 +1485,6 @@
     },
     {
       "channel_name": "Cartoonito",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoonito",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoonito HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -1610,11 +1535,6 @@
     },
     {
       "channel_name": "CGTN Français HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CGTN HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -1769,17 +1689,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Club MTV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "CMC TV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CNBC",
       "category": "Germany",
       "type": "Regional"
     },
@@ -1804,27 +1714,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "CNN HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "CNN Headlines",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "CNN International",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CNN International",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CNN International HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -1850,11 +1745,6 @@
     },
     {
       "channel_name": "Comedy & Shows",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Comedy Central",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2029,11 +1919,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "DAZN 2",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "DAZN 2 HD",
       "category": "Germany",
       "type": "Regional"
@@ -2080,11 +1965,6 @@
     },
     {
       "channel_name": "DAZN Rise",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "De Pelicula",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2209,42 +2089,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Discovery Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Discovery Channel +1",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2274,11 +2119,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Disney Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Disney Channel +1",
       "category": "Germany",
       "type": "Regional"
@@ -2290,16 +2130,6 @@
     },
     {
       "channel_name": "Disney Channel HD (Austria)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Junior",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Junior",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2584,11 +2414,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Energy München",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Energy Nürnberg",
       "category": "Germany",
       "type": "Regional"
@@ -2619,22 +2444,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ERT World HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "eSportsONE",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "eSportsONE HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Espreso.tv",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2669,27 +2484,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "euronews",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Euronews (EURONEW)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2724,21 +2519,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Eurosport 1",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 1",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 1",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Eurosport 1 HD",
       "category": "Germany",
       "type": "Regional"
@@ -2749,42 +2529,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Eurosport 1 HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Eurosport 1 HD (Amazon Duplicate)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 1 HD (Amazon Duplicate)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 2",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 2",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 2",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 2",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 2",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2800,11 +2545,6 @@
     },
     {
       "channel_name": "Eurosport 2 Xtra",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 2 Xtra HD (Amazon Duplicate)",
       "category": "Germany",
       "type": "Regional"
     },
@@ -2999,11 +2739,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "FilmRise Binge Watch",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "FilmRise Serien",
       "category": "Germany",
       "type": "Regional"
@@ -3059,11 +2794,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "France 2",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "France 2 HD",
       "category": "Germany",
       "type": "Regional"
@@ -3089,22 +2819,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "France 24 English HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "France 24 HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "France 24 HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "France 3",
       "category": "Germany",
       "type": "Regional"
     },
@@ -3229,11 +2944,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "FTV HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "FunBox UHD",
       "category": "Germany",
       "type": "Regional"
@@ -3300,16 +3010,6 @@
     },
     {
       "channel_name": "Geo Wild",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "GINX eSports TV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "GINX eSports TV",
       "category": "Germany",
       "type": "Regional"
     },
@@ -3489,16 +3189,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Hayat Plus",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Hayat Plus",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Headbangers",
       "category": "Germany",
       "type": "Regional"
@@ -3540,11 +3230,6 @@
     },
     {
       "channel_name": "HGTV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Highway to Heaven",
       "category": "Germany",
       "type": "Regional"
     },
@@ -3849,22 +3534,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "INPLUS",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Inspector Gadget",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Inspector Gadget",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "INULTRA",
       "category": "Germany",
       "type": "Regional"
     },
@@ -3979,11 +3649,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ITVN Extra",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ITVN Extra HD",
       "category": "Germany",
       "type": "Regional"
@@ -4080,11 +3745,6 @@
     },
     {
       "channel_name": "K-TV HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "kabel eins",
       "category": "Germany",
       "type": "Regional"
     },
@@ -4304,11 +3964,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "KultKrimi",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "KulturMD TV HD",
       "category": "Germany",
       "type": "Regional"
@@ -4499,11 +4154,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Luxe TV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "M6",
       "category": "Germany",
       "type": "Regional"
@@ -4525,11 +4175,6 @@
     },
     {
       "channel_name": "Made in Chelsea",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MagellanTV Now",
       "category": "Germany",
       "type": "Regional"
     },
@@ -4610,11 +4255,6 @@
     },
     {
       "channel_name": "MDR KLASSIK",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MDR Kultur",
       "category": "Germany",
       "type": "Regional"
     },
@@ -4794,22 +4434,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Mezzo",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Mezzo HD",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "Mezzo Live",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Mezzo Live HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -4959,11 +4589,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "MTV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "MTV 00s Europe",
       "category": "Germany",
       "type": "Regional"
@@ -5040,11 +4665,6 @@
     },
     {
       "channel_name": "MTV Live",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MTV Live HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -5154,11 +4774,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "N24 Doku",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "N24 Doku HD",
       "category": "Germany",
       "type": "Regional"
@@ -5204,42 +4819,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "National Geographic",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "National Geographic +1",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "National Geographic Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -5264,32 +4849,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "National Geographic Wild",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic Wild HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "National Geographic Wild HD",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "National Public Radio (NPR)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nautical Channel",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nautical Channel",
       "category": "Germany",
       "type": "Regional"
     },
@@ -5529,11 +5094,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Nick Jr.",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Nick Jr. HD",
       "category": "Germany",
       "type": "Regional"
@@ -5569,32 +5129,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Nickelodeon",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nickelodeon",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nickelodeon",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nickelodeon",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Nickelodeon HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nicktoons",
       "category": "Germany",
       "type": "Regional"
     },
@@ -5949,11 +5484,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "oldenburg eins",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Oldie 95",
       "category": "Germany",
       "type": "Regional"
@@ -6249,11 +5779,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Playboy TV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Playboy TV Europe",
       "category": "Germany",
       "type": "Regional"
@@ -6415,11 +5940,6 @@
     },
     {
       "channel_name": "Profiling Paris",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ProSieben",
       "category": "Germany",
       "type": "Regional"
     },
@@ -7399,11 +6919,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Rai Storia",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Rai Storia HD",
       "category": "Germany",
       "type": "Regional"
@@ -7500,16 +7015,6 @@
     },
     {
       "channel_name": "Record TV HD (RREC)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Red Bull TV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Red Bull TV",
       "category": "Germany",
       "type": "Regional"
     },
@@ -7734,11 +7239,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Rock Antenne",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ROCK ANTENNE Lokalradio",
       "category": "Germany",
       "type": "Regional"
@@ -7755,11 +7255,6 @@
     },
     {
       "channel_name": "Rock'n'Roll Oldies",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Rocket Beans TV",
       "category": "Germany",
       "type": "Regional"
     },
@@ -7859,16 +7354,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "RTL",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTL",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "RTL Bayern (RTLGER)",
       "category": "Germany",
       "type": "Regional"
@@ -7915,11 +7400,6 @@
     },
     {
       "channel_name": "RTL HB NDS",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTL HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -8054,27 +7534,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "RTLZWEI",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTLZWEI",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "RTLZWEI HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTLZWEI HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTP Internacional",
       "category": "Germany",
       "type": "Regional"
     },
@@ -8200,16 +7660,6 @@
     },
     {
       "channel_name": "Sam & Cat",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sat.1",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sat.1",
       "category": "Germany",
       "type": "Regional"
     },
@@ -8544,11 +7994,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Cinema Classics HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Cinema Drama",
       "category": "Germany",
       "type": "Regional"
@@ -8675,11 +8120,6 @@
     },
     {
       "channel_name": "Sky Showcase",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Showcase HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -8870,11 +8310,6 @@
     },
     {
       "channel_name": "Sky Sport Bundesliga UHD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Sport F1 HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -9389,11 +8824,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "STV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Summer Feelings",
       "category": "Germany",
       "type": "Regional"
@@ -9405,11 +8835,6 @@
     },
     {
       "channel_name": "SUPER 3 HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Super RTL",
       "category": "Germany",
       "type": "Regional"
     },
@@ -9559,11 +8984,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "SyFy Universal",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Syfy Universal (KD)",
       "category": "Germany",
       "type": "Regional"
@@ -9619,22 +9039,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TCM",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Tele 1",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "Tele 5",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Tele 5 HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -9709,22 +9119,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Telehit Música",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TeleLombardia",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "Telemadrid",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telenovela ZDF",
       "category": "Germany",
       "type": "Regional"
     },
@@ -9755,11 +9155,6 @@
     },
     {
       "channel_name": "TemporaTV",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Tennis Channel",
       "category": "Germany",
       "type": "Regional"
     },
@@ -9815,11 +9210,6 @@
     },
     {
       "channel_name": "The History Channel HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "The Pet Collective",
       "category": "Germany",
       "type": "Regional"
     },
@@ -9885,11 +9275,6 @@
     },
     {
       "channel_name": "TLC (Austria)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TLC HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -10015,11 +9400,6 @@
     },
     {
       "channel_name": "TRACE Urban",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Trace Urban",
       "category": "Germany",
       "type": "Regional"
     },
@@ -10224,16 +9604,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TV3",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TV3",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TV38 FERNSEHEN ZWISCHEN HARZ",
       "category": "Germany",
       "type": "Regional"
@@ -10250,11 +9620,6 @@
     },
     {
       "channel_name": "TV5 Monde (FBSM)",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TV5 Monde Europe",
       "category": "Germany",
       "type": "Regional"
     },
@@ -10315,11 +9680,6 @@
     },
     {
       "channel_name": "TVE HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TVE Internacional",
       "category": "Germany",
       "type": "Regional"
     },
@@ -10619,21 +9979,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "VOX",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "VOX",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "VOX HD",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "VOX HD",
       "category": "Germany",
       "type": "Regional"
@@ -10694,32 +10039,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "WBTV Film",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
       "channel_name": "WBTV Film HD",
       "category": "Germany",
       "type": "Regional"
     },
     {
       "channel_name": "WBTV Serie",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "WBTV Serie",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "WBTV Serie",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "WBTV Serie HD",
       "category": "Germany",
       "type": "Regional"
     },
@@ -11055,11 +10380,6 @@
     },
     {
       "channel_name": "YOU FM",
-      "category": "Germany",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Yu-Gi-Oh!",
       "category": "Germany",
       "type": "Regional"
     },

--- a/plugins/channel-mapparr/ES_channels.json
+++ b/plugins/channel-mapparr/ES_channels.json
@@ -184,11 +184,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Atreseries",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Atreseries HD",
       "category": "Spain",
       "type": "Regional"
@@ -534,11 +529,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Comedy Central",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Comedy Central HD",
       "category": "Spain",
       "type": "Regional"
@@ -600,16 +590,6 @@
     },
     {
       "channel_name": "DAZN 1",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "DAZN 1",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "DAZN 2",
       "category": "Spain",
       "type": "Regional"
     },
@@ -709,11 +689,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "DMAX",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
       "channel_name": "DMAX Austria",
       "category": "Spain",
       "type": "Regional"
@@ -785,16 +760,6 @@
     },
     {
       "channel_name": "euronews",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 1",
       "category": "Spain",
       "type": "Regional"
     },
@@ -915,11 +880,6 @@
     },
     {
       "channel_name": "France 24 Español",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "France 24 HD",
       "category": "Spain",
       "type": "Regional"
     },
@@ -1120,11 +1080,6 @@
     },
     {
       "channel_name": "K-TV",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "kabel eins",
       "category": "Spain",
       "type": "Regional"
     },
@@ -1744,11 +1699,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Nickelodeon",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Nickelodeon HD",
       "category": "Spain",
       "type": "Regional"
@@ -1860,11 +1810,6 @@
     },
     {
       "channel_name": "Pro TV int",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ProSieben",
       "category": "Spain",
       "type": "Regional"
     },
@@ -2044,11 +1989,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "RTL",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
       "channel_name": "RTL Bayern (RTLGER)",
       "category": "Spain",
       "type": "Regional"
@@ -2074,27 +2014,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "RTLZWEI",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTLZWEI",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
       "channel_name": "RTP Internacional Europe",
       "category": "Spain",
       "type": "Regional"
     },
     {
       "channel_name": "RTP Internacional Spanish",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sat.1",
       "category": "Spain",
       "type": "Regional"
     },
@@ -2479,11 +2404,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TV3",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TV3 HD",
       "category": "Spain",
       "type": "Regional"
@@ -2580,11 +2500,6 @@
     },
     {
       "channel_name": "Vizner TV",
-      "category": "Spain",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "VOX",
       "category": "Spain",
       "type": "Regional"
     },

--- a/plugins/channel-mapparr/FR_channels.json
+++ b/plugins/channel-mapparr/FR_channels.json
@@ -19,11 +19,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "13éme Rue HD",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
       "channel_name": "2M Maroc",
       "category": "France",
       "type": "Regional"
@@ -249,22 +244,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Armenia 1",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ARTE",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ARTE",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ARTE HD",
       "category": "France",
       "type": "Regional"
     },
@@ -285,11 +265,6 @@
     },
     {
       "channel_name": "Athlé TV",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Atreseries",
       "category": "France",
       "type": "Regional"
     },
@@ -535,11 +510,6 @@
     },
     {
       "channel_name": "Boomerang +1",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Boomerang HD",
       "category": "France",
       "type": "Regional"
     },
@@ -1084,16 +1054,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Disney Channel",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Channel",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Disney Channel +1",
       "category": "France",
       "type": "Regional"
@@ -1230,16 +1190,6 @@
     },
     {
       "channel_name": "Eurochannel HD",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
       "category": "France",
       "type": "Regional"
     },
@@ -1400,11 +1350,6 @@
     },
     {
       "channel_name": "France 24 Español HD",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "France 24 HD",
       "category": "France",
       "type": "Regional"
     },
@@ -2075,11 +2020,6 @@
     },
     {
       "channel_name": "K-TV",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "kabel eins",
       "category": "France",
       "type": "Regional"
     },
@@ -2829,11 +2769,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "OCS HD",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
       "channel_name": "OE24 TV HD",
       "category": "France",
       "type": "Regional"
@@ -3030,11 +2965,6 @@
     },
     {
       "channel_name": "Pro TV int",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ProSieben",
       "category": "France",
       "type": "Regional"
     },
@@ -3299,11 +3229,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "RTL",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
       "channel_name": "RTL Bayern (RTLGER)",
       "category": "France",
       "type": "Regional"
@@ -3349,11 +3274,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "RTLZWEI",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
       "channel_name": "RTNC",
       "category": "France",
       "type": "Regional"
@@ -3385,11 +3305,6 @@
     },
     {
       "channel_name": "Saisons HD",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sat.1",
       "category": "France",
       "type": "Regional"
     },
@@ -3615,11 +3530,6 @@
     },
     {
       "channel_name": "SWR Fernsehen RP HD (SW3BWG)",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "SyFy Universal HD",
       "category": "France",
       "type": "Regional"
     },
@@ -4195,11 +4105,6 @@
     },
     {
       "channel_name": "Volksmusik",
-      "category": "France",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "VOX",
       "category": "France",
       "type": "Regional"
     },

--- a/plugins/channel-mapparr/MX_channels.json
+++ b/plugins/channel-mapparr/MX_channels.json
@@ -29,11 +29,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "A&E",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "A&E SOUTH",
       "category": "Mexico",
       "type": "Regional"
@@ -84,21 +79,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Adrenalina Sports Network",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Adult Swim",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Adult Swim",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Adult Swim",
       "category": "Mexico",
       "type": "Regional"
@@ -129,32 +109,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Al Jazeera",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Al Jazeera HD",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "AMC",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "AMC",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "AMC",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "AMC Series",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -199,32 +159,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Animal Planet",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Animal Planet",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Animal Planet",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Animal Planet HD",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "Antena 3",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Antena 3 Internacional",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -289,27 +229,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Arirang",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ARTS",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "Atrescine",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Atrescine",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Atreseries",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -539,16 +464,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "AXN",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "AXN",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "AyM Sports",
       "category": "Mexico",
       "type": "Regional"
@@ -589,16 +504,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Azteca Deportes",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Azteca Internacional",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Azteca Internacional",
       "category": "Mexico",
       "type": "Regional"
@@ -634,11 +539,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Baby Tv",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Baby1",
       "category": "Mexico",
       "type": "Regional"
@@ -650,11 +550,6 @@
     },
     {
       "channel_name": "BabyFirst TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Bandamax",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -690,11 +585,6 @@
     },
     {
       "channel_name": "beIN SPORTS XTRA en Español",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Bitme",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -899,27 +789,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Canal Nueve (NU9NET)",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Canal Once (C11NET)",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Canal Sony",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Canal Sony",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Canal Sony",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -974,32 +844,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Cartoon Network",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoon Network",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoon Network",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoon Network",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Cartoon Network HD",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cartoonito",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1074,36 +919,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Cinecanal",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinecanal",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinecanal",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinecanal",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinecanal",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinema",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Cinema",
       "category": "Mexico",
       "type": "Regional"
@@ -1120,21 +935,6 @@
     },
     {
       "channel_name": "Cinema Platino Multiplex",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinemax",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinemax",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Cinemax",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1169,57 +969,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Claro Sports",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Claro Sports",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Claro Sports",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Claro Sports",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Claro Sports",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Claro Sports",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Classic Arts Showcase",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "Clic",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Clic",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Club MTV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Club MTV",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1289,32 +1044,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Comedy Central",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Comedy Central",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Comedy Central",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Como Dice el Dicho",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "COPS en Español",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Corazón",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1379,11 +1114,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "De Película",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "DeporTV HD",
       "category": "Mexico",
       "type": "Regional"
@@ -1404,21 +1134,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Discovery Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Discovery Channel HD",
       "category": "Mexico",
       "type": "Regional"
@@ -1429,42 +1144,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Discovery Home & Health",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Home & Health",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Home & Health",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Home & Health",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Home & Health",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Discovery Kids",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Kids",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Science",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1484,47 +1164,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Discovery Turbo",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Discovery World",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "Disney Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Junior",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Junior",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Disney Junior",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1684,11 +1329,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Dreamworks",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Dreamworks HD",
       "category": "Mexico",
       "type": "Regional"
@@ -1739,11 +1379,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "E! Entertainment TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Efekto Tv",
       "category": "Mexico",
       "type": "Regional"
@@ -1760,21 +1395,6 @@
     },
     {
       "channel_name": "El Financiero - Bloomberg TV HD",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "El Gourmet",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "El Gourmet",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "El Gourmet",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1819,41 +1439,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ESPN",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ESPN 2",
       "category": "Mexico",
       "type": "Regional"
@@ -1869,17 +1454,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ESPN 4 México",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ESPN 5 Centroamérica",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ESPN 6",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -1929,17 +1504,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "euronews",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Euronews - Spanish Edition",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Europa Europa",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2014,16 +1579,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Film & Arts",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Film & Arts",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "FilmBox Arthouse",
       "category": "Mexico",
       "type": "Regional"
@@ -2050,16 +1605,6 @@
     },
     {
       "channel_name": "Fix&Foxi Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Food Network",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Food Network",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2099,22 +1644,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Fox News Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Fox News Channel HD",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "FOX SPORTS",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Fox Sports",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2134,22 +1669,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Fox Sports 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Fox Sports 2 Cono Sur",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Fox Sports 3",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Fox Sports 3",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2165,11 +1685,6 @@
     },
     {
       "channel_name": "Fox Sports Premium",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "France 24",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2234,21 +1749,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "FX",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "FX",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "FX",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "FX LATIN AMERICA (Central Feed)",
       "category": "Mexico",
       "type": "Regional"
@@ -2270,11 +1770,6 @@
     },
     {
       "channel_name": "Galicia TV America",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Gametoon",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2324,11 +1819,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Ginx TV International",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Glitz",
       "category": "Mexico",
       "type": "Regional"
@@ -2350,16 +1840,6 @@
     },
     {
       "channel_name": "GOLDEN PLUS",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Golden Premier",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Golden Premier",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2409,42 +1889,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HBO",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HBO 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Family",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Family",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Family",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2504,32 +1949,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HBO Mundi",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Mundi",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HBO Plus",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Plus",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Plus",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Pop",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2544,42 +1964,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HBO Pop",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Pop",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HBO Signature",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Signature",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Signature",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Xtreme",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Xtreme",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HBO Xtreme",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2604,16 +1989,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HGTV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HGTV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Hi Sports",
       "category": "Mexico",
       "type": "Regional"
@@ -2625,26 +2000,6 @@
     },
     {
       "channel_name": "History",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "History",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "History",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "History 2",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "History 2",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2664,21 +2019,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HOLA! TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HOLA! TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "HTV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HTV",
       "category": "Mexico",
       "type": "Regional"
@@ -2690,11 +2030,6 @@
     },
     {
       "channel_name": "ID",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ID HD",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2765,11 +2100,6 @@
     },
     {
       "channel_name": "K17DL-D2 (CW)",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Kanal D Drama",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2859,16 +2189,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Las Estrellas (ESTRNET)",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Las Estrellas Internacional",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Las Estrellas Internacional",
       "category": "Mexico",
       "type": "Regional"
@@ -2885,16 +2205,6 @@
     },
     {
       "channel_name": "Latino Urbano",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Lifetime",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Lifetime",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -2935,11 +2245,6 @@
     },
     {
       "channel_name": "María Visión Italia",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MC",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -3034,16 +2339,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "MTV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MTV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "MTV - Music Television HD",
       "category": "Mexico",
       "type": "Regional"
@@ -3114,16 +2409,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Multipremier",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MVS TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "MVS TV",
       "category": "Mexico",
       "type": "Regional"
@@ -3169,11 +2454,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "N+ Media",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "N+ Monterrey",
       "category": "Mexico",
       "type": "Regional"
@@ -3184,27 +2464,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Nat Geo Kids",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Nat Geo Kids HD",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -3260,21 +2520,6 @@
     },
     {
       "channel_name": "Nick",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nick",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nick",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nick Jr.",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -3344,16 +2589,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Nu9ve",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Once",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Once",
       "category": "Mexico",
       "type": "Regional"
@@ -3365,16 +2600,6 @@
     },
     {
       "channel_name": "Outdoor Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Outdoor Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Outdoor Channel HD",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -3395,16 +2620,6 @@
     },
     {
       "channel_name": "Paramount",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Paramount Network",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Paramount Network",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -3520,11 +2735,6 @@
     },
     {
       "channel_name": "RAI International Spanish",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Rai Italia",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -3704,47 +2914,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sony Movies",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sortilegio",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "Space",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Space",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Space",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Space",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Star Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Star Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Star Channel",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -3865,11 +3040,6 @@
     },
     {
       "channel_name": "Stingray Euro Hits",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Stingray Felices Fiestas",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4054,11 +3224,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Stingray Retro Latino",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Stingray Rock",
       "category": "Mexico",
       "type": "Regional"
@@ -4075,11 +3240,6 @@
     },
     {
       "channel_name": "Stingray Rock En Español",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Stingray Romance Latino",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4194,21 +3354,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Stingray Éxitos Tropicales",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Studio Universal",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Studio Universal",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Studio Universal",
       "category": "Mexico",
       "type": "Regional"
@@ -4230,11 +3375,6 @@
     },
     {
       "channel_name": "TCM",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TeenNick",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4269,32 +3409,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Telehit",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telehit Música",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Telehit Música",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "Telehit Música Plus",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telemundo Internacional",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Telemundo Internacional",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4344,16 +3464,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TLC",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TLNovelas",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TLNovelas",
       "category": "Mexico",
       "type": "Regional"
@@ -4364,52 +3474,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TNT",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TNT Novelas",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT Novelas",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT Series",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT Series",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT Series",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT Series",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4470,21 +3535,6 @@
     },
     {
       "channel_name": "Tu Clío",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TUDN",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TUDN",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TUDN",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4564,11 +3614,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TVE",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TVE America Television Española HD",
       "category": "Mexico",
       "type": "Regional"
@@ -4580,11 +3625,6 @@
     },
     {
       "channel_name": "TyC Sports HD",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TyC Sports International",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4614,17 +3654,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Unicable",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "UniMas (UNIMAS)",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Universal Cinema",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4644,17 +3674,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Universal Comedy",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Universal Comedy HD",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Universal Crime",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4674,17 +3694,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Universal Premiere",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Universal Premiere HD",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Universal Reality",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4704,32 +3714,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Universal TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Universal TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Universal TV",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Univision Network (UNI)",
       "category": "Mexico",
       "type": "Regional"
     },
     {
       "channel_name": "Univision TDN",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "USA",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4765,11 +3755,6 @@
     },
     {
       "channel_name": "VEVO REGEATON/TRAP",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "VH1",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -4890,16 +3875,6 @@
     },
     {
       "channel_name": "Wapa+",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Warner Channel",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Warner Channel",
       "category": "Mexico",
       "type": "Regional"
     },
@@ -7110,11 +6085,6 @@
     },
     {
       "channel_name": "XTSY Spanish",
-      "category": "Mexico",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Zee Mundo",
       "category": "Mexico",
       "type": "Regional"
     },

--- a/plugins/channel-mapparr/NO_channels.json
+++ b/plugins/channel-mapparr/NO_channels.json
@@ -1,0 +1,477 @@
+{
+  "country_code": "NO",
+  "country_name": "Norway",
+  "version": "2026-06-10",
+  "channels": [
+    {
+      "channel_name": "NRK1",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "NRK2",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "NRK3",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV 2 Direkte",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "TVNorge",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "REX",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "FEM",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "VOX",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV3",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV3+",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV 2 Zebra",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal+ 1",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal+ 2",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal+ Series",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal+ Stars",
+      "category": "Entertainment",
+      "type": "National"
+    },
+    {
+      "channel_name": "NRK Nyheter",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV 2 Nyheter",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "VGTV",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Dagbladet TV",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "Nettavisen TV",
+      "category": "News",
+      "type": "National"
+    },
+    {
+      "channel_name": "CNN International",
+      "category": "News",
+      "type": "International"
+    },
+    {
+      "channel_name": "BBC World News",
+      "category": "News",
+      "type": "International"
+    },
+    {
+      "channel_name": "Bloomberg",
+      "category": "News",
+      "type": "International"
+    },
+    {
+      "channel_name": "CNBC Europe",
+      "category": "News",
+      "type": "International"
+    },
+    {
+      "channel_name": "Al Jazeera English",
+      "category": "News",
+      "type": "International"
+    },
+    {
+      "channel_name": "Euronews",
+      "category": "News",
+      "type": "International"
+    },
+    {
+      "channel_name": "NRK Sport",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV 2 Sport 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV 2 Sport 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV 2 Sport Premium",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "TV 2 Sport Premium 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport 3",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport +",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Premier League",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Premier League 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Premier League 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Premier League 3",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Premier League 4",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Golf",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Live 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Live 2",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Live 3",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Live 4",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Live 5",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Sport Ultra",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal+ Sport 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Eurosport Norge",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Eurosport 1",
+      "category": "Sports",
+      "type": "National"
+    },
+    {
+      "channel_name": "Eurosport",
+      "category": "Sports",
+      "type": "International"
+    },
+    {
+      "channel_name": "Eurosport 2",
+      "category": "Sports",
+      "type": "International"
+    },
+    {
+      "channel_name": "V Film",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Film Hits",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "V Film Family",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal+ Film 1",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "Canal+ Film 2",
+      "category": "Movies",
+      "type": "National"
+    },
+    {
+      "channel_name": "NRK Super",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Disney Channel",
+      "category": "Kids",
+      "type": "International"
+    },
+    {
+      "channel_name": "Nickelodeon",
+      "category": "Kids",
+      "type": "International"
+    },
+    {
+      "channel_name": "Nick Jr.",
+      "category": "Kids",
+      "type": "International"
+    },
+    {
+      "channel_name": "Cartoon Network",
+      "category": "Kids",
+      "type": "International"
+    },
+    {
+      "channel_name": "Canal+ Kids",
+      "category": "Kids",
+      "type": "National"
+    },
+    {
+      "channel_name": "Discovery Channel",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "Discovery Science",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "Investigation Discovery",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "Animal Planet",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "National Geographic",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "National Geographic Wild",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "Viasat Nature",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "Viasat History",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "Viasat Explore",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "History",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "NHK World",
+      "category": "Documentary",
+      "type": "International"
+    },
+    {
+      "channel_name": "TV 2 Livsstil",
+      "category": "Lifestyle",
+      "type": "National"
+    },
+    {
+      "channel_name": "TLC",
+      "category": "Lifestyle",
+      "type": "International"
+    },
+    {
+      "channel_name": "MTV",
+      "category": "Music",
+      "type": "International"
+    },
+    {
+      "channel_name": "NRK Sápmi",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Østfold",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Oslo og Viken",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Innlandet",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Buskerud",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Vestfold",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Telemark",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Agder",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Rogaland",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Vestland",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Møre og Romsdal",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Trøndelag",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Nordland",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Troms",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "NRK Finnmark",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "TV Vest",
+      "category": "Regional",
+      "type": "Regional"
+    },
+    {
+      "channel_name": "Kanal Lokal",
+      "category": "Regional",
+      "type": "Regional"
+    }
+  ]
+}

--- a/plugins/channel-mapparr/UK_channels.json
+++ b/plugins/channel-mapparr/UK_channels.json
@@ -49,22 +49,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "4Seven",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "4Seven HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "4Seven HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "5",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -75,11 +60,6 @@
     },
     {
       "channel_name": "5 +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "5 Action",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -124,11 +104,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "5 Star +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "5 USA+1 Eng/Wales/NI",
       "category": "United Kingdom",
       "type": "Regional"
@@ -140,11 +115,6 @@
     },
     {
       "channel_name": "5SELECT",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "5USA",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -264,16 +234,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Al Jazeera",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Al Jazeera",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Al Jazeera (Arabic)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -285,21 +245,6 @@
     },
     {
       "channel_name": "Al Jazeera English",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Al Jazeera English",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Al Jazeera HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Al Jazeera HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -369,11 +314,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Animal Planet +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Animal Planet HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -400,11 +340,6 @@
     },
     {
       "channel_name": "ARD-alpha HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Are We There Yet?",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -509,11 +444,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Babestation",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Babestation 2",
       "category": "United Kingdom",
       "type": "Regional"
@@ -549,27 +479,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Baywatch",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BB-MV Lokal-TV",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "BBC 2 England HD (VM Custom)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC Alba",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC Alba",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -634,11 +549,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC News HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One",
       "category": "United Kingdom",
       "type": "Regional"
@@ -679,11 +589,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC One East Midlands HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One East West HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -709,17 +614,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC One London HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One North East & Cumbria (BBC1)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC One North East & Cumbria HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -739,22 +634,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC One North West HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One Northern Ireland (BBC1)",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "BBC One Northern Ireland HD (BBC1)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC One Northern Ireland HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -794,22 +679,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC One Scotland HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One South (BBC1)",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "BBC One South East (BBC1)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC One South East HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -834,17 +709,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC One South HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One South West (BBC1)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC One South West HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -869,11 +734,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC One Wales HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One West (BBC1)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -884,17 +744,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "BBC One West HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "BBC One West Midlands (BBC1)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC One West Midlands HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -920,11 +770,6 @@
     },
     {
       "channel_name": "BBC One Yorkshire & Lincolnshire HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC One Yorkshire HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -1110,11 +955,6 @@
     },
     {
       "channel_name": "BBC Red Button 3",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "BBC Red Button HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -1319,11 +1159,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Bloomberg Originals",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Bloomberg Television",
       "category": "United Kingdom",
       "type": "Regional"
@@ -1345,11 +1180,6 @@
     },
     {
       "channel_name": "Boomerang +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Boomerang HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -1385,11 +1215,6 @@
     },
     {
       "channel_name": "British Muslim TV",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "British Screen Classics",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -1529,11 +1354,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Channel 4",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Channel 4 (Midlands((P1)(VM)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -1584,11 +1404,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Channel 4 +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Channel 4 HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -1615,11 +1430,6 @@
     },
     {
       "channel_name": "Channel 4 Scotland Advertising HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Channel 4 South & East",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -1794,11 +1604,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "CNBC",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "CNBC HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -1814,17 +1619,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "CNN HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "CNN Headlines",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "CNN International",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -1979,11 +1774,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Crime and Investigation Network",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Crime Investigation Australia",
       "category": "United Kingdom",
       "type": "Regional"
@@ -2124,17 +1914,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Discovery History +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Discovery Science",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Discovery Science +1",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -2165,16 +1945,6 @@
     },
     {
       "channel_name": "DMAX",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "DMAX",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "DMAX +1",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -2225,11 +1995,6 @@
     },
     {
       "channel_name": "Drool",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Duck Dynasty",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -2309,37 +2074,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "euronews",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "euronews",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Euronews HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "Eurosport 1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Eurosport 1 HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -2649,11 +2389,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "FailArmy",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Faith UK",
       "category": "United Kingdom",
       "type": "Regional"
@@ -2725,11 +2460,6 @@
     },
     {
       "channel_name": "Folx TV HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Food Network",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -2894,11 +2624,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Ghost Hunters",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "GIGS",
       "category": "United Kingdom",
       "type": "Regional"
@@ -2935,11 +2660,6 @@
     },
     {
       "channel_name": "Good News TV",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "GoUSA TV",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -3124,11 +2844,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Hell's Kitchen",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Hell's Kitchen (TiVo)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -3234,11 +2949,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Hobby Maker HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Hobbycraft TV",
       "category": "United Kingdom",
       "type": "Regional"
@@ -3279,17 +2989,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Horse & Country",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Hot Country",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Hot Ones",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -3339,11 +3039,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "HUM Europe",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "HUM Masala (Europe)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -3374,11 +3069,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Ice Pilots",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Ice Road Truckers",
       "category": "United Kingdom",
       "type": "Regional"
@@ -3400,11 +3090,6 @@
     },
     {
       "channel_name": "Ideal Extra",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Ideal World",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -3524,16 +3209,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Islam Channel",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Islam Channel",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Islam Channel Urdu",
       "category": "United Kingdom",
       "type": "Regional"
@@ -3614,17 +3289,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ITV Quiz",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ITV Quiz (Global Sports Standards)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ITV Quiz HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -3650,11 +3315,6 @@
     },
     {
       "channel_name": "ITV West Country HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ITV West HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -3735,21 +3395,6 @@
     },
     {
       "channel_name": "ITV1 (London)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ITV1 (London)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ITV1 (London)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ITV1 (Meridian South East)",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -3889,11 +3534,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ITV2 HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ITV3",
       "category": "United Kingdom",
       "type": "Regional"
@@ -3919,11 +3559,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "ITV3 HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "ITV4",
       "category": "United Kingdom",
       "type": "Regional"
@@ -3940,11 +3575,6 @@
     },
     {
       "channel_name": "ITV4 +1 (Freeview)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ITV4 HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -4010,11 +3640,6 @@
     },
     {
       "channel_name": "Juwelo TV",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "kabel eins",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -4244,11 +3869,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Love Pets",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Love The Planet",
       "category": "United Kingdom",
       "type": "Regional"
@@ -4349,11 +3969,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "McLeod's Daughters",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "MDR Sachsen (MDRGERH)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -4439,11 +4054,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "More4 +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Most Haunted",
       "category": "United Kingdom",
       "type": "Regional"
@@ -4465,11 +4075,6 @@
     },
     {
       "channel_name": "Movies 24+",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Moviesphere",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -4525,16 +4130,6 @@
     },
     {
       "channel_name": "MTV Live HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MTV Live HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "MTV Music",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -4599,16 +4194,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Mythbusters",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Mythbusters",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Mythical 24/7",
       "category": "United Kingdom",
       "type": "Regional"
@@ -4659,17 +4244,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "National Geographic HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "National Geographic Wild",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "National Geographic Wild HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -5494,17 +5069,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Nickelodeon",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Nickelodeon +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Nickelodeon HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -5574,11 +5139,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Nosey",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Nosey Escandalos",
       "category": "United Kingdom",
       "type": "Regional"
@@ -5599,22 +5159,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Now 70s",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Now 80s",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Now 80s",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "NOW 90s & 00s",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -5740,11 +5285,6 @@
     },
     {
       "channel_name": "PBC",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "PBS America",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -5999,11 +5539,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Pop",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "POP +1",
       "category": "United Kingdom",
       "type": "Regional"
@@ -6044,17 +5579,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Premier Sports 1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Premier Sports 1 HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Premier Sports 2",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -6084,11 +5609,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Premier Sports Rugby",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Prime Video",
       "category": "United Kingdom",
       "type": "Regional"
@@ -6100,21 +5620,6 @@
     },
     {
       "channel_name": "Project Runway",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Project Runway",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Project Runway",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "ProSieben",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -6189,11 +5694,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Quest +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Quest +1 Eng/NI",
       "category": "United Kingdom",
       "type": "Regional"
@@ -6209,27 +5709,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Quest HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Quest HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Quest HD Eng/NI",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "Quest HD Wales/Scotland",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Quest Red",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -6259,11 +5744,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "QVC",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "QVC (VM)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -6274,16 +5754,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "QVC Beauty",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "QVC Extra",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "QVC Extra",
       "category": "United Kingdom",
       "type": "Regional"
@@ -6294,22 +5764,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "QVC HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "QVC Style",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "QVC Style",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "QVC Style HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -6549,16 +6004,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "RTL",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTL",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "RTL Bremen/Niedersachsen (RTLGER)",
       "category": "United Kingdom",
       "type": "Regional"
@@ -6575,16 +6020,6 @@
     },
     {
       "channel_name": "RTLup",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTLZWEI",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "RTLZWEI",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -6644,22 +6079,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "S4C HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "S4C HD (England Scotland NI)",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "S4C HD (Wales)",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "SAB TV",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -6690,11 +6115,6 @@
     },
     {
       "channel_name": "Sanskar TV",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sat.1",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -6939,11 +6359,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Cinema Premiere HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Cinema Sci Fi & Horror",
       "category": "United Kingdom",
       "type": "Regional"
@@ -6994,11 +6409,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Crime",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Crime +1",
       "category": "United Kingdom",
       "type": "Regional"
@@ -7014,22 +6424,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Documentaries",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Documentaries HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Documentaries HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky History",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7059,27 +6454,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky History HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Intro",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "Sky Kids",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Kids",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Max HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7114,16 +6494,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Nature",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Nature HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Nature HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -7135,11 +6505,6 @@
     },
     {
       "channel_name": "Sky News Arabia",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky News HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7174,11 +6539,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Showcase",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Showcase +1",
       "category": "United Kingdom",
       "type": "Regional"
@@ -7200,11 +6560,6 @@
     },
     {
       "channel_name": "Sky Sports Action",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Sports Action HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7254,22 +6609,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Sports Football",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Sports Football HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "Sky Sports Golf",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Sports Golf HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7314,17 +6659,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Sports News HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Sports Premier League",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Sports Premier League HD",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7354,22 +6689,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Sky Sports Tennis HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sky Sports Tennis SD",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "Sky Sports Vault",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky Sports+",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7390,11 +6715,6 @@
     },
     {
       "channel_name": "Sky UHD Sports 1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Sky UHD Sports 2",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7534,11 +6854,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Speedvision",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Sport en France",
       "category": "United Kingdom",
       "type": "Regional"
@@ -7604,11 +6919,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Stingray Greatest Hits",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Stingray Holidayscapes",
       "category": "United Kingdom",
       "type": "Regional"
@@ -7625,11 +6935,6 @@
     },
     {
       "channel_name": "Studio 66 3",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "STV",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7829,11 +7134,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Tennis Channel",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Terra Mater Wild",
       "category": "United Kingdom",
       "type": "Regional"
@@ -7879,17 +7179,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "That's Oldies",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "That's Rock",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "That's TV",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -7925,16 +7215,6 @@
     },
     {
       "channel_name": "That's TV 2",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "That's TV 2",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "That's TV 3",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8005,11 +7285,6 @@
     },
     {
       "channel_name": "The Carol Burnett Show",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "The Chat Show Channel",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8104,11 +7379,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "This Old House",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Time2Rlx",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8134,22 +7404,12 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Tiny Pop +1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Tiny Pop SD",
       "category": "United Kingdom",
       "type": "Regional"
     },
     {
       "channel_name": "Tipping Point",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TLC",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8194,11 +7454,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TNT Sports 1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TNT Sports 1 HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8219,11 +7474,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TNT Sports 2",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TNT Sports 2 HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8234,17 +7484,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TNT Sports 3",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TNT Sports 3 HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TNT Sports 4",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8329,11 +7569,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "TNT Sports UHD 4K",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "TNT Sports Ultimate UHD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8355,11 +7590,6 @@
     },
     {
       "channel_name": "Toggo Plus",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Toon Goggles",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8404,11 +7634,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Trace Urban",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Trailblazer HD",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8430,11 +7655,6 @@
     },
     {
       "channel_name": "Travelxp Europe HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TRT World",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8505,11 +7725,6 @@
     },
     {
       "channel_name": "TV Trwam",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "TV Warehouse",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8629,11 +7844,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "U&Eden HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "U&Eden+1",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8719,16 +7929,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "U&Yesterday HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "U&Yesterday+1",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "U&Yesterday+1",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8789,16 +7989,6 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Unsolved Mysteries",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Untold Stories of the ER",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Untold Stories of the ER",
       "category": "United Kingdom",
       "type": "Regional"
@@ -8850,11 +8040,6 @@
     },
     {
       "channel_name": "UTV HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Viaplay Xtra",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -8930,16 +8115,6 @@
     },
     {
       "channel_name": "VM4K Duplicate",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "VOX",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "VOX",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -9109,17 +8284,7 @@
       "type": "Regional"
     },
     {
-      "channel_name": "Wonder",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
       "channel_name": "Word Network TV",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "World Poker Tour",
       "category": "United Kingdom",
       "type": "Regional"
     },
@@ -9240,11 +8405,6 @@
     },
     {
       "channel_name": "Zee Cinema HD",
-      "category": "United Kingdom",
-      "type": "Regional"
-    },
-    {
-      "channel_name": "Zee Punjabi",
       "category": "United Kingdom",
       "type": "Regional"
     },

--- a/plugins/channel-mapparr/fuzzy_matcher.py
+++ b/plugins/channel-mapparr/fuzzy_matcher.py
@@ -69,6 +69,17 @@ QUALITY_PATTERNS = [
     r'\s+\b(4K|8K|UHD|FHD|HD|SD|FD|Unknown|Unk|Slow|Dead)\b\s+',
 ]
 
+# Numeric resolution markers the keyword QUALITY_PATTERNS miss: 720p, 1080p/i, 2160p,
+# 3840P, 480p, etc. — a 3-4 digit run glued directly to p/i. The 3-digit lower bound
+# excludes 2-digit noise; the 4-digit upper bound excludes 5-digit numbers (10800p won't
+# match). The p/i must be GLUED to the digits (no space): real markers are always written
+# "720P"/"3840P", and requiring the glue avoids stripping a spaced standalone P/I such as a
+# roman numeral ("Volume 100 I"). The p/i \b anchor keeps bare numbers (1080, "Channel 4")
+# intact. Applied with re.IGNORECASE in the ignore_quality block, like QUALITY_PATTERNS.
+RESOLUTION_PATTERNS = [
+    r'\b\d{3,4}[pi]\b',
+]
+
 # Regional indicator patterns: Pacific, Central, Mountain, Atlantic
 # NOTE: East/West are intentionally NOT stripped — they distinguish separate channel feeds
 # (e.g., "HBO East" and "HBO West" are different channels)
@@ -141,6 +152,100 @@ NUM_WORDS_RE = re.compile(
     r'\b(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b',
     re.IGNORECASE,
 )
+
+
+# --------------------------------------------------------------------------- #
+# Stylized-Unicode decoration stripping
+# --------------------------------------------------------------------------- #
+# Streams tag names with stylized-Unicode tier/format markers (superscript
+# "WEATHERNATION RAW", small-cap "FHD", bullet-prefixed "CNN") that the ASCII tag
+# regexes below cannot see. We drop whole tokens that are pure decoration BEFORE
+# the ASCII pipeline runs. Detection is by Unicode character *name* (not code-point
+# ranges), so it covers superscripts, "modifier letter" superscript capitals, and
+# Latin small-caps wherever they live (e.g. small-cap H is U+029C in IPA Extensions
+# and modifier V is U+2C7D in Latin-Ext-C, both outside the obvious blocks).
+
+# Ornament glyphs whose Unicode name carries no decoration keyword.
+_DECORATIVE_SYMBOLS = frozenset("◉")  # FISHEYE; add individual chars (not strings) here
+
+
+def _is_decorative_char(ch):
+    """True for a stylized letterform/ornament that carries no semantic content in a
+    channel name (superscripts, subscripts, modifier-letter superscript capitals,
+    Latin small-capitals, curated bullets). ASCII and ordinary letters return False."""
+    if ch.isascii():
+        return False
+    if ch in _DECORATIVE_SYMBOLS:
+        return True
+    try:
+        nm = unicodedata.name(ch)
+    except ValueError:
+        # unnamed code point (control char / lone surrogate) -> not decoration
+        return False
+    return ('SUPERSCRIPT' in nm or 'SUBSCRIPT' in nm
+            or 'SMALL CAPITAL' in nm or 'MODIFIER LETTER' in nm)
+
+
+def _strip_stylized_tokens(name):
+    """Drop whitespace tokens that are pure stylized decoration, then NFKD-canonicalize
+    the remainder. A token is decoration when it has >=1 decorative char, no ASCII
+    alphanumeric, and every char is decorative or ASCII punctuation (so a bullet glued
+    to a colon, or "HD/RAW" written in superscripts, are dropped too). Real ASCII words
+    (Gold/VIP) and non-Latin letters (Arabic/Cyrillic/CJK) are always kept. ASCII-only
+    input is returned unchanged via the fast path (no per-char work; NFKD is a no-op
+    on ASCII, so skipping it changes nothing)."""
+    if name.isascii():
+        return name
+    kept = []
+    for tok in name.split():
+        has_decorative = any(_is_decorative_char(c) for c in tok)
+        has_ascii_alnum = any(c.isascii() and c.isalnum() for c in tok)
+        only_decorative_or_punct = all(
+            _is_decorative_char(c) or (c.isascii() and not c.isalnum()) for c in tok
+        )
+        if has_decorative and only_decorative_or_punct and not has_ascii_alnum:
+            continue  # pure decoration -> drop the whole token
+        kept.append(tok)
+    return unicodedata.normalize('NFKD', ' '.join(kept))
+
+
+# --------------------------------------------------------------------------- #
+# Emoji-as-letter + emoji decoration normalization
+# --------------------------------------------------------------------------- #
+# Some streams use an emoji AS A LETTER inside a word: "SP⚽RTS" / "Sp⚽rts" where the
+# soccer ball stands in for 'o' (= SPORTS, the beIN family). _strip_stylized_tokens keeps
+# the token (it has ASCII alnum) and process_string_for_matching would turn the ball into a
+# space ("sp rts"), so it never matches "sports". We substitute the glyph for the letter it
+# replaces (only when flanked by ASCII letters) and strip emoji used purely as decoration.
+
+# Emoji that visually replace an ASCII letter when embedded in a word. Extensible.
+_EMOJI_LETTER_MAP = {'⚽': 'o'}            # SOCCER BALL = 'o'  (SP⚽RTS -> SPORTS)
+# Pictographic ornaments to delete. NOTE: ⚽ is intentionally in BOTH maps — the letter
+# map handles it mid-word (-> 'o'); here it catches any ⚽ NOT flanked by ASCII letters
+# (standalone/edge), which the substitution above leaves untouched.
+_EMOJI_ORNAMENTS = frozenset('♬☾⚽')       # beamed notes, last-quarter moon, soccer ball
+# Zero-width / invisible code points that only add noise to a name.
+_ZERO_WIDTH = ('️', '‍')         # VARIATION SELECTOR-16, ZERO WIDTH JOINER
+
+
+def _normalize_emoji(name):
+    """Map emoji-as-letters to their letter and strip emoji decoration.
+
+    The letter substitution fires ONLY when the glyph is flanked by ASCII letters
+    (so "SP⚽RTS" -> "SPoRTS" but a standalone/edge "⚽" is treated as decoration and
+    dropped). Zero-width selectors and ornament pictographs are deleted outright.
+    ASCII-only input is returned unchanged (no emoji possible)."""
+    if name.isascii():
+        return name
+    for zw in _ZERO_WIDTH:
+        if zw in name:
+            name = name.replace(zw, '')
+    for glyph, letter in _EMOJI_LETTER_MAP.items():
+        if glyph in name:
+            name = re.sub(r'(?<=[A-Za-z])' + re.escape(glyph) + r'(?=[A-Za-z])', letter, name)
+    if any(c in _EMOJI_ORNAMENTS for c in name):
+        name = ''.join(c for c in name if c not in _EMOJI_ORNAMENTS)
+    return name
 
 
 class FuzzyMatcher:
@@ -639,12 +744,29 @@ class FuzzyMatcher:
         # Store original for logging
         original_name = name
 
+        # Map emoji-as-letters (⚽ = 'o' in "SP⚽RTS") and strip emoji decoration, before
+        # the stylized-Unicode strip and ASCII regexes below — so "beIN SP⚽RTS" -> "beIN sports".
+        name = _normalize_emoji(name)
+
+        # Strip stylized-Unicode decoration (superscript/small-cap tier markers,
+        # bullets) up front so the ASCII tag regexes below see plain text. Runs
+        # unconditionally: a token written in superscript/small-caps is decoration
+        # regardless of tag_handling, and it would otherwise block matches
+        # (e.g. a superscript-RAW suffix never matches channel "WeatherNation").
+        name = _strip_stylized_tokens(name)
+
         # CRITICAL FIX (v25.019.0100): Apply quality patterns FIRST, before space normalization
         # This prevents space normalization from breaking quality tags like "4K" -> "4 K"
         # which would then fail to match quality patterns looking for "4K"
         # Bug: Streams with "4K" suffix were not matching because "4K" was split to "4 K"
         # by the space normalization step, then quality patterns couldn't find "4K" at end
         if ignore_quality:
+            # Strip numeric resolution markers (3840P/2160P/1080P/720P/...) before the
+            # digit/letter spacer below would split "3840P" into "3840 P".
+            # Must run before QUALITY_PATTERNS so that removing " 4K " does not glue
+            # "SPoRTS" to "3840P" and break the word-boundary anchor.
+            for pattern in RESOLUTION_PATTERNS:
+                name = re.sub(pattern, '', name, flags=re.IGNORECASE)
             for pattern in QUALITY_PATTERNS:
                 name = re.sub(pattern, '', name, flags=re.IGNORECASE)
 

--- a/plugins/channel-mapparr/plugin.json
+++ b/plugins/channel-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Channel Mapparr",
-  "version": "1.26.1430910",
+  "version": "1.26.1651015",
   "description": "Standardizes broadcast (OTA) and premium/cable channel names using network data and channel lists. Supports M3U stream import, category organization, and fuzzy matching across 42K+ channels in 11 countries.",
   "author": "PiratesIRC",
   "license": "MIT",
@@ -173,7 +173,7 @@
       "id": "apply_tv_logos",
       "label": "Apply Per-Channel Logos (tv-logos)",
       "description": "Fuzzy-match each channel name to the tv-logo/tv-logos GitHub repo and assign per-channel logos. Uses the country codes from Channel Databases. Channels with an existing logo are left alone.",
-      "button_label": "🎨 Apply Per-Channel Logos",
+      "button_label": "\u2756 Apply Per-Channel Logos",
       "button_variant": "filled",
       "button_color": "green",
       "confirm": {"message": "This will fetch tv-logos and assign per-channel logos to channels without one. Continue?"}
@@ -200,7 +200,7 @@
       "id": "plugin_status",
       "label": "Show Status",
       "description": "Show live progress and ETA for the most recent or running operation. Reads a persistent progress file so you can check without watching container logs.",
-      "button_label": "📊 Status"
+      "button_label": "\u24d8 Status"
     },
     {
       "id": "clear_csv_exports",

--- a/plugins/channel-mapparr/plugin.py
+++ b/plugins/channel-mapparr/plugin.py
@@ -44,7 +44,7 @@ PROGRESS_FILE = "/data/channel_mapparr_progress.json"
 class PluginConfig:
     """Configuration constants for Channel Maparr."""
 
-    PLUGIN_VERSION = "1.26.1430910"
+    PLUGIN_VERSION = "1.26.1651015"
 
     # Channel Database Settings
     DEFAULT_CHANNEL_DATABASES = "US"
@@ -76,6 +76,7 @@ class PluginConfig:
         "GB": "united-kingdom", "AU": "australia", "DE": "germany",
         "FR": "france", "IT": "italy", "ES": "spain", "MX": "mexico",
         "BR": "brazil", "IN": "india", "IE": "ireland", "NL": "netherlands",
+        "NO": "norway",
     }
 
     # Rate Limiting


### PR DESCRIPTION
Updates `channel-mapparr` from 1.26.1430910 → **1.26.1651015**.

## Changes
- **Matcher hardening** — three `normalize_name` input-cleaning fixes ported from `stream-mapparr`: stylized-Unicode decoration strip, emoji-as-letter (`beIN SP⚽RTS` → SPORTS), and numeric resolution markers (`720p`/`3840P`). `fuzzy_matcher.py` +122/−0; ASCII channel names provably unchanged.
- **Deduplicated channel databases** — removed 651 fully-identical rows across 7 country files (UK/MX/DE/CA/BR/FR/ES).
- **Norwegian channel database** — new `NO_channels.json` (94 channels); coverage now 12 countries.
- **Manifest fix** — two `plugin.json` button labels (`Apply Per-Channel Logos`, `Show Status`) were a literal `?`; corrected to ❖/ⓘ (U+2756 / U+24D8) to match the Plugin class.

## Verification
- Full test suite green (151 cases, incl. a new manifest/class button-label parity guard).
- Packaged cleanly (BMP-only + `py_compile` pre-flight).
- Deployed + dry-run validated in a live Dispatcharr instance.

Upstream release: https://github.com/PiratesIRC/Dispatcharr-Channel-Maparr-Plugin/releases/tag/1.26.1651015