### PR TITLE
[reservoarr] Add plugin v6.2.2

### DIFF
--- a/plugins/reservoarr/README.md
+++ b/plugins/reservoarr/README.md
@@ -1,0 +1,39 @@
+# reservoarr
+
+A delay-buffer **stream profile** that absorbs IPTV CDN gaps so Plex Live TV stops dying. Eagerly drains the upstream into a RAM reservoir, then releases bytes to ffmpeg at the stream's PCR-derived content rate. Playback runs ~30s behind live, and gaps shorter than the cushion are invisible to the player.
+
+## What this is for
+
+- Your IPTV provider's CDN has prime-time gaps, occasional EOFs, or per-connection corrupt-loops.
+- You watch through **Plex Live TV** (~15s tuner timeout) or any consumer that's strict about input continuity.
+- Symptoms today: channels die mid-stream, won't tune on first try, A/V desync after a reconnect, short black-frame stutters.
+
+If your provider streams cleanly, you don't need this.
+
+## Install
+
+Dispatcharr → Plugins → **Find Plugins** → search "reservoarr" → Install. Click **Generate Stream Profile** in the plugin settings.
+
+Tuning is via `RESV_*` environment variables on the Dispatcharr container — see the [TUNABLES doc](https://github.com/brko7/reservoarr/blob/main/docs/TUNABLES.md). Defaults match production-validated behaviour and fit most providers.
+
+## Architecture (one paragraph)
+
+`upstream HTTP` → RAM reservoir (≤256MB, ~30s target cushion) → byte-rate paced release at the PCR content rate → ffmpeg remux (video copy + `dump_extra` + `-c:a ac3`) → Dispatcharr → Plex. Pacing happens in the wrapper, **not** with `ffmpeg -re` — the provider's streams carry occasional corrupt packets with garbage DTS, and `-re` sleeps on them. PCR is a *measurement* input; a garbage sample is rejected by a plausibility window. Three watchdogs ride alongside (corrupt-loop, stall, TS-corruption).
+
+## Telemetry
+
+`/data/scripts/logs/delaybuf.log` (configurable, self-rotates at 10 MB):
+
+```
+2026-06-14T10:03:33 [500004175] cushion=27s(pcr) buf=15.5MB out=4.66Mbps in=4.96Mbps crate=4.80Mbps in_total=1843MB reconnects=0 ccerr=0 pcrrej=0 disc=0 sync=0
+```
+
+Full schema in the [TELEMETRY doc](https://github.com/brko7/reservoarr/blob/main/docs/TELEMETRY.md).
+
+## More
+
+- Source, issues, discussions: https://github.com/brko7/reservoarr
+- Releases: https://github.com/brko7/reservoarr/releases
+- Hard invariants (every one earned by a production failure): https://github.com/brko7/reservoarr/blob/main/docs/INVARIANTS.md
+
+MIT licensed.

--- a/plugins/reservoarr/plugin.json
+++ b/plugins/reservoarr/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "reservoarr",
+  "version": "6.2.2",
+  "description": "Delay-buffer stream profile that absorbs IPTV CDN gaps so Plex Live TV stops dying",
+  "author": "brko7",
+  "maintainers": ["brko7"],
+  "license": "MIT",
+  "min_dispatcharr_version": "v0.25.0",
+  "repo_url": "https://github.com/brko7/reservoarr",
+  "source_type": "external",
+  "source_url": "https://github.com/brko7/reservoarr/releases/download/v{version}/reservoarr-{version}.zip"
+}


### PR DESCRIPTION
## Plugin: reservoarr

A delay-buffer **stream profile** for Dispatcharr that absorbs IPTV CDN gaps so Plex Live TV stops dying. Eagerly drains the upstream into a RAM reservoir, releases bytes to ffmpeg at the stream's PCR-derived content rate. Playback runs ~30s behind live; gaps shorter than the cushion are invisible to the player.

## Submission summary

- **Type:** external
- **Repo:** https://github.com/brko7/reservoarr
- **Release:** https://github.com/brko7/reservoarr/releases/tag/v6.2.2
- **Zip SHA256:** `178380a7608d34c660c77a1488f8ea9faa67ee3f57842433dd6951b876a6a331`
- **License:** MIT
- **`min_dispatcharr_version`:** v0.25.0
- **Author:** @brko7

## Pre-flight checks

- [x] Folder name `reservoarr` is lowercase, no separators
- [x] `plugin.json` is valid JSON, semver `6.2.2`, all required fields present
- [x] `source_type: external`, `source_url` is `https://github.com/brko7/reservoarr/releases/download/v{version}/reservoarr-{version}.zip` (HTTPS + `{version}` placeholder + GitHub Releases URL)
- [x] Release zip is reachable (public repo); top-level folder inside is `reservoarr/`; contains `plugin.py`, `plugin.json`, `reservoarr.py`, `LICENSE`, `README.md`
- [x] PR author (`brko7`) matches `author` in plugin.json
- [x] License is OSI-approved SPDX (`MIT`)

## What it does (longer)

Plex Live TV's tuner gives up after ~15s of input starvation. IPTV CDNs commonly deliver TS in short bursts with prime-time gaps that exceed this, plus corrupt packets with garbage DTS, mid-stream EOFs, and per-connection corrupt-loops. `reservoarr.py` sits between the CDN and Plex: eager urllib fetch → RAM reservoir (≤256 MB) → byte-rate paced release at PCR content rate → ffmpeg remux (video copy + `dump_extra` + `-c:a ac3` per Dispatcharr#1122) → Dispatcharr relay.

Three watchdogs: corrupt-loop (ffmpeg-stderr-side, default armed), stall (default armed), TS-corruption (default log-only pending arming evidence — see the project's CHANGELOG for the calibration story). Single-file, **stdlib-only at runtime** (Python ≥3.11). Spawned per channel-tune.

## Notes for reviewers

- **No exposed plugin fields** for the runtime knobs. The script reads `RESV_*` env vars from the container; the plugin keeps its surface area minimal. Documented at https://github.com/brko7/reservoarr/blob/main/docs/TUNABLES.md.
- **Telemetry path:** `/data/scripts/logs/delaybuf.log` (override via `RESV_LOG_DIR`). Self-rotates at 10 MB.
- **Plugin install path:** `/data/reservoarr/` — matches the pattern dispatchwrapparr uses (`/data/dispatchwrapparr/`).
- **Differentiators vs typical plugin packaging:** release zips are byte-deterministic (`SOURCE_DATE_EPOCH`-pinned), all GitHub Actions are SHA-pinned with version trailers, CI enforces version-sync between `pyproject.toml`, `plugin/plugin.json`, and `plugin/plugin.py`. This is the **first release** built under all those guards (v6.2.1's release zip had a known plugin.json version drift; v6.2.2 fixes it and prevents recurrence by construction).

## Support

- Issues / features: https://github.com/brko7/reservoarr/issues
- Questions: https://github.com/brko7/reservoarr/discussions
- Security: private advisory on the repo