### PR TITLE
[dispatcharr-ranked-matchups] v1.8.0: stream-name matching + Tier-1 broadcaster merge

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps **dispatcharr-ranked-matchups** to **1.8.0** (external listing; source stays in [Jacob-Lasky/dispatcharr_ranked_matchups](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups)).

Only `version` changes in the listing; `source_url` resolves to the new release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/download/v1.8.0/plugin.zip (HTTP 200, snake_case top folder, byte-verified).

### What's new in 1.8.0
- **Stream-name matching:** matches a game when the matchup lives only in a stream's name on a generically-named channel with no EPG (the channel-name and EPG-title paths miss these). Attaches stream-granular. Guarded against feed-prefix false positives (both teams must co-occur in one `:`/`|` segment; kickoff times aren't boundaries).
- **Fix:** Tier-1 no longer drops EPG-confirmed broadcasters (FOX/TSN/BBC) when a dedicated feed channel exists — they're merged behind it as fallback streams.

Full notes: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.8.0