### PR TITLE
[dispatcharr-ranked-matchups] v1.7.2: fix scheduler connection-leak container lock-up (#82/#136)

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.7.0",
+  "version": "1.7.2",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps **Ranked Matchups (Top Games)** to **1.7.2**.

Supersedes #125 (1.7.0, never merged); 1.7.2 includes all of 1.6.0/1.7.0/1.7.1 plus the lock-up fix.

### Since the listed 1.5.0
- **1.7.2** — Fixes a scheduler DB-connection leak that could lock up the whole Dispatcharr container. The background scheduler held a Postgres connection while parked, and the plugin is re-instantiated on every discovery (UI plugins-list polling), so connections leaked until `max_connections` was hit and every request (including login) blocked. Independent of channel count, so it hit small installs too. The scheduler now closes its connection before every sleep/on exit, and `__init__` is idempotent. Verified live.
- **1.7.1** — Apply no longer holds a DB transaction open across per-game network I/O.
- **1.7.0** — Field-event sports (UFC, F1, golf, NASCAR, ATP/WTA) match channels.
- **1.6.0** — "Diagnose matching" verbose log.

Release artifact: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/download/v1.7.2/plugin.zip (verified reachable, snake-case top folder, manifest 1.7.2).