### PR TITLE
[twitcharr] Bump version to 1.3.0

### DIFF
--- a/plugins/twitcharr/plugin.json
+++ b/plugins/twitcharr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Twitcharr",
-  "version": "1.2.25",
+  "version": "1.3.0",
   "description": "Twitch live-TV plugin for Dispatcharr with automatic channels, streams, XMLTV guide data and Streamlink playback.",
   "author": "eliasbruno124-dev",
   "maintainers": ["eliasbruno124-dev"],


### PR DESCRIPTION
## About this submission

Updates the existing Twitcharr catalog entry from `1.2.25` to `1.3.0`.

This publishes the upstream v1.3.0 release via the existing external `source_url`:
https://github.com/eliasbruno124-dev/Twitcharr/releases/download/v1.3.0/twitcharr.zip

## Pre-submission checklist

**If this is a new plugin:**
- [ ] Plugin folder is named `lowercase-kebab-case`
- [ ] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
- [ ] My GitHub username is in `author` or `maintainers`
- [ ] `license` is a valid [OSI-approved SPDX identifier](https://spdx.org/licenses/) (e.g. `MIT`, `Apache-2.0`)
- [ ] I have tested the plugin against a running Dispatcharr instance

**If this is an update to an existing plugin:**
- [x] `version` in `plugin.json` is incremented (unless this is a metadata-only change - see [Versioning](https://github.com/Dispatcharr/Plugins/blob/main/CONTRIBUTING.md#versioning))
- [x] I am listed in `author` or `maintainers` of the existing plugin