### PR TITLE
[tickarr]: Bump version to 0.1.02 — fix worker contention on Dispatcharr 0.26.0

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,1 +1,10 @@
-{"name": "Tickarr", "version": "0.1.01", "description": "Dynamic text overlays for IPTV channels - SiriusXM Now Playing, Sports Ticker, Custom Text", "author": "jstevenscl", "license": "MIT", "source_type": "external", "repo_url": "https://github.com/jstevenscl/tickarr", "source_url": "https://github.com/jstevenscl/tickarr/releases/download/v{version}/tickarr-{version}.zip"}
+{
+  "name": "Tickarr",
+  "version": "0.1.02",
+  "description": "Dynamic text overlays for IPTV channels - SiriusXM Now Playing, Sports Ticker, Custom Text",
+  "author": "jstevenscl",
+  "license": "MIT",
+  "source_type": "external",
+  "repo_url": "https://github.com/jstevenscl/tickarr",
+  "source_url": "https://github.com/jstevenscl/tickarr/releases/download/v{version}/tickarr-{version}.zip"
+}


### PR DESCRIPTION
Bumps Tickarr from v0.1.01 to v0.1.02.

## About this submission

This update fixes a serious interaction between Tickarr v0.1.01 and the known Dispatcharr 0.26.0 uWSGI worker bug, and we would like to request that **v0.1.01 be pulled from the plugin store** while 0.26.0 is current.

### The problem with v0.1.01 on Dispatcharr 0.26.0

Dispatcharr 0.26.0 has a known issue where psycopg3 holds persistent per-worker DB connections, causing uWSGI worker RSS to grow over time, leading to ghost FFmpeg processes and 504 cascades.

Tickarr v0.1.01 accelerates this significantly. With no worker coordination, every uWSGI worker runs the now-playing sweep simultaneously — all workers hammer the StellarTunerLog API, Redis, and the DB in parallel. This amplifies the per-worker RSS growth and triggers the 504 cascade far sooner than it would occur otherwise. On our test instance, CPU hit ~184% under normal streaming load with v0.1.01 installed on 0.26.0.

### What v0.1.02 fixes

- **Distributed Redis locks** — one worker wins the sweep lock per cycle; all others skip immediately. No parallel hammering.
- **Per-channel fetch dedup gate** — a Redis key per channel prevents duplicate API fetches within a sweep window, regardless of how many workers are active.

### Production test results

v0.1.02 has been running in production on a Dispatcharr 0.26.0 instance since 2026-06-12 (3 days). CPU load dropped from ~184% to ~5% under identical streaming conditions. Zero escalations of the 0.26.0 RSS/ghost-FFmpeg bug observed since deployment.

### Compatibility

Fully backward compatible with Dispatcharr 0.25.1 and earlier. Requires Redis (already a Dispatcharr dependency).

## Changes since v0.1.01

- Added distributed Redis sweep lock (`tickarr:sweep_lock`, `tickarr:fast_lock`, `tickarr:sports_lock`) — only one uWSGI worker runs each sweep loop per cycle
- Added per-channel Redis dedup gate — prevents duplicate fetches across concurrent workers
- All lock timeouts are non-blocking: if Redis is unavailable, workers fall back to running normally

## Release

GitHub Release: https://github.com/jstevenscl/tickarr/releases/tag/v0.1.02
ZIP: `tickarr-0.1.02.zip` attached to the release

## Pre-submission checklist

- [x] `version` in `plugin.json` is incremented
- [x] I am listed in `author` of the existing plugin