### PR TITLE
[stream-mapparr] Bump version to 1.26.1720023

### DIFF
--- a/plugins/stream-mapparr/CHANGELOG.md
+++ b/plugins/stream-mapparr/CHANGELOG.md
@@ -6,6 +6,46 @@ _Nothing yet._
 
 ---
 
+## v1.26.1720023 (June 21, 2026)
+
+**Type**: Bugfix release — OTA (broadcast) callsign matching restored, and a
+data-loss guard for overwrite runs. Fixes bug-063 (user-reported: running
+Match & Assign against US: ABC/CBS/FOX/NBC left almost every channel with no
+streams).
+
+### Fixed
+
+- **Overwrite no longer wipes streams on a zero-match run.** In
+  `add_streams_to_channels`, a channel that matched 0 streams while
+  `overwrite_streams=True` previously had all its existing `ChannelStream`
+  rows deleted and nothing assigned — so a run that matched nothing (wrong
+  threshold, a database/callsign gap) silently emptied every channel.
+  "Overwrite" now only replaces when there are actual replacement streams;
+  an empty match set leaves existing streams untouched.
+
+- **OTA affiliates match by callsign again.** OTA detection in
+  `_match_streams_to_channel` depended solely on a `US_channels.json` database
+  lookup, but that database carries no `broadcast`/`callsign` entries — so
+  affiliates like `ABC - AL Montgomery (WNCF)` fell through to strict fuzzy
+  name matching and matched nothing. New `_resolve_ota_callsign()` resolves the
+  callsign from the FCC station table first, then falls back to a
+  parenthesized callsign in the Dispatcharr channel name.
+
+### Added
+
+- **FCC station table (`networks.json`) is now loaded and used.** Stream-Mapparr
+  already shipped `networks.json` (1915 US OTA stations: callsign → network /
+  city / state) but never loaded it. `FuzzyMatcher._load_broadcast_stations()`
+  (ported from Channel-Maparr) now indexes it into `channel_lookup` on every
+  load, giving authoritative callsign validation. `_build_us_callsign_database`
+  (used by `Match US OTA Only`) is repointed from the empty `US_channels.json`
+  to `networks.json`, reviving that action. **`networks.json` is now part of the
+  deploy file set** (it was missing from the container entirely).
+
+- 19 regression tests in `tests/test_ota_callsign_fallback.py`.
+
+---
+
 ## v1.26.1650116 (June 13, 2026)
 
 **Type**: Maintenance — plugin manifest cleanup (no runtime behavior change).

--- a/plugins/stream-mapparr/fuzzy_matcher.py
+++ b/plugins/stream-mapparr/fuzzy_matcher.py
@@ -341,7 +341,53 @@ class FuzzyMatcher:
                 self.logger.error(f"Error loading {channel_file}: {e}")
         
         self.logger.info(f"Total channels loaded: {total_broadcast} broadcast, {total_premium} premium")
+        self._load_broadcast_stations()
         return True
+
+    def _load_broadcast_stations(self):
+        """Load the FCC station table (networks.json) into the OTA lookup.
+
+        The per-country *_channels.json databases ship only premium
+        (National/Regional) entries — no ``broadcast`` type, no ``callsign``
+        field — so OTA/callsign matching relies on this US station table:
+        callsign -> {network_affiliation, community_served_city,
+        community_served_state, ...}. Each station is appended to
+        ``broadcast_channels`` and indexed in ``channel_lookup`` by both its
+        full callsign (``WEWS-TV``) and base callsign (``WEWS``) so a stream
+        citing either form resolves. A missing file is non-fatal. Ported from
+        Channel-Maparr to revive OTA matching after the US database lost its
+        broadcast entries. bug-063.
+
+        Returns the number of stations loaded.
+        """
+        stations_path = os.path.join(self.plugin_dir, "networks.json")
+        if not os.path.exists(stations_path):
+            self.logger.info("No networks.json present — OTA station table not loaded")
+            return 0
+
+        try:
+            with open(stations_path, 'r', encoding='utf-8') as f:
+                stations = json.load(f)
+        except Exception as e:
+            self.logger.error(f"Error loading networks.json: {e}")
+            return 0
+
+        loaded = 0
+        for station in stations:
+            callsign = (station.get('callsign') or '').strip().upper()
+            if not callsign:
+                continue
+            self.broadcast_channels.append(station)
+            # setdefault: keep the first (primary) station for a given key so a
+            # later subchannel entry can't clobber the main affiliate.
+            self.channel_lookup.setdefault(callsign, station)
+            base_callsign = re.sub(r'-(?:TV|CD|LP|DT|LD)$', '', callsign)
+            if base_callsign != callsign:
+                self.channel_lookup.setdefault(base_callsign, station)
+            loaded += 1
+
+        self.logger.info(f"Loaded {loaded} OTA broadcast stations from networks.json")
+        return loaded
 
     def reload_databases(self, country_codes=None):
         """
@@ -429,6 +475,7 @@ class FuzzyMatcher:
                 self.logger.error(f"Error loading {channel_file}: {e}")
 
         self.logger.info(f"Total channels loaded: {total_broadcast} broadcast, {total_premium} premium")
+        self._load_broadcast_stations()
         return True
 
     def extract_callsign(self, channel_name):
@@ -446,7 +493,15 @@ class FuzzyMatcher:
             callsign = paren_match.group(1).upper()
             if callsign not in ['WEST', 'EAST', 'KIDS', 'WOMEN', 'WILD', 'WORLD']:
                 return callsign
-        
+
+        # Priority 1b: grandfathered 3-letter callsigns in parentheses without a suffix
+        # (WWL/WJZ/KYW/WRC). Suffixed forms fall through to Priority 2. bug-062.
+        paren3_match = re.search(r'\(([KW][A-Z]{2})\)', channel_name, re.IGNORECASE)
+        if paren3_match:
+            callsign = paren3_match.group(1).upper()
+            if callsign not in ['WEST', 'EAST', 'KIDS', 'WOMEN', 'WILD', 'WORLD']:
+                return callsign
+
         # Priority 2: Callsigns with suffix in parentheses
         paren_suffix_match = re.search(r'\(([KW][A-Z]{2,4}-(?:TV|CD|LP|DT|LD))\)', channel_name, re.IGNORECASE)
         if paren_suffix_match:

--- a/plugins/stream-mapparr/networks.json
+++ b/plugins/stream-mapparr/networks.json
@@ -1,0 +1,17237 @@
+[
+  {
+    "callsign": "KFCT",
+    "community_served_city": "FORT COLLINS",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "22",
+    "facility_id": "125"
+  },
+  {
+    "callsign": "KDVR",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "31",
+    "facility_id": "126"
+  },
+  {
+    "callsign": "WOTF-TV",
+    "community_served_city": "DAYTONA BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Grit",
+    "tv_virtual_channel": "26",
+    "facility_id": "131"
+  },
+  {
+    "callsign": "KNVA",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "54",
+    "facility_id": "144"
+  },
+  {
+    "callsign": "WXIN",
+    "community_served_city": "INDIANAPOLIS",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "59",
+    "facility_id": "146"
+  },
+  {
+    "callsign": "WTIC-TV",
+    "community_served_city": "HARTFORD",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "61",
+    "facility_id": "147"
+  },
+  {
+    "callsign": "KAKW-DT",
+    "community_served_city": "KILLEEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "62",
+    "facility_id": "148"
+  },
+  {
+    "callsign": "WWLM-CD",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "20",
+    "facility_id": "267"
+  },
+  {
+    "callsign": "KABC-TV",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "282"
+  },
+  {
+    "callsign": "KRBC-TV",
+    "community_served_city": "ABILENE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "9",
+    "facility_id": "306"
+  },
+  {
+    "callsign": "KSAN-TV",
+    "community_served_city": "SAN ANGELO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "307"
+  },
+  {
+    "callsign": "KTXS-TV",
+    "community_served_city": "SWEETWATER",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "308"
+  },
+  {
+    "callsign": "K20JX-D",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Three Angels Broadcasting Network",
+    "tv_virtual_channel": "27",
+    "facility_id": "334"
+  },
+  {
+    "callsign": "WACY-TV",
+    "community_served_city": "APPLETON",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "32",
+    "facility_id": "361"
+  },
+  {
+    "callsign": "WCAV",
+    "community_served_city": "CHARLOTTESVILLE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS FOX",
+    "tv_virtual_channel": "19",
+    "facility_id": "363"
+  },
+  {
+    "callsign": "WRGT-TV",
+    "community_served_city": "DAYTON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "DABL",
+    "tv_virtual_channel": "45",
+    "facility_id": "411"
+  },
+  {
+    "callsign": "WRLH-TV",
+    "community_served_city": "RICHMOND",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "35",
+    "facility_id": "412"
+  },
+  {
+    "callsign": "WUHF",
+    "community_served_city": "ROCHESTER",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "31",
+    "facility_id": "413"
+  },
+  {
+    "callsign": "WXLV-TV",
+    "community_served_city": "WINSTON-SALEM",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "45",
+    "facility_id": "414"
+  },
+  {
+    "callsign": "WUTV",
+    "community_served_city": "BUFFALO",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "29",
+    "facility_id": "415"
+  },
+  {
+    "callsign": "WTAT-TV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "24",
+    "facility_id": "416"
+  },
+  {
+    "callsign": "WVAH-TV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "Catchy",
+    "tv_virtual_channel": "11",
+    "facility_id": "417"
+  },
+  {
+    "callsign": "WZTV",
+    "community_served_city": "NASHVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "17",
+    "facility_id": "418"
+  },
+  {
+    "callsign": "WADL",
+    "community_served_city": "MOUNT CLEMENS",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetworkTV",
+    "tv_virtual_channel": "38",
+    "facility_id": "455"
+  },
+  {
+    "callsign": "WAFB",
+    "community_served_city": "BATON ROUGE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "589"
+  },
+  {
+    "callsign": "WTOC-TV",
+    "community_served_city": "SAVANNAH",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "590"
+  },
+  {
+    "callsign": "WAFF",
+    "community_served_city": "HUNTSVILLE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "48",
+    "facility_id": "591"
+  },
+  {
+    "callsign": "KFVS-TV",
+    "community_served_city": "CAPE GIRARDEAU",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "592"
+  },
+  {
+    "callsign": "KWWL",
+    "community_served_city": "WATERLOO",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "593"
+  },
+  {
+    "callsign": "WITN-TV",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "594"
+  },
+  {
+    "callsign": "WTVM",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "595"
+  },
+  {
+    "callsign": "KVTN-DT",
+    "community_served_city": "PINE BLUFF",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "25",
+    "facility_id": "607"
+  },
+  {
+    "callsign": "KVTH-DT",
+    "community_served_city": "HOT SPRINGS",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "26",
+    "facility_id": "608"
+  },
+  {
+    "callsign": "WTVU-CD",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Cornerstone TeleVision",
+    "tv_virtual_channel": "22",
+    "facility_id": "617"
+  },
+  {
+    "callsign": "WHSU-CD",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "The Walk Television Network",
+    "tv_virtual_channel": "51",
+    "facility_id": "629"
+  },
+  {
+    "callsign": "KFVE",
+    "community_served_city": "KAILUA-KONA",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "6",
+    "facility_id": "664"
+  },
+  {
+    "callsign": "WAKA",
+    "community_served_city": "SELMA",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "701"
+  },
+  {
+    "callsign": "WAIQ",
+    "community_served_city": "MONTGOMERY",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "706"
+  },
+  {
+    "callsign": "WGIQ",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "43",
+    "facility_id": "710"
+  },
+  {
+    "callsign": "WCIQ",
+    "community_served_city": "MOUNT CHEAHA",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "711"
+  },
+  {
+    "callsign": "WHIQ",
+    "community_served_city": "HUNTSVILLE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "713"
+  },
+  {
+    "callsign": "WDIQ",
+    "community_served_city": "DOZIER",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "714"
+  },
+  {
+    "callsign": "WFIQ",
+    "community_served_city": "FLORENCE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "715"
+  },
+  {
+    "callsign": "WBIQ",
+    "community_served_city": "BIRMINGHAM",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "717"
+  },
+  {
+    "callsign": "WIIQ",
+    "community_served_city": "DEMOPOLIS",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "41",
+    "facility_id": "720"
+  },
+  {
+    "callsign": "WEIQ",
+    "community_served_city": "MOBILE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "42",
+    "facility_id": "721"
+  },
+  {
+    "callsign": "KLRN",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "749"
+  },
+  {
+    "callsign": "KAKM",
+    "community_served_city": "ANCHORAGE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "804"
+  },
+  {
+    "callsign": "KNAT-TV",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "23",
+    "facility_id": "993"
+  },
+  {
+    "callsign": "WWTO-TV",
+    "community_served_city": "NAPERVILLE",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "35",
+    "facility_id": "998"
+  },
+  {
+    "callsign": "KTAJ-TV",
+    "community_served_city": "ST. JOSEPH",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "16",
+    "facility_id": "999"
+  },
+  {
+    "callsign": "WTJP-TV",
+    "community_served_city": "GADSDEN",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "60",
+    "facility_id": "1002"
+  },
+  {
+    "callsign": "KDOR-TV",
+    "community_served_city": "BARTLESVILLE",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "17",
+    "facility_id": "1005"
+  },
+  {
+    "callsign": "WJLA-TV",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "1051"
+  },
+  {
+    "callsign": "KUCW",
+    "community_served_city": "OGDEN",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "30",
+    "facility_id": "1136"
+  },
+  {
+    "callsign": "KAZQ",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "32",
+    "facility_id": "1151"
+  },
+  {
+    "callsign": "WLMA",
+    "community_served_city": "LIMA",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "44",
+    "facility_id": "1222"
+  },
+  {
+    "callsign": "KACV-TV",
+    "community_served_city": "AMARILLO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "1236"
+  },
+  {
+    "callsign": "KXTF",
+    "community_served_city": "TWIN FALLS",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "35",
+    "facility_id": "1255"
+  },
+  {
+    "callsign": "KPVI-DT",
+    "community_served_city": "POCATELLO",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, Catchy Comedy, Movies",
+    "tv_virtual_channel": "6",
+    "facility_id": "1270"
+  },
+  {
+    "callsign": "WDPN-TV",
+    "community_served_city": "WILMINGTON",
+    "community_served_state": "DE",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "2",
+    "facility_id": "1283"
+  },
+  {
+    "callsign": "WABC-TV",
+    "community_served_city": "NEW YORK",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "1328"
+  },
+  {
+    "callsign": "WMTJ",
+    "community_served_city": "FAJARDO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "40",
+    "facility_id": "2174"
+  },
+  {
+    "callsign": "WQTO",
+    "community_served_city": "PONCE",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "2175"
+  },
+  {
+    "callsign": "WPXJ-TV",
+    "community_served_city": "BATAVIA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "51",
+    "facility_id": "2325"
+  },
+  {
+    "callsign": "WSVI",
+    "community_served_city": "CHRISTIANSTED",
+    "community_served_state": "VI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "8",
+    "facility_id": "2370"
+  },
+  {
+    "callsign": "KBTV-CD",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "SONLIFE BROADCASTING NETWORK",
+    "tv_virtual_channel": "8",
+    "facility_id": "2424"
+  },
+  {
+    "callsign": "WCYB-TV",
+    "community_served_city": "BRISTOL",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "2455"
+  },
+  {
+    "callsign": "KVEW",
+    "community_served_city": "KENNEWICK",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "42",
+    "facility_id": "2495"
+  },
+  {
+    "callsign": "KAPP",
+    "community_served_city": "YAKIMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "35",
+    "facility_id": "2506"
+  },
+  {
+    "callsign": "KOPX-TV",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "62",
+    "facility_id": "2566"
+  },
+  {
+    "callsign": "WGBA-TV",
+    "community_served_city": "GREEN BAY",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "26",
+    "facility_id": "2708"
+  },
+  {
+    "callsign": "WEUX",
+    "community_served_city": "CHIPPEWA FALLS",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "48",
+    "facility_id": "2709"
+  },
+  {
+    "callsign": "WLAX",
+    "community_served_city": "LA CROSSE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "25",
+    "facility_id": "2710"
+  },
+  {
+    "callsign": "KUAS-TV",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "2722"
+  },
+  {
+    "callsign": "KAET",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "2728"
+  },
+  {
+    "callsign": "KUAT-TV",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "2731"
+  },
+  {
+    "callsign": "KFPH-CD",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "35",
+    "facility_id": "2739"
+  },
+  {
+    "callsign": "KAFT",
+    "community_served_city": "FAYETTEVILLE",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "2767"
+  },
+  {
+    "callsign": "KETG",
+    "community_served_city": "ARKADELPHIA",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "2768"
+  },
+  {
+    "callsign": "KTEJ",
+    "community_served_city": "JONESBORO",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "2769"
+  },
+  {
+    "callsign": "KETS",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "2770"
+  },
+  {
+    "callsign": "KEMV",
+    "community_served_city": "MOUNTAIN VIEW",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "2777"
+  },
+  {
+    "callsign": "KVTJ-DT",
+    "community_served_city": "JONESBORO",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "48",
+    "facility_id": "2784"
+  },
+  {
+    "callsign": "KTHV",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "2787"
+  },
+  {
+    "callsign": "WPGX",
+    "community_served_city": "PANAMA CITY",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "28",
+    "facility_id": "2942"
+  },
+  {
+    "callsign": "WCCV-TV",
+    "community_served_city": "ARECIBO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "54",
+    "facility_id": "3001"
+  },
+  {
+    "callsign": "WUVN",
+    "community_served_city": "HARTFORD",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "18",
+    "facility_id": "3072"
+  },
+  {
+    "callsign": "WVXF",
+    "community_served_city": "CHARLOTTE AMALIE",
+    "community_served_state": "VI",
+    "active_ind": "Y",
+    "network_affiliation": "Cozi TV",
+    "tv_virtual_channel": "17",
+    "facility_id": "3113"
+  },
+  {
+    "callsign": "WWMB",
+    "community_served_city": "FLORENCE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "DABL",
+    "tv_virtual_channel": "21",
+    "facility_id": "3133"
+  },
+  {
+    "callsign": "KNET-CD",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "25",
+    "facility_id": "3167"
+  },
+  {
+    "callsign": "WFXG",
+    "community_served_city": "AUGUSTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "54",
+    "facility_id": "3228"
+  },
+  {
+    "callsign": "KAAH-TV",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "26",
+    "facility_id": "3246"
+  },
+  {
+    "callsign": "WCLO-TV",
+    "community_served_city": "AGUADA",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "50",
+    "facility_id": "3255"
+  },
+  {
+    "callsign": "WRBL",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "3359"
+  },
+  {
+    "callsign": "WIPB",
+    "community_served_city": "MUNCIE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "49",
+    "facility_id": "3646"
+  },
+  {
+    "callsign": "KARD",
+    "community_served_city": "WEST MONROE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX Television Network",
+    "tv_virtual_channel": "14",
+    "facility_id": "3658"
+  },
+  {
+    "callsign": "KOZL-TV",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetworkTV",
+    "tv_virtual_channel": "27",
+    "facility_id": "3659"
+  },
+  {
+    "callsign": "KLBK-TV",
+    "community_served_city": "LUBBOCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "3660"
+  },
+  {
+    "callsign": "WTVW",
+    "community_served_city": "EVANSVILLE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "7",
+    "facility_id": "3661"
+  },
+  {
+    "callsign": "WVII-TV",
+    "community_served_city": "BANGOR",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "3667"
+  },
+  {
+    "callsign": "WLWC",
+    "community_served_city": "NEW BEDFORD",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "Court TV",
+    "tv_virtual_channel": "28",
+    "facility_id": "3978"
+  },
+  {
+    "callsign": "KBNT-CD",
+    "community_served_city": "SAN DIEGO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "17",
+    "facility_id": "4035"
+  },
+  {
+    "callsign": "DDWSJU-TV",
+    "community_served_city": "SAN JUAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "SBS/MEGA",
+    "tv_virtual_channel": "30",
+    "facility_id": "4077"
+  },
+  {
+    "callsign": "WTTA",
+    "community_served_city": "ST. PETERSBURG",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "The CW",
+    "tv_virtual_channel": "38",
+    "facility_id": "4108"
+  },
+  {
+    "callsign": "WDWL",
+    "community_served_city": "BAYAMON",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Enlace",
+    "tv_virtual_channel": "36",
+    "facility_id": "4110"
+  },
+  {
+    "callsign": "WALA-TV",
+    "community_served_city": "MOBILE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "10",
+    "facility_id": "4143"
+  },
+  {
+    "callsign": "KHON-TV",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX/CW/GRIT/REWIND",
+    "tv_virtual_channel": "2",
+    "facility_id": "4144"
+  },
+  {
+    "callsign": "KAII-TV",
+    "community_served_city": "WAILUKU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX/CW/GRIT/REWIND",
+    "tv_virtual_channel": "7",
+    "facility_id": "4145"
+  },
+  {
+    "callsign": "KHAW-TV",
+    "community_served_city": "HILO",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX/CW/GRIT/REWIND",
+    "tv_virtual_channel": "11",
+    "facility_id": "4146"
+  },
+  {
+    "callsign": "KBAK-TV",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "4148"
+  },
+  {
+    "callsign": "WVUE-DT",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "8",
+    "facility_id": "4149"
+  },
+  {
+    "callsign": "WLUK-TV",
+    "community_served_city": "GREEN BAY",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "11",
+    "facility_id": "4150"
+  },
+  {
+    "callsign": "WTVY",
+    "community_served_city": "DOTHAN",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, NBC, CW, MeTV",
+    "tv_virtual_channel": "4",
+    "facility_id": "4152"
+  },
+  {
+    "callsign": "WABE-TV",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "30",
+    "facility_id": "4190"
+  },
+  {
+    "callsign": "WSIU-TV",
+    "community_served_city": "CARBONDALE",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "4297"
+  },
+  {
+    "callsign": "WUSI-TV",
+    "community_served_city": "OLNEY",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "16",
+    "facility_id": "4301"
+  },
+  {
+    "callsign": "WNMU",
+    "community_served_city": "MARQUETTE",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "13",
+    "facility_id": "4318"
+  },
+  {
+    "callsign": "KMOS-TV",
+    "community_served_city": "SEDALIA",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "4326"
+  },
+  {
+    "callsign": "KOCE-TV",
+    "community_served_city": "HUNTINGTON BEACH",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "50",
+    "facility_id": "4328"
+  },
+  {
+    "callsign": "WVUT",
+    "community_served_city": "VINCENNES",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "4329"
+  },
+  {
+    "callsign": "WPCT",
+    "community_served_city": "PANAMA CITY BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "46",
+    "facility_id": "4354"
+  },
+  {
+    "callsign": "WTJR",
+    "community_served_city": "QUINCY",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "16",
+    "facility_id": "4593"
+  },
+  {
+    "callsign": "KUNS-TV",
+    "community_served_city": "BELLEVUE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "51",
+    "facility_id": "4624"
+  },
+  {
+    "callsign": "WTAP-TV",
+    "community_served_city": "PARKERSBURG",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "15",
+    "facility_id": "4685"
+  },
+  {
+    "callsign": "WTOK-TV",
+    "community_served_city": "MERIDIAN",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "11",
+    "facility_id": "4686"
+  },
+  {
+    "callsign": "WHSV-TV",
+    "community_served_city": "HARRISONBURG",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "3",
+    "facility_id": "4688"
+  },
+  {
+    "callsign": "DWIFR",
+    "community_served_city": "FREEPORT",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "4689"
+  },
+  {
+    "callsign": "KHQA-TV",
+    "community_served_city": "HANNIBAL",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "KHQA D1 - CBS; KHQA D2 - ABC; KHQA D3 - Comet",
+    "tv_virtual_channel": "7",
+    "facility_id": "4690"
+  },
+  {
+    "callsign": "KDLH",
+    "community_served_city": "DULUTH",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "3",
+    "facility_id": "4691"
+  },
+  {
+    "callsign": "WBKO",
+    "community_served_city": "BOWLING GREEN",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "4692"
+  },
+  {
+    "callsign": "WYTV",
+    "community_served_city": "YOUNGSTOWN",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "ABC / MyNetwork",
+    "tv_virtual_channel": "33",
+    "facility_id": "4693"
+  },
+  {
+    "callsign": "KBSV",
+    "community_served_city": "CERES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "23",
+    "facility_id": "4939"
+  },
+  {
+    "callsign": "KYUS-TV",
+    "community_served_city": "MILES CITY",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "5237"
+  },
+  {
+    "callsign": "KSVI",
+    "community_served_city": "BILLINGS",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "5243"
+  },
+  {
+    "callsign": "KTVH-DT",
+    "community_served_city": "HELENA",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC KTVH 12.1, MTN KTVH-D2 12.2, Cozi 12.3, Court TV 12.4, Mystery 12.5, HSN 12.6",
+    "tv_virtual_channel": "12",
+    "facility_id": "5290"
+  },
+  {
+    "callsign": "KUVN-CD",
+    "community_served_city": "FORT WORTH",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "47",
+    "facility_id": "5319"
+  },
+  {
+    "callsign": "WIAT",
+    "community_served_city": "BIRMINGHAM",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "42",
+    "facility_id": "5360"
+  },
+  {
+    "callsign": "WQPT-TV",
+    "community_served_city": "MOLINE",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "24",
+    "facility_id": "5468"
+  },
+  {
+    "callsign": "KQIN",
+    "community_served_city": "DAVENPORT",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "5471"
+  },
+  {
+    "callsign": "WPXD-TV",
+    "community_served_city": "ANN ARBOR",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "31",
+    "facility_id": "5800"
+  },
+  {
+    "callsign": "KPXG-TV",
+    "community_served_city": "SALEM",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Laff, IONPlus, SCRIPPS News, Jewelry TV, QVC, HSN",
+    "tv_virtual_channel": "22",
+    "facility_id": "5801"
+  },
+  {
+    "callsign": "WVEN-TV",
+    "community_served_city": "MELBOURNE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "UNIVISION",
+    "tv_virtual_channel": "43",
+    "facility_id": "5802"
+  },
+  {
+    "callsign": "WYZZ-TV",
+    "community_served_city": "BLOOMINGTON",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "43",
+    "facility_id": "5875"
+  },
+  {
+    "callsign": "WBRA-TV",
+    "community_served_city": "ROANOKE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "5981"
+  },
+  {
+    "callsign": "DWMSY-TV",
+    "community_served_city": "MARION",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "52",
+    "facility_id": "5982"
+  },
+  {
+    "callsign": "DWSBN-TV",
+    "community_served_city": "NORTON",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "47",
+    "facility_id": "5985"
+  },
+  {
+    "callsign": "WNYE-TV",
+    "community_served_city": "NEW YORK",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "25",
+    "facility_id": "6048"
+  },
+  {
+    "callsign": "WFSG",
+    "community_served_city": "PANAMA CITY",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "56",
+    "facility_id": "6093"
+  },
+  {
+    "callsign": "WHA-TV",
+    "community_served_city": "MADISON",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "6096"
+  },
+  {
+    "callsign": "WKAR-TV",
+    "community_served_city": "EAST LANSING",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "6104"
+  },
+  {
+    "callsign": "KPBS",
+    "community_served_city": "SAN DIEGO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PUBLIC BROADCASTING SERVICE",
+    "tv_virtual_channel": "15",
+    "facility_id": "6124"
+  },
+  {
+    "callsign": "KSL-TV",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "6359"
+  },
+  {
+    "callsign": "WFXT",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX (25.1); Comet TV (25.2) & Laff TV (25.3)",
+    "tv_virtual_channel": "25",
+    "facility_id": "6463"
+  },
+  {
+    "callsign": "WDPX-TV",
+    "community_served_city": "WOBURN",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "Grit",
+    "tv_virtual_channel": "58",
+    "facility_id": "6476"
+  },
+  {
+    "callsign": "WFGX",
+    "community_served_city": "FORT WALTON BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetworkTV",
+    "tv_virtual_channel": "35",
+    "facility_id": "6554"
+  },
+  {
+    "callsign": "WBGU-TV",
+    "community_served_city": "BOWLING GREEN",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "6568"
+  },
+  {
+    "callsign": "WXPX-TV",
+    "community_served_city": "BRADENTON",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Grit Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "66",
+    "facility_id": "6601"
+  },
+  {
+    "callsign": "KBTX-TV",
+    "community_served_city": "BRYAN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "6669"
+  },
+  {
+    "callsign": "DKDYW",
+    "community_served_city": "WACO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "34",
+    "facility_id": "6673"
+  },
+  {
+    "callsign": "WEFS",
+    "community_served_city": "COCOA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "68",
+    "facility_id": "6744"
+  },
+  {
+    "callsign": "KBYU-TV",
+    "community_served_city": "PROVO",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "6823"
+  },
+  {
+    "callsign": "WILX-TV",
+    "community_served_city": "ONONDAGA",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "6863"
+  },
+  {
+    "callsign": "KAUZ-TV",
+    "community_served_city": "WICHITA FALLS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "6864"
+  },
+  {
+    "callsign": "KOSA-TV",
+    "community_served_city": "ODESSA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "6865"
+  },
+  {
+    "callsign": "WHOI",
+    "community_served_city": "PEORIA",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "TBD",
+    "tv_virtual_channel": "19",
+    "facility_id": "6866"
+  },
+  {
+    "callsign": "WSAW-TV",
+    "community_served_city": "WAUSAU",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "6867"
+  },
+  {
+    "callsign": "WWLP",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "22",
+    "facility_id": "6868"
+  },
+  {
+    "callsign": "WTRF-TV",
+    "community_served_city": "WHEELING",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "6869"
+  },
+  {
+    "callsign": "WMTV",
+    "community_served_city": "MADISON",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CW, METV, START TV, WEATHERNATION",
+    "tv_virtual_channel": "15",
+    "facility_id": "6870"
+  },
+  {
+    "callsign": "KWQC-TV",
+    "community_served_city": "DAVENPORT",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "6885"
+  },
+  {
+    "callsign": "WUPA",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "69",
+    "facility_id": "6900"
+  },
+  {
+    "callsign": "KTPX-TV",
+    "community_served_city": "OKMULGEE",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "ION, KJRH, Court TV, Grit, Mystery, Jewelry TV, QVC, HSN",
+    "tv_virtual_channel": "44",
+    "facility_id": "7078"
+  },
+  {
+    "callsign": "KASW",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "61",
+    "facility_id": "7143"
+  },
+  {
+    "callsign": "WGTW-TV",
+    "community_served_city": "MILLVILLE",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "48",
+    "facility_id": "7623"
+  },
+  {
+    "callsign": "WJFB",
+    "community_served_city": "LEBANON",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "66",
+    "facility_id": "7651"
+  },
+  {
+    "callsign": "KJTL",
+    "community_served_city": "WICHITA FALLS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "18",
+    "facility_id": "7675"
+  },
+  {
+    "callsign": "WBPX-TV",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Mystery, SCRIPPS News, Bounce, IONPlus, Jewlery TV, HSN",
+    "tv_virtual_channel": "68",
+    "facility_id": "7692"
+  },
+  {
+    "callsign": "KUVI-DT",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Quest",
+    "tv_virtual_channel": "45",
+    "facility_id": "7700"
+  },
+  {
+    "callsign": "WGFL",
+    "community_served_city": "HIGH SPRINGS",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "53",
+    "facility_id": "7727"
+  },
+  {
+    "callsign": "WIVB-TV",
+    "community_served_city": "BUFFALO",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "7780"
+  },
+  {
+    "callsign": "KGCW",
+    "community_served_city": "BURLINGTON",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "26",
+    "facility_id": "7841"
+  },
+  {
+    "callsign": "KOLN",
+    "community_served_city": "LINCOLN",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "7890"
+  },
+  {
+    "callsign": "WEAU",
+    "community_served_city": "EAU CLAIRE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "13",
+    "facility_id": "7893"
+  },
+  {
+    "callsign": "KGIN",
+    "community_served_city": "GRAND ISLAND",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "7894"
+  },
+  {
+    "callsign": "WDTI",
+    "community_served_city": "INDIANAPOLIS",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "69",
+    "facility_id": "7908"
+  },
+  {
+    "callsign": "WNUV",
+    "community_served_city": "BALTIMORE",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "The CW Baltimore",
+    "tv_virtual_channel": "54",
+    "facility_id": "7933"
+  },
+  {
+    "callsign": "WUJA",
+    "community_served_city": "CAGUAS",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "58",
+    "facility_id": "8156"
+  },
+  {
+    "callsign": "KQET",
+    "community_served_city": "WATSONVILLE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "8214"
+  },
+  {
+    "callsign": "KOBI",
+    "community_served_city": "MEDFORD",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC and COZI",
+    "tv_virtual_channel": "5",
+    "facility_id": "8260"
+  },
+  {
+    "callsign": "KAEF-TV",
+    "community_served_city": "ARCATA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "23",
+    "facility_id": "8263"
+  },
+  {
+    "callsign": "KOTI",
+    "community_served_city": "KLAMATH FALLS",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC and COZI",
+    "tv_virtual_channel": "2",
+    "facility_id": "8284"
+  },
+  {
+    "callsign": "KRCR-TV",
+    "community_served_city": "REDDING",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "8291"
+  },
+  {
+    "callsign": "KLSR-TV",
+    "community_served_city": "EUGENE",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "FOX & MYNET",
+    "tv_virtual_channel": "34",
+    "facility_id": "8322"
+  },
+  {
+    "callsign": "KQSL",
+    "community_served_city": "FORT BRAGG",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "8",
+    "facility_id": "8378"
+  },
+  {
+    "callsign": "KAMR-TV",
+    "community_served_city": "AMARILLO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "8523"
+  },
+  {
+    "callsign": "WUAB",
+    "community_served_city": "LORAIN",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "43",
+    "facility_id": "8532"
+  },
+  {
+    "callsign": "KLRU",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "8564"
+  },
+  {
+    "callsign": "WPVI-TV",
+    "community_served_city": "PHILADELPHIA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "8616"
+  },
+  {
+    "callsign": "WTVD",
+    "community_served_city": "DURHAM",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "11",
+    "facility_id": "8617"
+  },
+  {
+    "callsign": "KFSN-TV",
+    "community_served_city": "FRESNO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "30",
+    "facility_id": "8620"
+  },
+  {
+    "callsign": "KTOO-TV",
+    "community_served_city": "JUNEAU",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "8651"
+  },
+  {
+    "callsign": "WOI-DT",
+    "community_served_city": "AMES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "5",
+    "facility_id": "8661"
+  },
+  {
+    "callsign": "WRAL-TV",
+    "community_served_city": "RALEIGH",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "8688"
+  },
+  {
+    "callsign": "WCIV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "My Network TV",
+    "tv_virtual_channel": "36",
+    "facility_id": "9015"
+  },
+  {
+    "callsign": "WFXB",
+    "community_served_city": "MYRTLE BEACH",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "Fox/MeTV",
+    "tv_virtual_channel": "43",
+    "facility_id": "9054"
+  },
+  {
+    "callsign": "WGGS-TV",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "16",
+    "facility_id": "9064"
+  },
+  {
+    "callsign": "WBBZ-TV",
+    "community_served_city": "SPRINGVILLE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "METV",
+    "tv_virtual_channel": "67",
+    "facility_id": "9088"
+  },
+  {
+    "callsign": "WCBS-TV",
+    "community_served_city": "NEW YORK",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "9610"
+  },
+  {
+    "callsign": "WBBM-TV",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "9617"
+  },
+  {
+    "callsign": "KCBS-TV",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "9628"
+  },
+  {
+    "callsign": "WCCO-TV",
+    "community_served_city": "MINNEAPOLIS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "9629"
+  },
+  {
+    "callsign": "WJMN-TV",
+    "community_served_city": "ESCANABA",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "MyTV Network",
+    "tv_virtual_channel": "3",
+    "facility_id": "9630"
+  },
+  {
+    "callsign": "DKCCO-TV",
+    "community_served_city": "ALEXANDRIA",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "9632"
+  },
+  {
+    "callsign": "WFRV-TV",
+    "community_served_city": "GREEN BAY",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "9635"
+  },
+  {
+    "callsign": "KCCW-TV",
+    "community_served_city": "WALKER",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "9640"
+  },
+  {
+    "callsign": "KCRG-TV",
+    "community_served_city": "CEDAR RAPIDS",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "9719"
+  },
+  {
+    "callsign": "WMCN-TV",
+    "community_served_city": "PRINCETON",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC to 6-30-24, IND beginning 7-1-24 - 12-31-24",
+    "tv_virtual_channel": "44",
+    "facility_id": "9739"
+  },
+  {
+    "callsign": "KNCT",
+    "community_served_city": "BELTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CW / StartTV / DABL / H & I",
+    "tv_virtual_channel": "46",
+    "facility_id": "9754"
+  },
+  {
+    "callsign": "WGNT",
+    "community_served_city": "PORTSMOUTH",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "CW, Antenna TV, Grit, DABL, QVC2, HSN2",
+    "tv_virtual_channel": "27",
+    "facility_id": "9762"
+  },
+  {
+    "callsign": "WBTS-CD",
+    "community_served_city": "NASHUA",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "15",
+    "facility_id": "9766"
+  },
+  {
+    "callsign": "KXXV",
+    "community_served_city": "WACO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "25",
+    "facility_id": "9781"
+  },
+  {
+    "callsign": "WTGL",
+    "community_served_city": "LEESBURG",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "45",
+    "facility_id": "9881"
+  },
+  {
+    "callsign": "WCMU-TV",
+    "community_served_city": "MOUNT PLEASANT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "14",
+    "facility_id": "9908"
+  },
+  {
+    "callsign": "WCMW",
+    "community_served_city": "MANISTEE",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "9913"
+  },
+  {
+    "callsign": "WCML",
+    "community_served_city": "ALPENA",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "9917"
+  },
+  {
+    "callsign": "WCMV",
+    "community_served_city": "CADILLAC",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "9922"
+  },
+  {
+    "callsign": "WUXP-TV",
+    "community_served_city": "NASHVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "MYTV",
+    "tv_virtual_channel": "30",
+    "facility_id": "9971"
+  },
+  {
+    "callsign": "WCVE-TV",
+    "community_served_city": "RICHMOND",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "9987"
+  },
+  {
+    "callsign": "WCVW",
+    "community_served_city": "RICHMOND",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "57",
+    "facility_id": "9989"
+  },
+  {
+    "callsign": "WHTJ",
+    "community_served_city": "CHARLOTTESVILLE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "41",
+    "facility_id": "9990"
+  },
+  {
+    "callsign": "WNVC",
+    "community_served_city": "CULPEPER",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "30",
+    "facility_id": "9999"
+  },
+  {
+    "callsign": "WNVT",
+    "community_served_city": "SPOTSYLVANIA",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "30",
+    "facility_id": "10019"
+  },
+  {
+    "callsign": "KWYP-DT",
+    "community_served_city": "LARAMIE",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "10032"
+  },
+  {
+    "callsign": "KCWC-DT",
+    "community_served_city": "LANDER",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "10036"
+  },
+  {
+    "callsign": "KGNS-TV",
+    "community_served_city": "LAREDO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "10061"
+  },
+  {
+    "callsign": "WFFF-TV",
+    "community_served_city": "BURLINGTON",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "44",
+    "facility_id": "10132"
+  },
+  {
+    "callsign": "WRAY-TV",
+    "community_served_city": "WAKE FOREST",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "30",
+    "facility_id": "10133"
+  },
+  {
+    "callsign": "KBMT",
+    "community_served_city": "BEAUMONT",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "10150"
+  },
+  {
+    "callsign": "WRDM-CD",
+    "community_served_city": "HARTFORD",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "19",
+    "facility_id": "10153"
+  },
+  {
+    "callsign": "KTUU-TV",
+    "community_served_city": "ANCHORAGE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "NBC,  H&I",
+    "tv_virtual_channel": "2",
+    "facility_id": "10173"
+  },
+  {
+    "callsign": "KTMW",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "20",
+    "facility_id": "10177"
+  },
+  {
+    "callsign": "KSNV",
+    "community_served_city": "LAS VEGAS",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "10179"
+  },
+  {
+    "callsign": "KIII",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "3",
+    "facility_id": "10188"
+  },
+  {
+    "callsign": "KRCW-TV",
+    "community_served_city": "SALEM",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "32",
+    "facility_id": "10192"
+  },
+  {
+    "callsign": "KVCW",
+    "community_served_city": "LAS VEGAS",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "The CW",
+    "tv_virtual_channel": "33",
+    "facility_id": "10195"
+  },
+  {
+    "callsign": "KSCE",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "38",
+    "facility_id": "10202"
+  },
+  {
+    "callsign": "WSFL-TV",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CW, Court TV, Antenna TV, Defy, ION Plus, QVC",
+    "tv_virtual_channel": "39",
+    "facility_id": "10203"
+  },
+  {
+    "callsign": "KTXL",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "40",
+    "facility_id": "10205"
+  },
+  {
+    "callsign": "WOTV",
+    "community_served_city": "BATTLE CREEK",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "41",
+    "facility_id": "10212"
+  },
+  {
+    "callsign": "WPMT",
+    "community_served_city": "YORK",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "43",
+    "facility_id": "10213"
+  },
+  {
+    "callsign": "WMSN-TV",
+    "community_served_city": "MADISON",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "47",
+    "facility_id": "10221"
+  },
+  {
+    "callsign": "KNPB",
+    "community_served_city": "RENO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "10228"
+  },
+  {
+    "callsign": "KUSI-TV",
+    "community_served_city": "SAN DIEGO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "51",
+    "facility_id": "10238"
+  },
+  {
+    "callsign": "KQCA",
+    "community_served_city": "STOCKTON",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "58",
+    "facility_id": "10242"
+  },
+  {
+    "callsign": "KCEN-TV",
+    "community_served_city": "TEMPLE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "10245"
+  },
+  {
+    "callsign": "WIPX-TV",
+    "community_served_city": "BLOOMINGTON",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "63",
+    "facility_id": "10253"
+  },
+  {
+    "callsign": "WJAL",
+    "community_served_city": "SILVER SPRING",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "Merit Street",
+    "tv_virtual_channel": "68",
+    "facility_id": "10259"
+  },
+  {
+    "callsign": "WXYZ-TV",
+    "community_served_city": "DETROIT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC; Bounce TV; Laff; Court TV; Shop LC",
+    "tv_virtual_channel": "7",
+    "facility_id": "10267"
+  },
+  {
+    "callsign": "KPSP-CD",
+    "community_served_city": "CATHEDRAL CITY",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "38",
+    "facility_id": "10535"
+  },
+  {
+    "callsign": "KRET-CD",
+    "community_served_city": "PALM SPRINGS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "45",
+    "facility_id": "10536"
+  },
+  {
+    "callsign": "WCBD-TV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "10587"
+  },
+  {
+    "callsign": "WTVI",
+    "community_served_city": "CHARLOTTE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "42",
+    "facility_id": "10645"
+  },
+  {
+    "callsign": "WBFF",
+    "community_served_city": "BALTIMORE",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "45",
+    "facility_id": "10758"
+  },
+  {
+    "callsign": "WTTW",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "10802"
+  },
+  {
+    "callsign": "WHBR",
+    "community_served_city": "PENSACOLA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "33",
+    "facility_id": "10894"
+  },
+  {
+    "callsign": "WUPV",
+    "community_served_city": "ASHLAND",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "65",
+    "facility_id": "10897"
+  },
+  {
+    "callsign": "WVFX",
+    "community_served_city": "CLARKSBURG",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, CW, START TV",
+    "tv_virtual_channel": "46",
+    "facility_id": "10976"
+  },
+  {
+    "callsign": "WCPX-TV",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Court TV, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN",
+    "tv_virtual_channel": "38",
+    "facility_id": "10981"
+  },
+  {
+    "callsign": "WGGN-TV",
+    "community_served_city": "SANDUSKY",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "52",
+    "facility_id": "11027"
+  },
+  {
+    "callsign": "WLLA",
+    "community_served_city": "KALAMAZOO",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "64",
+    "facility_id": "11033"
+  },
+  {
+    "callsign": "K20DN-D",
+    "community_served_city": "WICHITA FALLS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NRB",
+    "tv_virtual_channel": "20",
+    "facility_id": "11034"
+  },
+  {
+    "callsign": "WGBP-TV",
+    "community_served_city": "OPELIKA",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "Merit Street",
+    "tv_virtual_channel": "66",
+    "facility_id": "11113"
+  },
+  {
+    "callsign": "WHTN",
+    "community_served_city": "MURFREESBORO",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "Christian Television Network",
+    "tv_virtual_channel": "39",
+    "facility_id": "11117"
+  },
+  {
+    "callsign": "WSFJ-TV",
+    "community_served_city": "LONDON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "SCRIPPS News, Bounce, ION",
+    "tv_virtual_channel": "51",
+    "facility_id": "11118"
+  },
+  {
+    "callsign": "WFGC",
+    "community_served_city": "PALM BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "61",
+    "facility_id": "11123"
+  },
+  {
+    "callsign": "WCLF",
+    "community_served_city": "CLEARWATER",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "22",
+    "facility_id": "11125"
+  },
+  {
+    "callsign": "WSTR-TV",
+    "community_served_city": "CINCINNATI",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "64",
+    "facility_id": "11204"
+  },
+  {
+    "callsign": "WVNY",
+    "community_served_city": "BURLINGTON",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "22",
+    "facility_id": "11259"
+  },
+  {
+    "callsign": "WIVT",
+    "community_served_city": "BINGHAMTON",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "34",
+    "facility_id": "11260"
+  },
+  {
+    "callsign": "KLKN",
+    "community_served_city": "LINCOLN",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "11264"
+  },
+  {
+    "callsign": "KCAU-TV",
+    "community_served_city": "SIOUX CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "11265"
+  },
+  {
+    "callsign": "WKRC-TV",
+    "community_served_city": "CINCINNATI",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "11289"
+  },
+  {
+    "callsign": "WTSP",
+    "community_served_city": "ST. PETERSBURG",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "11290"
+  },
+  {
+    "callsign": "WDAF-TV",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "4",
+    "facility_id": "11291"
+  },
+  {
+    "callsign": "KLVX",
+    "community_served_city": "LAS VEGAS",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "10",
+    "facility_id": "11683"
+  },
+  {
+    "callsign": "KETF-CD",
+    "community_served_city": "LAREDO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "39",
+    "facility_id": "11699"
+  },
+  {
+    "callsign": "WJXX",
+    "community_served_city": "ORANGE PARK",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "25",
+    "facility_id": "11893"
+  },
+  {
+    "callsign": "WPMI-TV",
+    "community_served_city": "MOBILE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "15",
+    "facility_id": "11906"
+  },
+  {
+    "callsign": "WATN-TV",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "24",
+    "facility_id": "11907"
+  },
+  {
+    "callsign": "KTTU-TV",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "MYNET (1/1-8/31); CW (beginning 9/1)",
+    "tv_virtual_channel": "18",
+    "facility_id": "11908"
+  },
+  {
+    "callsign": "WFOX-TV",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX/ME-TV/HEROES & ICONS/TELEMUNDO",
+    "tv_virtual_channel": "30",
+    "facility_id": "11909"
+  },
+  {
+    "callsign": "KOKI-TV",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "FOX (23.1), METV (23.2), Dabl (23.3)",
+    "tv_virtual_channel": "23",
+    "facility_id": "11910"
+  },
+  {
+    "callsign": "KSAS-TV",
+    "community_served_city": "WICHITA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "24",
+    "facility_id": "11911"
+  },
+  {
+    "callsign": "KAAS-TV",
+    "community_served_city": "SALINA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "18",
+    "facility_id": "11912"
+  },
+  {
+    "callsign": "WFTC",
+    "community_served_city": "MINNEAPOLIS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "MNT",
+    "tv_virtual_channel": "29",
+    "facility_id": "11913"
+  },
+  {
+    "callsign": "KLRT-TV",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "16",
+    "facility_id": "11951"
+  },
+  {
+    "callsign": "WXXA-TV",
+    "community_served_city": "ALBANY",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "23",
+    "facility_id": "11970"
+  },
+  {
+    "callsign": "WWAY",
+    "community_served_city": "WILMINGTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC,CBS,CW",
+    "tv_virtual_channel": "3",
+    "facility_id": "12033"
+  },
+  {
+    "callsign": "KPMR",
+    "community_served_city": "SANTA BARBARA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "38",
+    "facility_id": "12144"
+  },
+  {
+    "callsign": "WDSC-TV",
+    "community_served_city": "NEW SMYRNA BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "12171"
+  },
+  {
+    "callsign": "DDWYCC",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "12279"
+  },
+  {
+    "callsign": "KNDO",
+    "community_served_city": "YAKIMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC; SWX",
+    "tv_virtual_channel": "23",
+    "facility_id": "12395"
+  },
+  {
+    "callsign": "KNDU",
+    "community_served_city": "RICHLAND",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC; SWX",
+    "tv_virtual_channel": "25",
+    "facility_id": "12427"
+  },
+  {
+    "callsign": "WXTX",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "54",
+    "facility_id": "12472"
+  },
+  {
+    "callsign": "WCBI-TV",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, FOX, MNT",
+    "tv_virtual_channel": "4",
+    "facility_id": "12477"
+  },
+  {
+    "callsign": "WBFS-TV",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "33",
+    "facility_id": "12497"
+  },
+  {
+    "callsign": "WGBO-DT",
+    "community_served_city": "JOLIET",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "66",
+    "facility_id": "12498"
+  },
+  {
+    "callsign": "WPSG",
+    "community_served_city": "PHILADELPHIA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "57",
+    "facility_id": "12499"
+  },
+  {
+    "callsign": "KOCO-TV",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Me-TV",
+    "tv_virtual_channel": "5",
+    "facility_id": "12508"
+  },
+  {
+    "callsign": "WGMB-TV",
+    "community_served_city": "BATON ROUGE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "44",
+    "facility_id": "12520"
+  },
+  {
+    "callsign": "WHBQ-TV",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX (13.1), Heroes & Icons (13.2), and ION Mystery (13.3)",
+    "tv_virtual_channel": "13",
+    "facility_id": "12521"
+  },
+  {
+    "callsign": "KWKT-TV",
+    "community_served_city": "WACO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "44",
+    "facility_id": "12522"
+  },
+  {
+    "callsign": "KVEO-TV",
+    "community_served_city": "BROWNSVILLE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC and CBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "12523"
+  },
+  {
+    "callsign": "KPEJ-TV",
+    "community_served_city": "ODESSA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "24",
+    "facility_id": "12524"
+  },
+  {
+    "callsign": "KMSS-TV",
+    "community_served_city": "SHREVEPORT",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "33",
+    "facility_id": "12525"
+  },
+  {
+    "callsign": "KFFX-TV",
+    "community_served_city": "PENDLETON",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "FOX,  Telemundo",
+    "tv_virtual_channel": "11",
+    "facility_id": "12729"
+  },
+  {
+    "callsign": "WAXN-TV",
+    "community_served_city": "KANNAPOLIS",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "64",
+    "facility_id": "12793"
+  },
+  {
+    "callsign": "WUCF-TV",
+    "community_served_city": "ORLANDO",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "12855"
+  },
+  {
+    "callsign": "KETH-TV",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TRINITY BROADCASTING NETWORK",
+    "tv_virtual_channel": "14",
+    "facility_id": "12895"
+  },
+  {
+    "callsign": "KITU-TV",
+    "community_served_city": "BEAUMONT",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TRINITY BROADCASTING NETWORK",
+    "tv_virtual_channel": "34",
+    "facility_id": "12896"
+  },
+  {
+    "callsign": "KLUJ-TV",
+    "community_served_city": "HARLINGEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TRINITY BROADCASTING NETWORK",
+    "tv_virtual_channel": "44",
+    "facility_id": "12913"
+  },
+  {
+    "callsign": "KTAS",
+    "community_served_city": "SAN LUIS OBISPO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Telexitos",
+    "tv_virtual_channel": "33",
+    "facility_id": "12930"
+  },
+  {
+    "callsign": "KUVM-CD",
+    "community_served_city": "MISSOURI CITY",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NEW TANG DYNASTY",
+    "tv_virtual_channel": "34",
+    "facility_id": "13200"
+  },
+  {
+    "callsign": "WATC-DT",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "57",
+    "facility_id": "13206"
+  },
+  {
+    "callsign": "WPBT",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "13456"
+  },
+  {
+    "callsign": "WEDW",
+    "community_served_city": "STAMFORD",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "49",
+    "facility_id": "13594"
+  },
+  {
+    "callsign": "WEDY",
+    "community_served_city": "NEW HAVEN",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "65",
+    "facility_id": "13595"
+  },
+  {
+    "callsign": "WEDH",
+    "community_served_city": "HARTFORD",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "13602"
+  },
+  {
+    "callsign": "WEDN",
+    "community_served_city": "NORWICH",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "53",
+    "facility_id": "13607"
+  },
+  {
+    "callsign": "KJJC-TV",
+    "community_served_city": "GREAT FALLS",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "16",
+    "facility_id": "13792"
+  },
+  {
+    "callsign": "KATN",
+    "community_served_city": "FAIRBANKS",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "2",
+    "facility_id": "13813"
+  },
+  {
+    "callsign": "KJUD",
+    "community_served_city": "JUNEAU",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "13814"
+  },
+  {
+    "callsign": "KYUR",
+    "community_served_city": "ANCHORAGE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "13815"
+  },
+  {
+    "callsign": "WPCB-TV",
+    "community_served_city": "GREENSBURG",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "40",
+    "facility_id": "13924"
+  },
+  {
+    "callsign": "WKBS-TV",
+    "community_served_city": "ALTOONA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "47",
+    "facility_id": "13929"
+  },
+  {
+    "callsign": "WYPX-TV",
+    "community_served_city": "AMSTERDAM",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "55",
+    "facility_id": "13933"
+  },
+  {
+    "callsign": "WUPL",
+    "community_served_city": "SLIDELL",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "54",
+    "facility_id": "13938"
+  },
+  {
+    "callsign": "WHBF-TV",
+    "community_served_city": "ROCK ISLAND",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "13950"
+  },
+  {
+    "callsign": "WISE-TV",
+    "community_served_city": "FORT WAYNE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "33",
+    "facility_id": "13960"
+  },
+  {
+    "callsign": "KAIT",
+    "community_served_city": "JONESBORO",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, NBC, CW",
+    "tv_virtual_channel": "8",
+    "facility_id": "13988"
+  },
+  {
+    "callsign": "WAVE",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "13989"
+  },
+  {
+    "callsign": "WIS",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "13990"
+  },
+  {
+    "callsign": "WFIE",
+    "community_served_city": "EVANSVILLE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "14",
+    "facility_id": "13991"
+  },
+  {
+    "callsign": "WTOL",
+    "community_served_city": "TOLEDO",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "13992"
+  },
+  {
+    "callsign": "WSFA",
+    "community_served_city": "MONTGOMERY",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "12",
+    "facility_id": "13993"
+  },
+  {
+    "callsign": "KPLC",
+    "community_served_city": "LAKE CHARLES",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "13994"
+  },
+  {
+    "callsign": "WLOX",
+    "community_served_city": "BILOXI",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "13995"
+  },
+  {
+    "callsign": "KJLA",
+    "community_served_city": "VENTURA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Vision Latina",
+    "tv_virtual_channel": "57",
+    "facility_id": "14000"
+  },
+  {
+    "callsign": "KRMA-TV",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "14040"
+  },
+  {
+    "callsign": "KRMJ",
+    "community_served_city": "GRAND JUNCTION",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "14042"
+  },
+  {
+    "callsign": "WCCT-TV",
+    "community_served_city": "WATERBURY",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "20",
+    "facility_id": "14050"
+  },
+  {
+    "callsign": "WMJQ-CD",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "40",
+    "facility_id": "14312"
+  },
+  {
+    "callsign": "WONO-CD",
+    "community_served_city": "SYRACUSE, ETC.",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "AMG TV",
+    "tv_virtual_channel": "11",
+    "facility_id": "14315"
+  },
+  {
+    "callsign": "KWYB",
+    "community_served_city": "BUTTE",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "ABC; SWX",
+    "tv_virtual_channel": "18",
+    "facility_id": "14674"
+  },
+  {
+    "callsign": "KTMF",
+    "community_served_city": "MISSOULA",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "ABC; SWX",
+    "tv_virtual_channel": "23",
+    "facility_id": "14675"
+  },
+  {
+    "callsign": "WWJE-DT",
+    "community_served_city": "DERRY",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "True Crime",
+    "tv_virtual_channel": "50",
+    "facility_id": "14682"
+  },
+  {
+    "callsign": "KCBA",
+    "community_served_city": "SALINAS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "35",
+    "facility_id": "14867"
+  },
+  {
+    "callsign": "WRUA",
+    "community_served_city": "FAJARDO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "34",
+    "facility_id": "15320"
+  },
+  {
+    "callsign": "DDWDHS",
+    "community_served_city": "IRON MOUNTAIN",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "N/A",
+    "tv_virtual_channel": "8",
+    "facility_id": "15498"
+  },
+  {
+    "callsign": "WZBJ",
+    "community_served_city": "DANVILLE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork, DABL",
+    "tv_virtual_channel": "24",
+    "facility_id": "15507"
+  },
+  {
+    "callsign": "WBUI",
+    "community_served_city": "DECATUR",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "23",
+    "facility_id": "16363"
+  },
+  {
+    "callsign": "WMDT",
+    "community_served_city": "SALISBURY",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/CW/MeTV/ION",
+    "tv_virtual_channel": "47",
+    "facility_id": "16455"
+  },
+  {
+    "callsign": "WUVC-DT",
+    "community_served_city": "FAYETTEVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "UNIVISION",
+    "tv_virtual_channel": "40",
+    "facility_id": "16517"
+  },
+  {
+    "callsign": "WDCQ-TV",
+    "community_served_city": "BAD AXE",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "35",
+    "facility_id": "16530"
+  },
+  {
+    "callsign": "WNTZ-TV",
+    "community_served_city": "NATCHEZ",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "48",
+    "facility_id": "16539"
+  },
+  {
+    "callsign": "KVMD",
+    "community_served_city": "TWENTYNINE PALMS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "31",
+    "facility_id": "16729"
+  },
+  {
+    "callsign": "WWTI",
+    "community_served_city": "WATERTOWN",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "50",
+    "facility_id": "16747"
+  },
+  {
+    "callsign": "KMIR-TV",
+    "community_served_city": "PALM SPRINGS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "36",
+    "facility_id": "16749"
+  },
+  {
+    "callsign": "WFTT-TV",
+    "community_served_city": "VENICE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "The Church of Scientology",
+    "tv_virtual_channel": "62",
+    "facility_id": "16788"
+  },
+  {
+    "callsign": "WTVS",
+    "community_served_city": "DETROIT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "56",
+    "facility_id": "16817"
+  },
+  {
+    "callsign": "WABM",
+    "community_served_city": "BIRMINGHAM",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "My Network",
+    "tv_virtual_channel": "68",
+    "facility_id": "16820"
+  },
+  {
+    "callsign": "KLEG-CD",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "44",
+    "facility_id": "16930"
+  },
+  {
+    "callsign": "KBCA",
+    "community_served_city": "ALEXANDRIA",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "Heroes and Icons",
+    "tv_virtual_channel": "41",
+    "facility_id": "16940"
+  },
+  {
+    "callsign": "KIFR",
+    "community_served_city": "VISALIA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "49",
+    "facility_id": "16950"
+  },
+  {
+    "callsign": "WCJB-TV",
+    "community_served_city": "GAINESVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "20",
+    "facility_id": "16993"
+  },
+  {
+    "callsign": "WABI-TV",
+    "community_served_city": "BANGOR",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "CBS; CW",
+    "tv_virtual_channel": "5",
+    "facility_id": "17005"
+  },
+  {
+    "callsign": "WYOU",
+    "community_served_city": "SCRANTON",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "17010"
+  },
+  {
+    "callsign": "WPDE-TV",
+    "community_served_city": "FLORENCE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "15",
+    "facility_id": "17012"
+  },
+  {
+    "callsign": "KDFI",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "27",
+    "facility_id": "17037"
+  },
+  {
+    "callsign": "WLMB",
+    "community_served_city": "TOLEDO",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "40",
+    "facility_id": "17076"
+  },
+  {
+    "callsign": "KAZD",
+    "community_served_city": "LAKE DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Spectrum News 1",
+    "tv_virtual_channel": "55",
+    "facility_id": "17433"
+  },
+  {
+    "callsign": "WSRE",
+    "community_served_city": "PENSACOLA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "17611"
+  },
+  {
+    "callsign": "KFXB-TV",
+    "community_served_city": "DUBUQUE",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "40",
+    "facility_id": "17625"
+  },
+  {
+    "callsign": "KSGW-TV",
+    "community_served_city": "SHERIDAN",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/FOX",
+    "tv_virtual_channel": "12",
+    "facility_id": "17680"
+  },
+  {
+    "callsign": "KNEP",
+    "community_served_city": "SIDNEY",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "17683"
+  },
+  {
+    "callsign": "KQME",
+    "community_served_city": "LEAD",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV/Heroes and Icons/StartTV/Catchy Comedy/Oxygen",
+    "tv_virtual_channel": "11",
+    "facility_id": "17686"
+  },
+  {
+    "callsign": "KHME",
+    "community_served_city": "RAPID CITY",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV/Heroes and Icons/StartTV/Catchy Comedy/Oxygen",
+    "tv_virtual_channel": "23",
+    "facility_id": "17688"
+  },
+  {
+    "callsign": "WDSE",
+    "community_served_city": "DULUTH",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "17726"
+  },
+  {
+    "callsign": "KGMM-CD",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Merit Street",
+    "tv_virtual_channel": "24",
+    "facility_id": "17830"
+  },
+  {
+    "callsign": "KTVM-TV",
+    "community_served_city": "BUTTE",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "18066"
+  },
+  {
+    "callsign": "KCFW-TV",
+    "community_served_city": "KALISPELL",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "9",
+    "facility_id": "18079"
+  },
+  {
+    "callsign": "KECI-TV",
+    "community_served_city": "MISSOULA",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "13",
+    "facility_id": "18084"
+  },
+  {
+    "callsign": "KDTV-CD",
+    "community_served_city": "SANTA ROSA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "28",
+    "facility_id": "18148"
+  },
+  {
+    "callsign": "WETP-TV",
+    "community_served_city": "SNEEDVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "18252"
+  },
+  {
+    "callsign": "WKOP-TV",
+    "community_served_city": "KNOXVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "18267"
+  },
+  {
+    "callsign": "KODE-TV",
+    "community_served_city": "JOPLIN",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "18283"
+  },
+  {
+    "callsign": "KAAL",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "18285"
+  },
+  {
+    "callsign": "KTWO-TV",
+    "community_served_city": "CASPER",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "2",
+    "facility_id": "18286"
+  },
+  {
+    "callsign": "KQCK",
+    "community_served_city": "CHEYENNE",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "33",
+    "facility_id": "18287"
+  },
+  {
+    "callsign": "WEIU-TV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "51",
+    "facility_id": "18301"
+  },
+  {
+    "callsign": "WCTI-TV",
+    "community_served_city": "NEW BERN",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "18334"
+  },
+  {
+    "callsign": "KENW",
+    "community_served_city": "PORTALES",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "18338"
+  },
+  {
+    "callsign": "WIDP",
+    "community_served_city": "GUAYAMA",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "46",
+    "facility_id": "18410"
+  },
+  {
+    "callsign": "KMUM-CD",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TELEMUNDO",
+    "tv_virtual_channel": "33",
+    "facility_id": "18736"
+  },
+  {
+    "callsign": "KZMM-CD",
+    "community_served_city": "FRESNO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CRTV NETWORK",
+    "tv_virtual_channel": "22",
+    "facility_id": "18740"
+  },
+  {
+    "callsign": "KVMM-CD",
+    "community_served_city": "SANTA BARBARA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "COZI TV",
+    "tv_virtual_channel": "41",
+    "facility_id": "18741"
+  },
+  {
+    "callsign": "KABE-CD",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "39",
+    "facility_id": "18747"
+  },
+  {
+    "callsign": "WVIZ",
+    "community_served_city": "CLEVELAND",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "18753"
+  },
+  {
+    "callsign": "WHLA-TV",
+    "community_served_city": "LA CROSSE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "31",
+    "facility_id": "18780"
+  },
+  {
+    "callsign": "WYDN",
+    "community_served_city": "LOWELL",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "48",
+    "facility_id": "18783"
+  },
+  {
+    "callsign": "WHWC-TV",
+    "community_served_city": "MENOMONIE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "28",
+    "facility_id": "18793"
+  },
+  {
+    "callsign": "WNET",
+    "community_served_city": "NEWARK",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "18795"
+  },
+  {
+    "callsign": "WPNE-TV",
+    "community_served_city": "GREEN BAY",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "38",
+    "facility_id": "18798"
+  },
+  {
+    "callsign": "WLAE-TV",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "32",
+    "facility_id": "18819"
+  },
+  {
+    "callsign": "KCOS",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "19117"
+  },
+  {
+    "callsign": "WZVN-TV",
+    "community_served_city": "NAPLES",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "26",
+    "facility_id": "19183"
+  },
+  {
+    "callsign": "WMC-TV",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "19184"
+  },
+  {
+    "callsign": "WUPW",
+    "community_served_city": "TOLEDO",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "36",
+    "facility_id": "19190"
+  },
+  {
+    "callsign": "KNSN-TV",
+    "community_served_city": "RENO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "21",
+    "facility_id": "19191"
+  },
+  {
+    "callsign": "WACH",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "57",
+    "facility_id": "19199"
+  },
+  {
+    "callsign": "WTNZ",
+    "community_served_city": "KNOXVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "43",
+    "facility_id": "19200"
+  },
+  {
+    "callsign": "WECN",
+    "community_served_city": "NARANJITO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "64",
+    "facility_id": "19561"
+  },
+  {
+    "callsign": "KBSI",
+    "community_served_city": "CAPE GIRARDEAU",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "23",
+    "facility_id": "19593"
+  },
+  {
+    "callsign": "KSBW",
+    "community_served_city": "SALINAS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, ABC, ESTV, Story TV",
+    "tv_virtual_channel": "8",
+    "facility_id": "19653"
+  },
+  {
+    "callsign": "KSBY",
+    "community_served_city": "SAN LUIS OBISPO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC; LAFF; GRIT; Court TV; Scripps News; ION",
+    "tv_virtual_channel": "6",
+    "facility_id": "19654"
+  },
+  {
+    "callsign": "WFXP",
+    "community_served_city": "ERIE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "66",
+    "facility_id": "19707"
+  },
+  {
+    "callsign": "WSUR-DT",
+    "community_served_city": "PONCE",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "9",
+    "facility_id": "19776"
+  },
+  {
+    "callsign": "WLII-DT",
+    "community_served_city": "CAGUAS",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "11",
+    "facility_id": "19777"
+  },
+  {
+    "callsign": "KVEA",
+    "community_served_city": "CORONA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "52",
+    "facility_id": "19783"
+  },
+  {
+    "callsign": "KJNP-TV",
+    "community_served_city": "NORTH POLE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "20015"
+  },
+  {
+    "callsign": "WATM-TV",
+    "community_served_city": "ALTOONA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "23",
+    "facility_id": "20287"
+  },
+  {
+    "callsign": "WWCP-TV",
+    "community_served_city": "JOHNSTOWN",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "8",
+    "facility_id": "20295"
+  },
+  {
+    "callsign": "KRMZ",
+    "community_served_city": "STEAMBOAT SPRINGS",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "20373"
+  },
+  {
+    "callsign": "WTWO",
+    "community_served_city": "TERRE HAUTE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "20426"
+  },
+  {
+    "callsign": "KQTV",
+    "community_served_city": "ST. JOSEPH",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ION TV",
+    "tv_virtual_channel": "2",
+    "facility_id": "20427"
+  },
+  {
+    "callsign": "KRMT",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "41",
+    "facility_id": "20476"
+  },
+  {
+    "callsign": "WRPX-TV",
+    "community_served_city": "ROCKY MOUNT",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, IONPlus, Bounce, CRIME, Jewelry TV, QVC",
+    "tv_virtual_channel": "47",
+    "facility_id": "20590"
+  },
+  {
+    "callsign": "WMYT-TV",
+    "community_served_city": "ROCK HILL",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "55",
+    "facility_id": "20624"
+  },
+  {
+    "callsign": "DWNYJ-TV",
+    "community_served_city": "WEST MILFORD",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "66",
+    "facility_id": "20818"
+  },
+  {
+    "callsign": "KTFK-DT",
+    "community_served_city": "STOCKTON",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "64",
+    "facility_id": "20871"
+  },
+  {
+    "callsign": "KPXR-TV",
+    "community_served_city": "CEDAR RAPIDS",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Grit, Bounce, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "48",
+    "facility_id": "21156"
+  },
+  {
+    "callsign": "WWHO",
+    "community_served_city": "CHILLICOTHE",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "53",
+    "facility_id": "21158"
+  },
+  {
+    "callsign": "KHGI-TV",
+    "community_served_city": "KEARNEY",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "21160"
+  },
+  {
+    "callsign": "KSNB-TV",
+    "community_served_city": "YORK",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/MeMY/ION/Oxygen/Outlaw",
+    "tv_virtual_channel": "4",
+    "facility_id": "21161"
+  },
+  {
+    "callsign": "KWNB-TV",
+    "community_served_city": "HAYES CENTER",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "21162"
+  },
+  {
+    "callsign": "WFPX-TV",
+    "community_served_city": "ARCHER LODGE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "SCRIPPS News, Bounce, LAFF",
+    "tv_virtual_channel": "62",
+    "facility_id": "21245"
+  },
+  {
+    "callsign": "WDAM-TV",
+    "community_served_city": "LAUREL",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, ABC,  Bounce, True Crime, Grit",
+    "tv_virtual_channel": "7",
+    "facility_id": "21250"
+  },
+  {
+    "callsign": "KTVO",
+    "community_served_city": "KIRKSVILLE",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "KTVO D1 - ABC; KTVO D2 - CBS; KTVO D3 - Comet",
+    "tv_virtual_channel": "3",
+    "facility_id": "21251"
+  },
+  {
+    "callsign": "WSTM-TV",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "21252"
+  },
+  {
+    "callsign": "WPBN-TV",
+    "community_served_city": "TRAVERSE CITY",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "21253"
+  },
+  {
+    "callsign": "WTOM-TV",
+    "community_served_city": "CHEBOYGAN",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "21254"
+  },
+  {
+    "callsign": "WSES",
+    "community_served_city": "TUSCALOOSA",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "Heroes and Icons, Catchy Comedy, Start TV",
+    "tv_virtual_channel": "33",
+    "facility_id": "21258"
+  },
+  {
+    "callsign": "WLUC-TV",
+    "community_served_city": "MARQUETTE",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, FOX",
+    "tv_virtual_channel": "6",
+    "facility_id": "21259"
+  },
+  {
+    "callsign": "KCAL-TV",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "9",
+    "facility_id": "21422"
+  },
+  {
+    "callsign": "WKPC-TV",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "21432"
+  },
+  {
+    "callsign": "KAUU",
+    "community_served_city": "ANCHORAGE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "My Network, CBS and Antenna",
+    "tv_virtual_channel": "5",
+    "facility_id": "21488"
+  },
+  {
+    "callsign": "KTNC-TV",
+    "community_served_city": "CONCORD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "42",
+    "facility_id": "21533"
+  },
+  {
+    "callsign": "WGWG",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "Heroes and Icons, Decades, Antenna TV, Start TV",
+    "tv_virtual_channel": "4",
+    "facility_id": "21536"
+  },
+  {
+    "callsign": "KFNR",
+    "community_served_city": "RAWLINS",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "11",
+    "facility_id": "21612"
+  },
+  {
+    "callsign": "KFNE",
+    "community_served_city": "RIVERTON",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "10",
+    "facility_id": "21613"
+  },
+  {
+    "callsign": "KATU",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "2",
+    "facility_id": "21649"
+  },
+  {
+    "callsign": "KOMO-TV",
+    "community_served_city": "SEATTLE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "4",
+    "facility_id": "21656"
+  },
+  {
+    "callsign": "WPXX-TV",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "50",
+    "facility_id": "21726"
+  },
+  {
+    "callsign": "WPXL-TV",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Grit, Court TV, SCRIPPS News, Jewelry TV, HSN, QVC, HSN2",
+    "tv_virtual_channel": "49",
+    "facility_id": "21729"
+  },
+  {
+    "callsign": "WJRT-TV",
+    "community_served_city": "FLINT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC(D1), MeTV(D2), theGRIO (D3), Start TV (D4), Heroes & Icons (D5), Bounce (D6), This TV/MeTV Toons (D7)",
+    "tv_virtual_channel": "12",
+    "facility_id": "21735"
+  },
+  {
+    "callsign": "WSMH",
+    "community_served_city": "FLINT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "66",
+    "facility_id": "21737"
+  },
+  {
+    "callsign": "WFSU-TV",
+    "community_served_city": "TALLAHASSEE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "11",
+    "facility_id": "21801"
+  },
+  {
+    "callsign": "WEDU",
+    "community_served_city": "TAMPA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "21808"
+  },
+  {
+    "callsign": "WINK-TV",
+    "community_served_city": "FORT MYERS",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "22093"
+  },
+  {
+    "callsign": "WFWA",
+    "community_served_city": "FORT WAYNE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "39",
+    "facility_id": "22108"
+  },
+  {
+    "callsign": "KBMY",
+    "community_served_city": "BISMARCK",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "17",
+    "facility_id": "22121"
+  },
+  {
+    "callsign": "WDAZ-TV",
+    "community_served_city": "DEVIL'S LAKE",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "22124"
+  },
+  {
+    "callsign": "KMCY",
+    "community_served_city": "MINOT",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "14",
+    "facility_id": "22127"
+  },
+  {
+    "callsign": "WDAY-TV",
+    "community_served_city": "FARGO",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "22129"
+  },
+  {
+    "callsign": "KRCA",
+    "community_served_city": "RIVERSIDE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "EstrellaTV",
+    "tv_virtual_channel": "62",
+    "facility_id": "22161"
+  },
+  {
+    "callsign": "KDAF",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "33",
+    "facility_id": "22201"
+  },
+  {
+    "callsign": "KRIV",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "26",
+    "facility_id": "22204"
+  },
+  {
+    "callsign": "WNYW",
+    "community_served_city": "NEW YORK",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "5",
+    "facility_id": "22206"
+  },
+  {
+    "callsign": "WTTG",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "5",
+    "facility_id": "22207"
+  },
+  {
+    "callsign": "KTTV",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "11",
+    "facility_id": "22208"
+  },
+  {
+    "callsign": "WFLD",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "32",
+    "facility_id": "22211"
+  },
+  {
+    "callsign": "KSTU",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, Antenna TV",
+    "tv_virtual_channel": "13",
+    "facility_id": "22215"
+  },
+  {
+    "callsign": "WFXU",
+    "community_served_city": "LIVE OAK",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "My Net",
+    "tv_virtual_channel": "57",
+    "facility_id": "22245"
+  },
+  {
+    "callsign": "KTVL",
+    "community_served_city": "MEDFORD",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "22570"
+  },
+  {
+    "callsign": "KFDM",
+    "community_served_city": "BEAUMONT",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "22589"
+  },
+  {
+    "callsign": "WTVC",
+    "community_served_city": "CHATTANOOGA",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "22590"
+  },
+  {
+    "callsign": "WLNE-TV",
+    "community_served_city": "NEW BEDFORD",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "22591"
+  },
+  {
+    "callsign": "KKPX-TV",
+    "community_served_city": "SAN JOSE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Court TV, IONPlus, Laff, SCRIPPS News, Jewelry TV, QVC",
+    "tv_virtual_channel": "65",
+    "facility_id": "22644"
+  },
+  {
+    "callsign": "KBDI-TV",
+    "community_served_city": "BROOMFIELD",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "22685"
+  },
+  {
+    "callsign": "WATL",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "MYNET",
+    "tv_virtual_channel": "36",
+    "facility_id": "22819"
+  },
+  {
+    "callsign": "KUSA",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "9",
+    "facility_id": "23074"
+  },
+  {
+    "callsign": "KARE",
+    "community_served_city": "MINNEAPOLIS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "23079"
+  },
+  {
+    "callsign": "WUPX-TV",
+    "community_served_city": "RICHMOND",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "67",
+    "facility_id": "23128"
+  },
+  {
+    "callsign": "WWSI",
+    "community_served_city": "MOUNT LAUREL",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "TELEMUNDO",
+    "tv_virtual_channel": "62",
+    "facility_id": "23142"
+  },
+  {
+    "callsign": "WWPX-TV",
+    "community_served_city": "MARTINSBURG",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Court TV, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN",
+    "tv_virtual_channel": "60",
+    "facility_id": "23264"
+  },
+  {
+    "callsign": "KXVO",
+    "community_served_city": "OMAHA",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "TBD",
+    "tv_virtual_channel": "15",
+    "facility_id": "23277"
+  },
+  {
+    "callsign": "KNSO",
+    "community_served_city": "CLOVIS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TELEMUNDO",
+    "tv_virtual_channel": "51",
+    "facility_id": "23302"
+  },
+  {
+    "callsign": "WBNG-TV",
+    "community_served_city": "BINGHAMTON",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS (12.1), CW (12.2), MeTV (12.3)",
+    "tv_virtual_channel": "12",
+    "facility_id": "23337"
+  },
+  {
+    "callsign": "WXBU",
+    "community_served_city": "LANCASTER",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "TelevisaUnivision, Inc",
+    "tv_virtual_channel": "15",
+    "facility_id": "23338"
+  },
+  {
+    "callsign": "WTAJ-TV",
+    "community_served_city": "ALTOONA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "23341"
+  },
+  {
+    "callsign": "WOWK-TV",
+    "community_served_city": "HUNTINGTON",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "23342"
+  },
+  {
+    "callsign": "KIAH",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "39",
+    "facility_id": "23394"
+  },
+  {
+    "callsign": "KTVT",
+    "community_served_city": "FORT WORTH",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "23422"
+  },
+  {
+    "callsign": "KSTW",
+    "community_served_city": "TACOMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "11",
+    "facility_id": "23428"
+  },
+  {
+    "callsign": "WTLH",
+    "community_served_city": "BAINBRIDGE",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Heroes & Icons",
+    "tv_virtual_channel": "49",
+    "facility_id": "23486"
+  },
+  {
+    "callsign": "WWDP",
+    "community_served_city": "NORWELL",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC",
+    "tv_virtual_channel": "46",
+    "facility_id": "23671"
+  },
+  {
+    "callsign": "WABW-TV",
+    "community_served_city": "PELHAM",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "14",
+    "facility_id": "23917"
+  },
+  {
+    "callsign": "WJSP-TV",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "28",
+    "facility_id": "23918"
+  },
+  {
+    "callsign": "WXGA-TV",
+    "community_served_city": "WAYCROSS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "23929"
+  },
+  {
+    "callsign": "WACS-TV",
+    "community_served_city": "DAWSON",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "23930"
+  },
+  {
+    "callsign": "WMUM-TV",
+    "community_served_city": "COCHRAN",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "23935"
+  },
+  {
+    "callsign": "WCES-TV",
+    "community_served_city": "WRENS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "23937"
+  },
+  {
+    "callsign": "WNGH-TV",
+    "community_served_city": "CHATSWORTH",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "23942"
+  },
+  {
+    "callsign": "WVAN-TV",
+    "community_served_city": "SAVANNAH",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "23947"
+  },
+  {
+    "callsign": "WGTV",
+    "community_served_city": "ATHENS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "23948"
+  },
+  {
+    "callsign": "WSB-TV",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Bounce, DABL, Comet, Scripps News (Ended 11/19/24), ION (Started 11/19/24)",
+    "tv_virtual_channel": "2",
+    "facility_id": "23960"
+  },
+  {
+    "callsign": "WEHT",
+    "community_served_city": "EVANSVILLE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "25",
+    "facility_id": "24215"
+  },
+  {
+    "callsign": "KXGN-TV",
+    "community_served_city": "GLENDIVE",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS/NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "24287"
+  },
+  {
+    "callsign": "WGBC",
+    "community_served_city": "MERIDIAN",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, NBC",
+    "tv_virtual_channel": "30",
+    "facility_id": "24314"
+  },
+  {
+    "callsign": "KCWX",
+    "community_served_city": "FREDERICKSBURG",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "2",
+    "facility_id": "24316"
+  },
+  {
+    "callsign": "KLTJ",
+    "community_served_city": "GALVESTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "22",
+    "facility_id": "24436"
+  },
+  {
+    "callsign": "KGEB",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "53",
+    "facility_id": "24485"
+  },
+  {
+    "callsign": "KHSL-TV",
+    "community_served_city": "CHICO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "24508"
+  },
+  {
+    "callsign": "KTFD-TV",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "50",
+    "facility_id": "24514"
+  },
+  {
+    "callsign": "KDOC-TV",
+    "community_served_city": "ANAHEIM",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "56",
+    "facility_id": "24518"
+  },
+  {
+    "callsign": "K25OB-D",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NEW TANG DYNASTY",
+    "tv_virtual_channel": "14",
+    "facility_id": "24570"
+  },
+  {
+    "callsign": "WHLV-TV",
+    "community_served_city": "COCOA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "52",
+    "facility_id": "24582"
+  },
+  {
+    "callsign": "WGNM",
+    "community_served_city": "MACON",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "64",
+    "facility_id": "24618"
+  },
+  {
+    "callsign": "KNAZ-TV",
+    "community_served_city": "FLAGSTAFF",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "24749"
+  },
+  {
+    "callsign": "KMEE-TV",
+    "community_served_city": "KINGMAN",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "6",
+    "facility_id": "24753"
+  },
+  {
+    "callsign": "KKCO",
+    "community_served_city": "GRAND JUNCTION",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "KKCO",
+    "tv_virtual_channel": "11",
+    "facility_id": "24766"
+  },
+  {
+    "callsign": "WGVK",
+    "community_served_city": "KALAMAZOO",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "52",
+    "facility_id": "24783"
+  },
+  {
+    "callsign": "WGVU-TV",
+    "community_served_city": "GRAND RAPIDS",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "35",
+    "facility_id": "24784"
+  },
+  {
+    "callsign": "WEEK-TV",
+    "community_served_city": "PEORIA",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, ABC, CW, ION",
+    "tv_virtual_channel": "25",
+    "facility_id": "24801"
+  },
+  {
+    "callsign": "WWCW",
+    "community_served_city": "LYNCHBURG",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "21",
+    "facility_id": "24812"
+  },
+  {
+    "callsign": "WFXR",
+    "community_served_city": "ROANOKE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "27",
+    "facility_id": "24813"
+  },
+  {
+    "callsign": "WKYT-TV",
+    "community_served_city": "LEXINGTON",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "24914"
+  },
+  {
+    "callsign": "WYMT-TV",
+    "community_served_city": "HAZARD",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "57",
+    "facility_id": "24915"
+  },
+  {
+    "callsign": "WICU-TV",
+    "community_served_city": "ERIE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC (Main), MeTV (Multicast)",
+    "tv_virtual_channel": "12",
+    "facility_id": "24970"
+  },
+  {
+    "callsign": "WFFT-TV",
+    "community_served_city": "FORT WAYNE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "55",
+    "facility_id": "25040"
+  },
+  {
+    "callsign": "WDVM-TV",
+    "community_served_city": "HAGERSTOWN",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "25",
+    "facility_id": "25045"
+  },
+  {
+    "callsign": "KXTV",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "10",
+    "facility_id": "25048"
+  },
+  {
+    "callsign": "WPTO",
+    "community_served_city": "OXFORD",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "14",
+    "facility_id": "25065"
+  },
+  {
+    "callsign": "WPTD",
+    "community_served_city": "DAYTON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "16",
+    "facility_id": "25067"
+  },
+  {
+    "callsign": "WYES-TV",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "25090"
+  },
+  {
+    "callsign": "DWBKI-TV",
+    "community_served_city": "CAMPBELLSVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "34",
+    "facility_id": "25173"
+  },
+  {
+    "callsign": "KDMD",
+    "community_served_city": "ANCHORAGE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "33",
+    "facility_id": "25221"
+  },
+  {
+    "callsign": "WFXW",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "15",
+    "facility_id": "25236"
+  },
+  {
+    "callsign": "KWTV-DT",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "25382"
+  },
+  {
+    "callsign": "WFUP",
+    "community_served_city": "VANDERBILT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX Broadcasting Network",
+    "tv_virtual_channel": "45",
+    "facility_id": "25395"
+  },
+  {
+    "callsign": "WFQX-TV",
+    "community_served_city": "CADILLAC",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX Broadcasting Network",
+    "tv_virtual_channel": "33",
+    "facility_id": "25396"
+  },
+  {
+    "callsign": "KPIX-TV",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "25452"
+  },
+  {
+    "callsign": "KYW-TV",
+    "community_served_city": "PHILADELPHIA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "25453"
+  },
+  {
+    "callsign": "KDKA-TV",
+    "community_served_city": "PITTSBURGH",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "25454"
+  },
+  {
+    "callsign": "WJZ-TV",
+    "community_served_city": "BALTIMORE",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "25455"
+  },
+  {
+    "callsign": "WBZ-TV",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "25456"
+  },
+  {
+    "callsign": "KGTF",
+    "community_served_city": "HAGATNA",
+    "community_served_state": "GU",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "25511"
+  },
+  {
+    "callsign": "WMYV",
+    "community_served_city": "GREENSBORO",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "My Network",
+    "tv_virtual_channel": "48",
+    "facility_id": "25544"
+  },
+  {
+    "callsign": "KRIS-TV",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CW/LAFF, Grit TV, Court TV, ION, Newsy",
+    "tv_virtual_channel": "6",
+    "facility_id": "25559"
+  },
+  {
+    "callsign": "KESQ-TV",
+    "community_served_city": "PALM SPRINGS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, CBS, FOX, CW, Telemundo",
+    "tv_virtual_channel": "42",
+    "facility_id": "25577"
+  },
+  {
+    "callsign": "WGGB-TV",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "(40.1) ABC, (40.2) FOX",
+    "tv_virtual_channel": "40",
+    "facility_id": "25682"
+  },
+  {
+    "callsign": "WGME-TV",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "25683"
+  },
+  {
+    "callsign": "WICD",
+    "community_served_city": "CHAMPAIGN",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "15",
+    "facility_id": "25684"
+  },
+  {
+    "callsign": "KGAN",
+    "community_served_city": "CEDAR RAPIDS",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS & FOX",
+    "tv_virtual_channel": "2",
+    "facility_id": "25685"
+  },
+  {
+    "callsign": "WICS",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "20",
+    "facility_id": "25686"
+  },
+  {
+    "callsign": "KVOA",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, COZI",
+    "tv_virtual_channel": "4",
+    "facility_id": "25735"
+  },
+  {
+    "callsign": "WESH",
+    "community_served_city": "DAYTONA BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, MeTV",
+    "tv_virtual_channel": "2",
+    "facility_id": "25738"
+  },
+  {
+    "callsign": "WHRO-TV",
+    "community_served_city": "HAMPTON-NORFOLK",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "25932"
+  },
+  {
+    "callsign": "WIFS",
+    "community_served_city": "JANESVILLE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "Ion Network",
+    "tv_virtual_channel": "57",
+    "facility_id": "26025"
+  },
+  {
+    "callsign": "KSCN-TV",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "22",
+    "facility_id": "26231"
+  },
+  {
+    "callsign": "KION-TV",
+    "community_served_city": "MONTEREY",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "46",
+    "facility_id": "26249"
+  },
+  {
+    "callsign": "KENS",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "26304"
+  },
+  {
+    "callsign": "KMEB",
+    "community_served_city": "WAILUKU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "26428"
+  },
+  {
+    "callsign": "KHET",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "26431"
+  },
+  {
+    "callsign": "WELU",
+    "community_served_city": "TOA BAJA",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "CTNI",
+    "tv_virtual_channel": "32",
+    "facility_id": "26602"
+  },
+  {
+    "callsign": "KPPX-TV",
+    "community_served_city": "TOLLESON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "51",
+    "facility_id": "26655"
+  },
+  {
+    "callsign": "DWMEI",
+    "community_served_city": "ARECIBO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "14",
+    "facility_id": "26676"
+  },
+  {
+    "callsign": "WTIN-TV",
+    "community_served_city": "PONCE",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "26681"
+  },
+  {
+    "callsign": "WWUP-TV",
+    "community_served_city": "SAULT STE. MARIE",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS Network",
+    "tv_virtual_channel": "10",
+    "facility_id": "26993"
+  },
+  {
+    "callsign": "WWTV",
+    "community_served_city": "CADILLAC",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS Network",
+    "tv_virtual_channel": "9",
+    "facility_id": "26994"
+  },
+  {
+    "callsign": "WJBF",
+    "community_served_city": "AUGUSTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "27140"
+  },
+  {
+    "callsign": "DKTVG-TV",
+    "community_served_city": "GRAND ISLAND",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "17",
+    "facility_id": "27220"
+  },
+  {
+    "callsign": "WTGS",
+    "community_served_city": "HARDEEVILLE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "28",
+    "facility_id": "27245"
+  },
+  {
+    "callsign": "WPXP-TV",
+    "community_served_city": "LAKE WORTH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "67",
+    "facility_id": "27290"
+  },
+  {
+    "callsign": "KHCE-TV",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TRINITY BROADCASTING NETWORK",
+    "tv_virtual_channel": "23",
+    "facility_id": "27300"
+  },
+  {
+    "callsign": "WGEN-TV",
+    "community_served_city": "KEY WEST",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "EstrellaTV",
+    "tv_virtual_channel": "8",
+    "facility_id": "27387"
+  },
+  {
+    "callsign": "KWBN",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "44",
+    "facility_id": "27425"
+  },
+  {
+    "callsign": "KUPT",
+    "community_served_city": "HOBBS",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "COZI",
+    "tv_virtual_channel": "29",
+    "facility_id": "27431"
+  },
+  {
+    "callsign": "WKPT-TV",
+    "community_served_city": "KINGSPORT",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "COZI TV",
+    "tv_virtual_channel": "19",
+    "facility_id": "27504"
+  },
+  {
+    "callsign": "KCBD",
+    "community_served_city": "LUBBOCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC and DABL",
+    "tv_virtual_channel": "11",
+    "facility_id": "27507"
+  },
+  {
+    "callsign": "WLJC-TV",
+    "community_served_city": "BEATTYVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "65",
+    "facility_id": "27696"
+  },
+  {
+    "callsign": "WHUT-TV",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "32",
+    "facility_id": "27772"
+  },
+  {
+    "callsign": "KSTP-TV",
+    "community_served_city": "ST. PAUL",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "5",
+    "facility_id": "28010"
+  },
+  {
+    "callsign": "WZDX",
+    "community_served_city": "HUNTSVILLE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "54",
+    "facility_id": "28119"
+  },
+  {
+    "callsign": "WSWG",
+    "community_served_city": "VALDOSTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "44",
+    "facility_id": "28155"
+  },
+  {
+    "callsign": "KTRV-TV",
+    "community_served_city": "NAMPA",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "12",
+    "facility_id": "28230"
+  },
+  {
+    "callsign": "KTFV-CD",
+    "community_served_city": "MCALLEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "32",
+    "facility_id": "28280"
+  },
+  {
+    "callsign": "WTVP",
+    "community_served_city": "PEORIA",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "47",
+    "facility_id": "28311"
+  },
+  {
+    "callsign": "KTBU",
+    "community_served_city": "CONROE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "QUEST",
+    "tv_virtual_channel": "55",
+    "facility_id": "28324"
+  },
+  {
+    "callsign": "WNDY-TV",
+    "community_served_city": "MARION",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "23",
+    "facility_id": "28462"
+  },
+  {
+    "callsign": "WNPX-TV",
+    "community_served_city": "FRANKLIN",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Grit, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "28",
+    "facility_id": "28468"
+  },
+  {
+    "callsign": "WDRB",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, Antenna TV, ION, Scripps News",
+    "tv_virtual_channel": "41",
+    "facility_id": "28476"
+  },
+  {
+    "callsign": "WPPT",
+    "community_served_city": "PHILADELPHIA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "35",
+    "facility_id": "28480"
+  },
+  {
+    "callsign": "KOLR",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "28496"
+  },
+  {
+    "callsign": "KTTM",
+    "community_served_city": "HURON",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "12",
+    "facility_id": "28501"
+  },
+  {
+    "callsign": "KSMQ-TV",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "28510"
+  },
+  {
+    "callsign": "KTTW",
+    "community_served_city": "SIOUX FALLS",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "17",
+    "facility_id": "28521"
+  },
+  {
+    "callsign": "WTCV",
+    "community_served_city": "SAN JUAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "MegaTV",
+    "tv_virtual_channel": "18",
+    "facility_id": "28954"
+  },
+  {
+    "callsign": "WVOZ-TV",
+    "community_served_city": "PONCE",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "MegaTV",
+    "tv_virtual_channel": "18",
+    "facility_id": "29000"
+  },
+  {
+    "callsign": "KFWD",
+    "community_served_city": "FORT WORTH",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC",
+    "tv_virtual_channel": "52",
+    "facility_id": "29015"
+  },
+  {
+    "callsign": "KHIN",
+    "community_served_city": "RED OAK",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "29085"
+  },
+  {
+    "callsign": "KYIN",
+    "community_served_city": "MASON CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "29086"
+  },
+  {
+    "callsign": "KIIN",
+    "community_served_city": "IOWA CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "29095"
+  },
+  {
+    "callsign": "KSIN-TV",
+    "community_served_city": "SIOUX CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "29096"
+  },
+  {
+    "callsign": "KTIN",
+    "community_served_city": "FORT DODGE",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "29100"
+  },
+  {
+    "callsign": "KDIN-TV",
+    "community_served_city": "DES MOINES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "29102"
+  },
+  {
+    "callsign": "KBIN-TV",
+    "community_served_city": "COUNCIL BLUFFS",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "32",
+    "facility_id": "29108"
+  },
+  {
+    "callsign": "KRIN",
+    "community_served_city": "WATERLOO",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "32",
+    "facility_id": "29114"
+  },
+  {
+    "callsign": "KSFL-TV",
+    "community_served_city": "SIOUX FALLS",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "36",
+    "facility_id": "29121"
+  },
+  {
+    "callsign": "KTGM",
+    "community_served_city": "TAMUNING",
+    "community_served_state": "GU",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "14",
+    "facility_id": "29232"
+  },
+  {
+    "callsign": "KAZA-TV",
+    "community_served_city": "AVALON",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "54",
+    "facility_id": "29234"
+  },
+  {
+    "callsign": "KTVW-CD",
+    "community_served_city": "FLAGSTAFF/DONEY PARK",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "6",
+    "facility_id": "29464"
+  },
+  {
+    "callsign": "KNWA-TV",
+    "community_served_city": "ROGERS",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "51",
+    "facility_id": "29557"
+  },
+  {
+    "callsign": "KFTA-TV",
+    "community_served_city": "FORT SMITH",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "24",
+    "facility_id": "29560"
+  },
+  {
+    "callsign": "DWHTV",
+    "community_served_city": "JACKSON",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "MY NETWORK TV",
+    "tv_virtual_channel": "18",
+    "facility_id": "29706"
+  },
+  {
+    "callsign": "WCWJ",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "The CW",
+    "tv_virtual_channel": "17",
+    "facility_id": "29712"
+  },
+  {
+    "callsign": "WTCE-TV",
+    "community_served_city": "FORT PIERCE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "TRINITY BROADCASTING NETWORK",
+    "tv_virtual_channel": "21",
+    "facility_id": "29715"
+  },
+  {
+    "callsign": "WJEB-TV",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "TRINITY BROADCASTING NETWORK",
+    "tv_virtual_channel": "59",
+    "facility_id": "29719"
+  },
+  {
+    "callsign": "K32LT-D",
+    "community_served_city": "SAN LUIS OBISPO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "28",
+    "facility_id": "29885"
+  },
+  {
+    "callsign": "WNYB",
+    "community_served_city": "JAMESTOWN",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "26",
+    "facility_id": "30303"
+  },
+  {
+    "callsign": "WEPT-CD",
+    "community_served_city": "PEEKSKILL",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "15",
+    "facility_id": "30429"
+  },
+  {
+    "callsign": "WDCW",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "50",
+    "facility_id": "30576"
+  },
+  {
+    "callsign": "WUTF-TV",
+    "community_served_city": "WORCESTER",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "27",
+    "facility_id": "30577"
+  },
+  {
+    "callsign": "KHRR",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo Network",
+    "tv_virtual_channel": "40",
+    "facility_id": "30601"
+  },
+  {
+    "callsign": "WBTV",
+    "community_served_city": "CHARLOTTE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "30826"
+  },
+  {
+    "callsign": "WWBT",
+    "community_served_city": "RICHMOND",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "12",
+    "facility_id": "30833"
+  },
+  {
+    "callsign": "KLST",
+    "community_served_city": "SAN ANGELO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "31114"
+  },
+  {
+    "callsign": "KTSB-CD",
+    "community_served_city": "SANTA MARIA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "UNIMAS",
+    "tv_virtual_channel": "35",
+    "facility_id": "31352"
+  },
+  {
+    "callsign": "KSBO-CD",
+    "community_served_city": "SAN LUIS OBISPO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "42",
+    "facility_id": "31354"
+  },
+  {
+    "callsign": "KTVC",
+    "community_served_city": "ROSEBURG",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "3ABN",
+    "tv_virtual_channel": "36",
+    "facility_id": "31437"
+  },
+  {
+    "callsign": "WPAN",
+    "community_served_city": "FORT WALTON BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "53",
+    "facility_id": "31570"
+  },
+  {
+    "callsign": "WCTV",
+    "community_served_city": "THOMASVILLE",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "31590"
+  },
+  {
+    "callsign": "KFQX",
+    "community_served_city": "GRAND JUNCTION",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "4",
+    "facility_id": "31597"
+  },
+  {
+    "callsign": "KYAZ",
+    "community_served_city": "KATY",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "51",
+    "facility_id": "31870"
+  },
+  {
+    "callsign": "KRZG-CD",
+    "community_served_city": "MCALLEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CRTV NETWORK",
+    "tv_virtual_channel": "35",
+    "facility_id": "32176"
+  },
+  {
+    "callsign": "KXOF-CD",
+    "community_served_city": "LAREDO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "31",
+    "facility_id": "32177"
+  },
+  {
+    "callsign": "KXFX-CD",
+    "community_served_city": "BROWNSVILLE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "21",
+    "facility_id": "32179"
+  },
+  {
+    "callsign": "KASA-TV",
+    "community_served_city": "SANTA FE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "2",
+    "facility_id": "32311"
+  },
+  {
+    "callsign": "WCNC-TV",
+    "community_served_city": "CHARLOTTE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "36",
+    "facility_id": "32326"
+  },
+  {
+    "callsign": "WHAS-TV",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "11",
+    "facility_id": "32327"
+  },
+  {
+    "callsign": "WJYS",
+    "community_served_city": "HAMMOND",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "62",
+    "facility_id": "32334"
+  },
+  {
+    "callsign": "KVAW",
+    "community_served_city": "EAGLE PASS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "16",
+    "facility_id": "32621"
+  },
+  {
+    "callsign": "WDFX-TV",
+    "community_served_city": "OZARK",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "34",
+    "facility_id": "32851"
+  },
+  {
+    "callsign": "KMVU-DT",
+    "community_served_city": "MEDFORD",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, Telemundo, MeTV",
+    "tv_virtual_channel": "26",
+    "facility_id": "32958"
+  },
+  {
+    "callsign": "KVTV",
+    "community_served_city": "LAREDO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "13",
+    "facility_id": "33078"
+  },
+  {
+    "callsign": "KZTV",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, Telemundo",
+    "tv_virtual_channel": "10",
+    "facility_id": "33079"
+  },
+  {
+    "callsign": "WCTX",
+    "community_served_city": "NEW HAVEN",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "59",
+    "facility_id": "33081"
+  },
+  {
+    "callsign": "KADN-TV",
+    "community_served_city": "LAFAYETTE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "15",
+    "facility_id": "33261"
+  },
+  {
+    "callsign": "KSMO-TV",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "My Net 62.1/Grio/H&I 62.2/Dabl 62.3/Cozi 62.4/Comet 62.5",
+    "tv_virtual_channel": "62",
+    "facility_id": "33336"
+  },
+  {
+    "callsign": "KPXE-TV",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "50",
+    "facility_id": "33337"
+  },
+  {
+    "callsign": "KPTS",
+    "community_served_city": "HUTCHINSON",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "33345"
+  },
+  {
+    "callsign": "KARK-TV",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "33440"
+  },
+  {
+    "callsign": "KATC",
+    "community_served_city": "LAFAYETTE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC; CW; GRIT; COURT TV; BOUNCE",
+    "tv_virtual_channel": "3",
+    "facility_id": "33471"
+  },
+  {
+    "callsign": "KATV",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "33543"
+  },
+  {
+    "callsign": "KYMA-DT",
+    "community_served_city": "YUMA",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "CBS/NBC/Estrella/ION",
+    "tv_virtual_channel": "13",
+    "facility_id": "33639"
+  },
+  {
+    "callsign": "KBJR-TV",
+    "community_served_city": "SUPERIOR",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CBS, My9, H&I",
+    "tv_virtual_channel": "6",
+    "facility_id": "33658"
+  },
+  {
+    "callsign": "KEYE-TV",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "42",
+    "facility_id": "33691"
+  },
+  {
+    "callsign": "KCCI",
+    "community_served_city": "DES MOINES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "33710"
+  },
+  {
+    "callsign": "KFOX-TV",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "14",
+    "facility_id": "33716"
+  },
+  {
+    "callsign": "KCIT",
+    "community_served_city": "AMARILLO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "14",
+    "facility_id": "33722"
+  },
+  {
+    "callsign": "KCOP-TV",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "13",
+    "facility_id": "33742"
+  },
+  {
+    "callsign": "KNVN",
+    "community_served_city": "CHICO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "24",
+    "facility_id": "33745"
+  },
+  {
+    "callsign": "KCTS-TV",
+    "community_served_city": "SEATTLE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "33749"
+  },
+  {
+    "callsign": "KYVE",
+    "community_served_city": "YAKIMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "47",
+    "facility_id": "33752"
+  },
+  {
+    "callsign": "KBZK",
+    "community_served_city": "BOZEMAN",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, MTN, Grit, Ion, Court TV, Scripps News, Laff",
+    "tv_virtual_channel": "7",
+    "facility_id": "33756"
+  },
+  {
+    "callsign": "KDBC-TV",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "33764"
+  },
+  {
+    "callsign": "KDFW",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "4",
+    "facility_id": "33770"
+  },
+  {
+    "callsign": "KDTV-DT",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "14",
+    "facility_id": "33778"
+  },
+  {
+    "callsign": "KKFX-CD",
+    "community_served_city": "SAN LUIS OBISPO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "24",
+    "facility_id": "33870"
+  },
+  {
+    "callsign": "KCRA-TV",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "33875"
+  },
+  {
+    "callsign": "KCPQ",
+    "community_served_city": "TACOMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "13",
+    "facility_id": "33894"
+  },
+  {
+    "callsign": "WBKI",
+    "community_served_city": "SALEM",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CW, My Network, Cozi, Movies, Ion Plus, Ion Mystery",
+    "tv_virtual_channel": "58",
+    "facility_id": "34167"
+  },
+  {
+    "callsign": "WKAS",
+    "community_served_city": "ASHLAND",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "34171"
+  },
+  {
+    "callsign": "WKMU",
+    "community_served_city": "MURRAY",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "34174"
+  },
+  {
+    "callsign": "WKGB-TV",
+    "community_served_city": "BOWLING GREEN",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "53",
+    "facility_id": "34177"
+  },
+  {
+    "callsign": "WKZT-TV",
+    "community_served_city": "ELIZABETHTOWN",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "34181"
+  },
+  {
+    "callsign": "WKMJ-TV",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "68",
+    "facility_id": "34195"
+  },
+  {
+    "callsign": "WKHA",
+    "community_served_city": "HAZARD",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "35",
+    "facility_id": "34196"
+  },
+  {
+    "callsign": "WKPI-TV",
+    "community_served_city": "PIKEVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "34200"
+  },
+  {
+    "callsign": "WKMR",
+    "community_served_city": "MOREHEAD",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "38",
+    "facility_id": "34202"
+  },
+  {
+    "callsign": "WCVN-TV",
+    "community_served_city": "COVINGTON",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "54",
+    "facility_id": "34204"
+  },
+  {
+    "callsign": "WKOH",
+    "community_served_city": "OWENSBORO",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "31",
+    "facility_id": "34205"
+  },
+  {
+    "callsign": "WKLE",
+    "community_served_city": "LEXINGTON",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "46",
+    "facility_id": "34207"
+  },
+  {
+    "callsign": "WKON",
+    "community_served_city": "OWENTON",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "52",
+    "facility_id": "34211"
+  },
+  {
+    "callsign": "WKMA-TV",
+    "community_served_city": "MADISONVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "35",
+    "facility_id": "34212"
+  },
+  {
+    "callsign": "WKSO-TV",
+    "community_served_city": "SOMERSET",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "34222"
+  },
+  {
+    "callsign": "WNYI",
+    "community_served_city": "ITHACA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "52",
+    "facility_id": "34329"
+  },
+  {
+    "callsign": "WTKO-CD",
+    "community_served_city": "ONEIDA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Cornerstone TeleVision",
+    "tv_virtual_channel": "13",
+    "facility_id": "34341"
+  },
+  {
+    "callsign": "WWDG-CD",
+    "community_served_city": "UTICA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Cornerstone TeleVision",
+    "tv_virtual_channel": "12",
+    "facility_id": "34342"
+  },
+  {
+    "callsign": "KOTA-TV",
+    "community_served_city": "RAPID CITY",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/FOX/True Crime/Grit/Outlaw",
+    "tv_virtual_channel": "3",
+    "facility_id": "34347"
+  },
+  {
+    "callsign": "KHSD-TV",
+    "community_served_city": "LEAD",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/FOX/True Crime/Grit/Outlaw",
+    "tv_virtual_channel": "11",
+    "facility_id": "34348"
+  },
+  {
+    "callsign": "KEZI",
+    "community_served_city": "EUGENE",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "34406"
+  },
+  {
+    "callsign": "KFBB-TV",
+    "community_served_city": "GREAT FALLS",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "ABC; SWX",
+    "tv_virtual_channel": "5",
+    "facility_id": "34412"
+  },
+  {
+    "callsign": "KBTF-CD",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "UNIMAS",
+    "tv_virtual_channel": "31",
+    "facility_id": "34438"
+  },
+  {
+    "callsign": "KFTV-DT",
+    "community_served_city": "HANFORD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "21",
+    "facility_id": "34439"
+  },
+  {
+    "callsign": "KEMO-TV",
+    "community_served_city": "FREMONT",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "VISION LATINA",
+    "tv_virtual_channel": "50",
+    "facility_id": "34440"
+  },
+  {
+    "callsign": "KGMB",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "34445"
+  },
+  {
+    "callsign": "KGBT-TV",
+    "community_served_city": "HARLINGEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "34457"
+  },
+  {
+    "callsign": "KGET-TV",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "17",
+    "facility_id": "34459"
+  },
+  {
+    "callsign": "KGO-TV",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "34470"
+  },
+  {
+    "callsign": "KIKU",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "20",
+    "facility_id": "34527"
+  },
+  {
+    "callsign": "KHOU",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "QUEST",
+    "tv_virtual_channel": "11",
+    "facility_id": "34529"
+  },
+  {
+    "callsign": "KHQ-TV",
+    "community_served_city": "SPOKANE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC; SWX",
+    "tv_virtual_channel": "6",
+    "facility_id": "34537"
+  },
+  {
+    "callsign": "KICU-TV",
+    "community_served_city": "SAN JOSE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "36",
+    "facility_id": "34564"
+  },
+  {
+    "callsign": "KRDT-CD",
+    "community_served_city": "REDDING",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "47",
+    "facility_id": "34574"
+  },
+  {
+    "callsign": "KSIX-TV",
+    "community_served_city": "HILO",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "34846"
+  },
+  {
+    "callsign": "KING-TV",
+    "community_served_city": "SEATTLE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "34847"
+  },
+  {
+    "callsign": "KTVB",
+    "community_served_city": "BOISE",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "34858"
+  },
+  {
+    "callsign": "KOGG",
+    "community_served_city": "WAILUKU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "15",
+    "facility_id": "34859"
+  },
+  {
+    "callsign": "KHNL",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "13",
+    "facility_id": "34867"
+  },
+  {
+    "callsign": "KREM",
+    "community_served_city": "SPOKANE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "34868"
+  },
+  {
+    "callsign": "KGW",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "34874"
+  },
+  {
+    "callsign": "KKTV",
+    "community_served_city": "COLORADO SPRINGS",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "35037"
+  },
+  {
+    "callsign": "KLAS-TV",
+    "community_served_city": "LAS VEGAS",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "35042"
+  },
+  {
+    "callsign": "KLFY-TV",
+    "community_served_city": "LAFAYETTE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "35059"
+  },
+  {
+    "callsign": "KTFQ-TV",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "41",
+    "facility_id": "35084"
+  },
+  {
+    "callsign": "KWBA-TV",
+    "community_served_city": "SIERRA VISTA",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "58",
+    "facility_id": "35095"
+  },
+  {
+    "callsign": "KWKB",
+    "community_served_city": "IOWA CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "20",
+    "facility_id": "35096"
+  },
+  {
+    "callsign": "KKJB",
+    "community_served_city": "BOISE",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "39",
+    "facility_id": "35097"
+  },
+  {
+    "callsign": "DKBEO",
+    "community_served_city": "JACKSON",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "AMERICA ONE",
+    "tv_virtual_channel": "11",
+    "facility_id": "35103"
+  },
+  {
+    "callsign": "DKCFG",
+    "community_served_city": "FLAGSTAFF",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "AMER1",
+    "tv_virtual_channel": "9",
+    "facility_id": "35104"
+  },
+  {
+    "callsign": "KMEX-DT",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "34",
+    "facility_id": "35123"
+  },
+  {
+    "callsign": "KMID",
+    "community_served_city": "MIDLAND",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "2",
+    "facility_id": "35131"
+  },
+  {
+    "callsign": "KMCB",
+    "community_served_city": "COOS BAY",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "23",
+    "facility_id": "35183"
+  },
+  {
+    "callsign": "KTCW",
+    "community_served_city": "ROSEBURG",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "46",
+    "facility_id": "35187"
+  },
+  {
+    "callsign": "KMTR",
+    "community_served_city": "EUGENE",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "16",
+    "facility_id": "35189"
+  },
+  {
+    "callsign": "KMTV-TV",
+    "community_served_city": "OMAHA",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "35190"
+  },
+  {
+    "callsign": "KMVT",
+    "community_served_city": "TWIN FALLS",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "CBS. FOX, CW",
+    "tv_virtual_channel": "11",
+    "facility_id": "35200"
+  },
+  {
+    "callsign": "KNSD",
+    "community_served_city": "SAN DIEGO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "39",
+    "facility_id": "35277"
+  },
+  {
+    "callsign": "KNTV",
+    "community_served_city": "SAN JOSE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "35280"
+  },
+  {
+    "callsign": "KOB",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "35313"
+  },
+  {
+    "callsign": "KOBF",
+    "community_served_city": "FARMINGTON",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "12",
+    "facility_id": "35321"
+  },
+  {
+    "callsign": "KFXA",
+    "community_served_city": "CEDAR RAPIDS",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "DABL",
+    "tv_virtual_channel": "28",
+    "facility_id": "35336"
+  },
+  {
+    "callsign": "KOIN",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "35380"
+  },
+  {
+    "callsign": "WCWG",
+    "community_served_city": "LEXINGTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "WCWG/Bounce/Dabl",
+    "tv_virtual_channel": "20",
+    "facility_id": "35385"
+  },
+  {
+    "callsign": "KOKH-TV",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "25",
+    "facility_id": "35388"
+  },
+  {
+    "callsign": "KONG",
+    "community_served_city": "EVERETT",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "16",
+    "facility_id": "35396"
+  },
+  {
+    "callsign": "KPLR-TV",
+    "community_served_city": "ST. LOUIS",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "11",
+    "facility_id": "35417"
+  },
+  {
+    "callsign": "KWDK",
+    "community_served_city": "TACOMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "REL",
+    "tv_virtual_channel": "56",
+    "facility_id": "35419"
+  },
+  {
+    "callsign": "KOTV-DT",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "35434"
+  },
+  {
+    "callsign": "KPAX-TV",
+    "community_served_city": "MISSOULA",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, COURT TV, GRIT, ION, NEWSY, MTN",
+    "tv_virtual_channel": "8",
+    "facility_id": "35455"
+  },
+  {
+    "callsign": "KPDX",
+    "community_served_city": "VANCOUVER",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork TV (D1), Ion Mystery (D2), Outlaw (D3), Court TV (D4)",
+    "tv_virtual_channel": "49",
+    "facility_id": "35460"
+  },
+  {
+    "callsign": "KPNX",
+    "community_served_city": "MESA",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "12",
+    "facility_id": "35486"
+  },
+  {
+    "callsign": "KQED",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "35500"
+  },
+  {
+    "callsign": "KTFF-DT",
+    "community_served_city": "PORTERVILLE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "61",
+    "facility_id": "35512"
+  },
+  {
+    "callsign": "KQDS-TV",
+    "community_served_city": "DULUTH",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "21",
+    "facility_id": "35525"
+  },
+  {
+    "callsign": "KRTV",
+    "community_served_city": "GREAT FALLS",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS Ch 3.1, CW/MTN Ch 3.2, Grit CH 3.3, DEFY Ch 3.4, Newsy",
+    "tv_virtual_channel": "3",
+    "facility_id": "35567"
+  },
+  {
+    "callsign": "WTVX",
+    "community_served_city": "FORT PIERCE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "34",
+    "facility_id": "35575"
+  },
+  {
+    "callsign": "WJAX-TV",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS/COZI TV/CATCHY COMEDY/ME TV TOONS (EFFECITVE 6/24/24)",
+    "tv_virtual_channel": "47",
+    "facility_id": "35576"
+  },
+  {
+    "callsign": "WYDO",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "14",
+    "facility_id": "35582"
+  },
+  {
+    "callsign": "KSAX",
+    "community_served_city": "ALEXANDRIA",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "42",
+    "facility_id": "35584"
+  },
+  {
+    "callsign": "KRWF",
+    "community_served_city": "REDWOOD FALLS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "43",
+    "facility_id": "35585"
+  },
+  {
+    "callsign": "KSAZ-TV",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "10",
+    "facility_id": "35587"
+  },
+  {
+    "callsign": "KSEE",
+    "community_served_city": "FRESNO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "24",
+    "facility_id": "35594"
+  },
+  {
+    "callsign": "KSKN",
+    "community_served_city": "SPOKANE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "22",
+    "facility_id": "35606"
+  },
+  {
+    "callsign": "KSCI",
+    "community_served_city": "LONG BEACH",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC",
+    "tv_virtual_channel": "18",
+    "facility_id": "35608"
+  },
+  {
+    "callsign": "KSMS-TV",
+    "community_served_city": "MONTEREY",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "67",
+    "facility_id": "35611"
+  },
+  {
+    "callsign": "DKGHZ",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "15",
+    "facility_id": "35630"
+  },
+  {
+    "callsign": "KSWO-TV",
+    "community_served_city": "LAWTON",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "35645"
+  },
+  {
+    "callsign": "KTAL-TV",
+    "community_served_city": "TEXARKANA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "35648"
+  },
+  {
+    "callsign": "KTBC",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "7",
+    "facility_id": "35649"
+  },
+  {
+    "callsign": "KTBS-TV",
+    "community_served_city": "SHREVEPORT",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "3",
+    "facility_id": "35652"
+  },
+  {
+    "callsign": "KTBY",
+    "community_served_city": "ANCHORAGE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "4",
+    "facility_id": "35655"
+  },
+  {
+    "callsign": "KQEH",
+    "community_served_city": "SAN JOSE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "54",
+    "facility_id": "35663"
+  },
+  {
+    "callsign": "KTEN",
+    "community_served_city": "ADA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "35666"
+  },
+  {
+    "callsign": "KTLA",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "5",
+    "facility_id": "35670"
+  },
+  {
+    "callsign": "KTRK-TV",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "35675"
+  },
+  {
+    "callsign": "KTTC",
+    "community_served_city": "ROCHESTER",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CW, Heroes & Icons",
+    "tv_virtual_channel": "10",
+    "facility_id": "35678"
+  },
+  {
+    "callsign": "KTUL",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "35685"
+  },
+  {
+    "callsign": "KTVE",
+    "community_served_city": "EL DORADO",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "35692"
+  },
+  {
+    "callsign": "KTVI",
+    "community_served_city": "ST. LOUIS",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "2",
+    "facility_id": "35693"
+  },
+  {
+    "callsign": "KTVQ",
+    "community_served_city": "BILLINGS",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS Ch 2.1, CW/MTN Ch 2.2",
+    "tv_virtual_channel": "2",
+    "facility_id": "35694"
+  },
+  {
+    "callsign": "KTVU",
+    "community_served_city": "OAKLAND",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "2",
+    "facility_id": "35703"
+  },
+  {
+    "callsign": "KTVW-DT",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "33",
+    "facility_id": "35705"
+  },
+  {
+    "callsign": "KULR-TV",
+    "community_served_city": "BILLINGS",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC; SWX",
+    "tv_virtual_channel": "8",
+    "facility_id": "35724"
+  },
+  {
+    "callsign": "KAZT-TV",
+    "community_served_city": "PRESCOTT",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "7",
+    "facility_id": "35811"
+  },
+  {
+    "callsign": "KMYU",
+    "community_served_city": "ST. GEORGE",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "My Network",
+    "tv_virtual_channel": "12",
+    "facility_id": "35822"
+  },
+  {
+    "callsign": "KUTV",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "35823"
+  },
+  {
+    "callsign": "KUVN-DT",
+    "community_served_city": "GARLAND",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "23",
+    "facility_id": "35841"
+  },
+  {
+    "callsign": "KSTC-TV",
+    "community_served_city": "MINNEAPOLIS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "45",
+    "facility_id": "35843"
+  },
+  {
+    "callsign": "KVCT",
+    "community_served_city": "VICTORIA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "19",
+    "facility_id": "35846"
+  },
+  {
+    "callsign": "KVHP",
+    "community_served_city": "LAKE CHARLES",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "KVHP",
+    "tv_virtual_channel": "29",
+    "facility_id": "35852"
+  },
+  {
+    "callsign": "KVIE",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "35855"
+  },
+  {
+    "callsign": "KVOS-TV",
+    "community_served_city": "BELLINGHAM",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "12",
+    "facility_id": "35862"
+  },
+  {
+    "callsign": "KVUE",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "24",
+    "facility_id": "35867"
+  },
+  {
+    "callsign": "KVVU-TV",
+    "community_served_city": "HENDERSON",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "5.1 FOX, 5.2 SSSEN, 5.3 Court TV Mystery, 5.4 Dabl",
+    "tv_virtual_channel": "5",
+    "facility_id": "35870"
+  },
+  {
+    "callsign": "KWEX-DT",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "41",
+    "facility_id": "35881"
+  },
+  {
+    "callsign": "KTFO-CD",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "31",
+    "facility_id": "35882"
+  },
+  {
+    "callsign": "KWGN-TV",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "2",
+    "facility_id": "35883"
+  },
+  {
+    "callsign": "KWTX-TV",
+    "community_served_city": "WACO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS / Telemundo / MeTV",
+    "tv_virtual_channel": "10",
+    "facility_id": "35903"
+  },
+  {
+    "callsign": "KXLT-TV",
+    "community_served_city": "ROCHESTER",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, Me-TV",
+    "tv_virtual_channel": "47",
+    "facility_id": "35906"
+  },
+  {
+    "callsign": "KPXM-TV",
+    "community_served_city": "ST. CLOUD",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Grit, Mystery, Laff, SCRIPPS News, Jewelry TV, QVC",
+    "tv_virtual_channel": "41",
+    "facility_id": "35907"
+  },
+  {
+    "callsign": "WVLT-TV",
+    "community_served_city": "KNOXVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "35908"
+  },
+  {
+    "callsign": "KBVO",
+    "community_served_city": "LLANO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "14",
+    "facility_id": "35909"
+  },
+  {
+    "callsign": "KHPZ-CD",
+    "community_served_city": "ROUND ROCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "15",
+    "facility_id": "35910"
+  },
+  {
+    "callsign": "KHPX-CD",
+    "community_served_city": "GEORGETOWN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "28",
+    "facility_id": "35911"
+  },
+  {
+    "callsign": "KHPL-CD",
+    "community_served_city": "LA GRANGE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "40",
+    "facility_id": "35913"
+  },
+  {
+    "callsign": "KBVO-CD",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "51",
+    "facility_id": "35918"
+  },
+  {
+    "callsign": "KXAN-TV",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "36",
+    "facility_id": "35920"
+  },
+  {
+    "callsign": "KHPM-CD",
+    "community_served_city": "SAN MARCOS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "40",
+    "facility_id": "35921"
+  },
+  {
+    "callsign": "KHPF-CD",
+    "community_served_city": "FREDERICKSBURG",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "44",
+    "facility_id": "35923"
+  },
+  {
+    "callsign": "KXII",
+    "community_served_city": "SHERMAN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "35954"
+  },
+  {
+    "callsign": "KXLF-TV",
+    "community_served_city": "BUTTE",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, MTN, Grit, Ion, Court TV, Scripps News, Laff",
+    "tv_virtual_channel": "4",
+    "facility_id": "35959"
+  },
+  {
+    "callsign": "KXRM-TV",
+    "community_served_city": "COLORADO SPRINGS",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "21",
+    "facility_id": "35991"
+  },
+  {
+    "callsign": "KXTX-TV",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "39",
+    "facility_id": "35994"
+  },
+  {
+    "callsign": "KYTV",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, ABC, CW",
+    "tv_virtual_channel": "3",
+    "facility_id": "36003"
+  },
+  {
+    "callsign": "WHME-TV",
+    "community_served_city": "SOUTH BEND",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "46",
+    "facility_id": "36117"
+  },
+  {
+    "callsign": "KVYE",
+    "community_served_city": "EL CENTRO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "7",
+    "facility_id": "36170"
+  },
+  {
+    "callsign": "WUCW",
+    "community_served_city": "MINNEAPOLIS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "23",
+    "facility_id": "36395"
+  },
+  {
+    "callsign": "WTVF",
+    "community_served_city": "NASHVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "36504"
+  },
+  {
+    "callsign": "WLAJ",
+    "community_served_city": "LANSING",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/CW",
+    "tv_virtual_channel": "53",
+    "facility_id": "36533"
+  },
+  {
+    "callsign": "KJZZ-TV",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "14",
+    "facility_id": "36607"
+  },
+  {
+    "callsign": "KSKJ-CD",
+    "community_served_city": "VAN NUYS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "DAYSTAR TELEVISION NETWORK",
+    "tv_virtual_channel": "38",
+    "facility_id": "36717"
+  },
+  {
+    "callsign": "WOOD-TV",
+    "community_served_city": "GRAND RAPIDS",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "36838"
+  },
+  {
+    "callsign": "KWHE",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "14",
+    "facility_id": "36846"
+  },
+  {
+    "callsign": "WSAZ-TV",
+    "community_served_city": "HUNTINGTON",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "36912"
+  },
+  {
+    "callsign": "KGMD-TV",
+    "community_served_city": "HILO",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "9",
+    "facility_id": "36914"
+  },
+  {
+    "callsign": "KTDO",
+    "community_served_city": "LAS CRUCES",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "48",
+    "facility_id": "36916"
+  },
+  {
+    "callsign": "KHII-TV",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "9",
+    "facility_id": "36917"
+  },
+  {
+    "callsign": "KGUN-TV",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "36918"
+  },
+  {
+    "callsign": "KGMV",
+    "community_served_city": "WAILUKU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "3",
+    "facility_id": "36920"
+  },
+  {
+    "callsign": "WLVT-TV",
+    "community_served_city": "ALLENTOWN",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "39",
+    "facility_id": "36989"
+  },
+  {
+    "callsign": "KARZ-TV",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetworkTV",
+    "tv_virtual_channel": "42",
+    "facility_id": "37005"
+  },
+  {
+    "callsign": "KWHB",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "47",
+    "facility_id": "37099"
+  },
+  {
+    "callsign": "KETD",
+    "community_served_city": "CASTLE ROCK",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "EstrellaTV",
+    "tv_virtual_channel": "53",
+    "facility_id": "37101"
+  },
+  {
+    "callsign": "WHMB-TV",
+    "community_served_city": "INDIANAPOLIS",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "40",
+    "facility_id": "37102"
+  },
+  {
+    "callsign": "KXHI",
+    "community_served_city": "HILO",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "14",
+    "facility_id": "37103"
+  },
+  {
+    "callsign": "WPXE-TV",
+    "community_served_city": "KENOSHA",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Court TV, Grit, IONPlus, SCRIPPS News, Jewelry TV, QVC",
+    "tv_virtual_channel": "55",
+    "facility_id": "37104"
+  },
+  {
+    "callsign": "KLEI",
+    "community_served_city": "WAILUKU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "21",
+    "facility_id": "37105"
+  },
+  {
+    "callsign": "WHNO",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "20",
+    "facility_id": "37106"
+  },
+  {
+    "callsign": "WJCL",
+    "community_served_city": "SAVANNAH",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, MeTV",
+    "tv_virtual_channel": "22",
+    "facility_id": "37174"
+  },
+  {
+    "callsign": "WLTX",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "37176"
+  },
+  {
+    "callsign": "WLTZ",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "38",
+    "facility_id": "37179"
+  },
+  {
+    "callsign": "WLIO",
+    "community_served_city": "LIMA",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, FOX",
+    "tv_virtual_channel": "35",
+    "facility_id": "37503"
+  },
+  {
+    "callsign": "KTSF",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "26",
+    "facility_id": "37511"
+  },
+  {
+    "callsign": "KAXT-CD",
+    "community_served_city": "SAN FRANCISO, SAN JO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Catchy Comedy",
+    "tv_virtual_channel": "1",
+    "facility_id": "37689"
+  },
+  {
+    "callsign": "WLOV-TV",
+    "community_served_city": "WEST POINT",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "CW, METV, THISTV, METV Toons",
+    "tv_virtual_channel": "27",
+    "facility_id": "37732"
+  },
+  {
+    "callsign": "WLFB",
+    "community_served_city": "BLUEFIELD",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "40",
+    "facility_id": "37806"
+  },
+  {
+    "callsign": "WLFG",
+    "community_served_city": "GRUNDY",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "68",
+    "facility_id": "37808"
+  },
+  {
+    "callsign": "WAGV",
+    "community_served_city": "HARLAN",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "44",
+    "facility_id": "37809"
+  },
+  {
+    "callsign": "WPXU-TV",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Grit, Laff, IonPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "35",
+    "facility_id": "37971"
+  },
+  {
+    "callsign": "DWFXI",
+    "community_served_city": "MOREHEAD CITY",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "8",
+    "facility_id": "37982"
+  },
+  {
+    "callsign": "KSBI",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork TV",
+    "tv_virtual_channel": "52",
+    "facility_id": "38214"
+  },
+  {
+    "callsign": "WLIW",
+    "community_served_city": "GARDEN CITY",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "38336"
+  },
+  {
+    "callsign": "KDEN-TV",
+    "community_served_city": "LONGMONT",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "25",
+    "facility_id": "38375"
+  },
+  {
+    "callsign": "KLCS",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "58",
+    "facility_id": "38430"
+  },
+  {
+    "callsign": "KGBS-CD",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TBD NETWORK",
+    "tv_virtual_channel": "32",
+    "facility_id": "38562"
+  },
+  {
+    "callsign": "KMCT-TV",
+    "community_served_city": "WEST MONROE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "39",
+    "facility_id": "38584"
+  },
+  {
+    "callsign": "WLPB-TV",
+    "community_served_city": "BATON ROUGE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "38586"
+  },
+  {
+    "callsign": "KLTL-TV",
+    "community_served_city": "LAKE CHARLES",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "38587"
+  },
+  {
+    "callsign": "KLPB-TV",
+    "community_served_city": "LAFAYETTE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "38588"
+  },
+  {
+    "callsign": "KLTM-TV",
+    "community_served_city": "MONROE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "38589"
+  },
+  {
+    "callsign": "KLPA-TV",
+    "community_served_city": "ALEXANDRIA",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "38590"
+  },
+  {
+    "callsign": "KLTS-TV",
+    "community_served_city": "SHREVEPORT",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "38591"
+  },
+  {
+    "callsign": "WBRZ-TV",
+    "community_served_city": "BATON ROUGE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "2",
+    "facility_id": "38616"
+  },
+  {
+    "callsign": "WISH-TV",
+    "community_served_city": "INDIANAPOLIS",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "8",
+    "facility_id": "39269"
+  },
+  {
+    "callsign": "WANE-TV",
+    "community_served_city": "FORT WAYNE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "39270"
+  },
+  {
+    "callsign": "WDKA",
+    "community_served_city": "PADUCAH",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "My Network TV",
+    "tv_virtual_channel": "49",
+    "facility_id": "39561"
+  },
+  {
+    "callsign": "WLBZ",
+    "community_served_city": "BANGOR",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "39644"
+  },
+  {
+    "callsign": "WMEB-TV",
+    "community_served_city": "ORONO",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "39648"
+  },
+  {
+    "callsign": "WMED-TV",
+    "community_served_city": "CALAIS",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "39649"
+  },
+  {
+    "callsign": "WMEA-TV",
+    "community_served_city": "BIDDEFORD",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "39656"
+  },
+  {
+    "callsign": "WCBB",
+    "community_served_city": "AUGUSTA",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "39659"
+  },
+  {
+    "callsign": "WMEM-TV",
+    "community_served_city": "PRESQUE ISLE",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "39662"
+  },
+  {
+    "callsign": "WCSH",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "39664"
+  },
+  {
+    "callsign": "KMEG",
+    "community_served_city": "SIOUX CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "Dabl",
+    "tv_virtual_channel": "14",
+    "facility_id": "39665"
+  },
+  {
+    "callsign": "WFLX",
+    "community_served_city": "WEST PALM BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "29",
+    "facility_id": "39736"
+  },
+  {
+    "callsign": "WXIX-TV",
+    "community_served_city": "NEWPORT",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "19",
+    "facility_id": "39738"
+  },
+  {
+    "callsign": "WOIO",
+    "community_served_city": "SHAKER HEIGHTS",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "39746"
+  },
+  {
+    "callsign": "WFMZ-TV",
+    "community_served_city": "ALLENTOWN",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "69",
+    "facility_id": "39884"
+  },
+  {
+    "callsign": "WIRS",
+    "community_served_city": "YAUCO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "42",
+    "facility_id": "39887"
+  },
+  {
+    "callsign": "KCWT-CD",
+    "community_served_city": "LA FERIA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "21",
+    "facility_id": "40058"
+  },
+  {
+    "callsign": "KLWY",
+    "community_served_city": "CHEYENNE",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "27",
+    "facility_id": "40250"
+  },
+  {
+    "callsign": "KVII-TV",
+    "community_served_city": "AMARILLO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "40446"
+  },
+  {
+    "callsign": "KVIH-TV",
+    "community_served_city": "CLOVIS",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "40450"
+  },
+  {
+    "callsign": "KAJB",
+    "community_served_city": "CALIPATRIA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "54",
+    "facility_id": "40517"
+  },
+  {
+    "callsign": "WCPB",
+    "community_served_city": "SALISBURY",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "28",
+    "facility_id": "40618"
+  },
+  {
+    "callsign": "WGPT",
+    "community_served_city": "OAKLAND",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "40619"
+  },
+  {
+    "callsign": "WFPT",
+    "community_served_city": "FREDERICK",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "62",
+    "facility_id": "40626"
+  },
+  {
+    "callsign": "WSYT",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX/COZI-TV",
+    "tv_virtual_channel": "68",
+    "facility_id": "40758"
+  },
+  {
+    "callsign": "WTVZ-TV",
+    "community_served_city": "NORFOLK",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "My Network TV",
+    "tv_virtual_channel": "33",
+    "facility_id": "40759"
+  },
+  {
+    "callsign": "WEMT",
+    "community_served_city": "GREENEVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "39",
+    "facility_id": "40761"
+  },
+  {
+    "callsign": "KAMC",
+    "community_served_city": "LUBBOCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "28",
+    "facility_id": "40820"
+  },
+  {
+    "callsign": "WPXS",
+    "community_served_city": "MOUNT VERNON",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "13",
+    "facility_id": "40861"
+  },
+  {
+    "callsign": "KMGH-TV",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "40875"
+  },
+  {
+    "callsign": "KGTV",
+    "community_served_city": "SAN DIEGO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "10",
+    "facility_id": "40876"
+  },
+  {
+    "callsign": "WRTV",
+    "community_served_city": "INDIANAPOLIS",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "40877"
+  },
+  {
+    "callsign": "KERO-TV",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "23",
+    "facility_id": "40878"
+  },
+  {
+    "callsign": "WKTC",
+    "community_served_city": "SUMTER",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "My Network TV",
+    "tv_virtual_channel": "63",
+    "facility_id": "40902"
+  },
+  {
+    "callsign": "KTVK",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "3",
+    "facility_id": "40993"
+  },
+  {
+    "callsign": "WTXL-TV",
+    "community_served_city": "TALLAHASSEE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "27",
+    "facility_id": "41065"
+  },
+  {
+    "callsign": "WRTD-CD",
+    "community_served_city": "RALEIGH",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "TELEMUNDO",
+    "tv_virtual_channel": "54",
+    "facility_id": "41095"
+  },
+  {
+    "callsign": "KRCG",
+    "community_served_city": "JEFFERSON CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "41110"
+  },
+  {
+    "callsign": "K10OG-D",
+    "community_served_city": "LOMPOC",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "UNIMAS",
+    "tv_virtual_channel": "10",
+    "facility_id": "41125"
+  },
+  {
+    "callsign": "KLDF-CD",
+    "community_served_city": "LOMPOC",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "17",
+    "facility_id": "41126"
+  },
+  {
+    "callsign": "WJTC",
+    "community_served_city": "PENSACOLA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "44",
+    "facility_id": "41210"
+  },
+  {
+    "callsign": "KASN",
+    "community_served_city": "PINE BLUFF",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "38",
+    "facility_id": "41212"
+  },
+  {
+    "callsign": "WNEM-TV",
+    "community_served_city": "BAY CITY",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "5.1 (CBS); 5.2 (MyNetwork); 5.3 (Cozi); 5.4 (Ion)",
+    "tv_virtual_channel": "5",
+    "facility_id": "41221"
+  },
+  {
+    "callsign": "KPHO-TV",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "41223"
+  },
+  {
+    "callsign": "WOFL",
+    "community_served_city": "ORLANDO",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "35",
+    "facility_id": "41225"
+  },
+  {
+    "callsign": "KCTV",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS 5.1/The 365 5.2/This TV & Start 5.3/Quest 5.4/The Outlaw5.5",
+    "tv_virtual_channel": "5",
+    "facility_id": "41230"
+  },
+  {
+    "callsign": "WSMV-TV",
+    "community_served_city": "NASHVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "41232"
+  },
+  {
+    "callsign": "KMCC",
+    "community_served_city": "LAUGHLIN",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "34",
+    "facility_id": "41237"
+  },
+  {
+    "callsign": "WINP-TV",
+    "community_served_city": "PITTSBURGH",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Mystery, IONPlus, SCRIPPS News, Jewelry TV, QVC, HSN",
+    "tv_virtual_channel": "16",
+    "facility_id": "41314"
+  },
+  {
+    "callsign": "WQED",
+    "community_served_city": "PITTSBURGH",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "41315"
+  },
+  {
+    "callsign": "WFYI",
+    "community_served_city": "INDIANAPOLIS",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "41397"
+  },
+  {
+    "callsign": "WNPT",
+    "community_served_city": "NASHVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "41398"
+  },
+  {
+    "callsign": "KMOT",
+    "community_served_city": "MINOT",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "41425"
+  },
+  {
+    "callsign": "KFYR-TV",
+    "community_served_city": "BISMARCK",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "41427"
+  },
+  {
+    "callsign": "KUMV-TV",
+    "community_served_city": "WILLISTON",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "41429"
+  },
+  {
+    "callsign": "KQCD-TV",
+    "community_served_city": "DICKINSON",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "41430"
+  },
+  {
+    "callsign": "WMFP",
+    "community_served_city": "FOXBOROUGH",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "IND 1/1 - 3/31/24, Shop LC 4/1 - 12/31/24",
+    "tv_virtual_channel": "62",
+    "facility_id": "41436"
+  },
+  {
+    "callsign": "WHIO-TV",
+    "community_served_city": "DAYTON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CBS Network (7.1),  METV (7.2),  Laff (7.3), METV Toons (7.4)",
+    "tv_virtual_channel": "7",
+    "facility_id": "41458"
+  },
+  {
+    "callsign": "KFPH-DT",
+    "community_served_city": "FLAGSTAFF",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "13",
+    "facility_id": "41517"
+  },
+  {
+    "callsign": "WNIT",
+    "community_served_city": "SOUTH BEND",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "34",
+    "facility_id": "41671"
+  },
+  {
+    "callsign": "WNDU-TV",
+    "community_served_city": "SOUTH BEND",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, AntennaTV, GetTV",
+    "tv_virtual_channel": "16",
+    "facility_id": "41674"
+  },
+  {
+    "callsign": "WMFD-TV",
+    "community_served_city": "MANSFIELD",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "68",
+    "facility_id": "41893"
+  },
+  {
+    "callsign": "KPLO-TV",
+    "community_served_city": "RELIANCE",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "41964"
+  },
+  {
+    "callsign": "KCLO-TV",
+    "community_served_city": "RAPID CITY",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "41969"
+  },
+  {
+    "callsign": "KDLO-TV",
+    "community_served_city": "FLORENCE",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "41975"
+  },
+  {
+    "callsign": "KELO-TV",
+    "community_served_city": "SIOUX FALLS",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "41983"
+  },
+  {
+    "callsign": "KWES-TV",
+    "community_served_city": "ODESSA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "9",
+    "facility_id": "42007"
+  },
+  {
+    "callsign": "KCWO-TV",
+    "community_served_city": "BIG SPRING",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CW PLUS",
+    "tv_virtual_channel": "4",
+    "facility_id": "42008"
+  },
+  {
+    "callsign": "WKNO",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "42061"
+  },
+  {
+    "callsign": "WCIX",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "49",
+    "facility_id": "42116"
+  },
+  {
+    "callsign": "WMBD-TV",
+    "community_served_city": "PEORIA",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "31",
+    "facility_id": "42121"
+  },
+  {
+    "callsign": "KFMB-TV",
+    "community_served_city": "SAN DIEGO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "42122"
+  },
+  {
+    "callsign": "WCIA",
+    "community_served_city": "CHAMPAIGN",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "42124"
+  },
+  {
+    "callsign": "KTXD-TV",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "47",
+    "facility_id": "42359"
+  },
+  {
+    "callsign": "KMCI-TV",
+    "community_served_city": "LAWRENCE",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "38",
+    "facility_id": "42636"
+  },
+  {
+    "callsign": "DKJRW",
+    "community_served_city": "EUREKA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "42640"
+  },
+  {
+    "callsign": "WMVS",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "42663"
+  },
+  {
+    "callsign": "WMVT",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "42665"
+  },
+  {
+    "callsign": "KMTP-TV",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "32",
+    "facility_id": "43095"
+  },
+  {
+    "callsign": "WMPN-TV",
+    "community_served_city": "JACKSON",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "43168"
+  },
+  {
+    "callsign": "WMAW-TV",
+    "community_served_city": "MERIDIAN",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "14",
+    "facility_id": "43169"
+  },
+  {
+    "callsign": "WMAE-TV",
+    "community_served_city": "BOONEVILLE",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "43170"
+  },
+  {
+    "callsign": "WMAO-TV",
+    "community_served_city": "GREENWOOD",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "43176"
+  },
+  {
+    "callsign": "WMAU-TV",
+    "community_served_city": "BUDE",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "17",
+    "facility_id": "43184"
+  },
+  {
+    "callsign": "WMAB-TV",
+    "community_served_city": "MISSISSIPPI STATE",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "43192"
+  },
+  {
+    "callsign": "WMAV-TV",
+    "community_served_city": "OXFORD",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "43193"
+  },
+  {
+    "callsign": "WMAH-TV",
+    "community_served_city": "BILOXI",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "43197"
+  },
+  {
+    "callsign": "WABG-TV",
+    "community_served_city": "GREENWOOD",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC and FOX",
+    "tv_virtual_channel": "6",
+    "facility_id": "43203"
+  },
+  {
+    "callsign": "KRGV-TV",
+    "community_served_city": "WESLACO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "5",
+    "facility_id": "43328"
+  },
+  {
+    "callsign": "WFXV",
+    "community_served_city": "UTICA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "33",
+    "facility_id": "43424"
+  },
+  {
+    "callsign": "KUSM-TV",
+    "community_served_city": "BOZEMAN",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "43567"
+  },
+  {
+    "callsign": "WDHN",
+    "community_served_city": "DOTHAN",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "18",
+    "facility_id": "43846"
+  },
+  {
+    "callsign": "WMGT-TV",
+    "community_served_city": "MACON",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "41",
+    "facility_id": "43847"
+  },
+  {
+    "callsign": "WRLM",
+    "community_served_city": "CANTON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "67",
+    "facility_id": "43870"
+  },
+  {
+    "callsign": "WMBC-TV",
+    "community_served_city": "NEWTON",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "Merit Street Media",
+    "tv_virtual_channel": "63",
+    "facility_id": "43952"
+  },
+  {
+    "callsign": "KMSB",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "11",
+    "facility_id": "44052"
+  },
+  {
+    "callsign": "WCAX-TV",
+    "community_served_city": "BURLINGTON",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "46728"
+  },
+  {
+    "callsign": "KDIT-CD",
+    "community_served_city": "Des Moines",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "Catchy Comedy",
+    "tv_virtual_channel": "45",
+    "facility_id": "46753"
+  },
+  {
+    "callsign": "WCFE-TV",
+    "community_served_city": "PLATTSBURGH",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "57",
+    "facility_id": "46755"
+  },
+  {
+    "callsign": "WLWT",
+    "community_served_city": "CINCINNATI",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "46979"
+  },
+  {
+    "callsign": "KSDK",
+    "community_served_city": "ST. LOUIS",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "46981"
+  },
+  {
+    "callsign": "WBIR-TV",
+    "community_served_city": "KNOXVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "46984"
+  },
+  {
+    "callsign": "WMAZ-TV",
+    "community_served_city": "MACON",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "46991"
+  },
+  {
+    "callsign": "KIXE-TV",
+    "community_served_city": "REDDING",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "47285"
+  },
+  {
+    "callsign": "WTKR",
+    "community_served_city": "NORFOLK",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, Court TV, Bounce, HSN, QVC",
+    "tv_virtual_channel": "3",
+    "facility_id": "47401"
+  },
+  {
+    "callsign": "WPRI-TV",
+    "community_served_city": "PROVIDENCE",
+    "community_served_state": "RI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, myNetwork, Dabl",
+    "tv_virtual_channel": "12",
+    "facility_id": "47404"
+  },
+  {
+    "callsign": "WNBC",
+    "community_served_city": "NEW YORK",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "47535"
+  },
+  {
+    "callsign": "KHMT",
+    "community_served_city": "HARDIN",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "4",
+    "facility_id": "47670"
+  },
+  {
+    "callsign": "WVIR-CD",
+    "community_served_city": "CHARLOTTESVILLE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CW, TRUE CRIME",
+    "tv_virtual_channel": "27",
+    "facility_id": "47705"
+  },
+  {
+    "callsign": "KNMT",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "24",
+    "facility_id": "47707"
+  },
+  {
+    "callsign": "WFOR-TV",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "47902"
+  },
+  {
+    "callsign": "KCNC-TV",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "47903"
+  },
+  {
+    "callsign": "WRC-TV",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "47904"
+  },
+  {
+    "callsign": "WMAQ-TV",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "47905"
+  },
+  {
+    "callsign": "KNBC",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "47906"
+  },
+  {
+    "callsign": "WVIA-TV",
+    "community_served_city": "SCRANTON",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "44",
+    "facility_id": "47929"
+  },
+  {
+    "callsign": "KRNE-TV",
+    "community_served_city": "MERRIMAN",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "47971"
+  },
+  {
+    "callsign": "KPNE-TV",
+    "community_served_city": "NORTH PLATTE",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "47973"
+  },
+  {
+    "callsign": "KYNE-TV",
+    "community_served_city": "OMAHA",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "47974"
+  },
+  {
+    "callsign": "KLNE-TV",
+    "community_served_city": "LEXINGTON",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "47975"
+  },
+  {
+    "callsign": "KMNE-TV",
+    "community_served_city": "BASSETT",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "47981"
+  },
+  {
+    "callsign": "KHNE-TV",
+    "community_served_city": "HASTINGS",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "47987"
+  },
+  {
+    "callsign": "KXNE-TV",
+    "community_served_city": "NORFOLK",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "47995"
+  },
+  {
+    "callsign": "KTNE-TV",
+    "community_served_city": "ALLIANCE",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "47996"
+  },
+  {
+    "callsign": "KNHL",
+    "community_served_city": "HASTINGS",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "METV",
+    "tv_virtual_channel": "5",
+    "facility_id": "48003"
+  },
+  {
+    "callsign": "WSJN-CD",
+    "community_served_city": "SAN JUAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "CTNI",
+    "tv_virtual_channel": "15",
+    "facility_id": "48239"
+  },
+  {
+    "callsign": "WAGM-TV",
+    "community_served_city": "PRESQUE ISLE",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, FOX, CW",
+    "tv_virtual_channel": "8",
+    "facility_id": "48305"
+  },
+  {
+    "callsign": "KRXI-TV",
+    "community_served_city": "RENO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "11",
+    "facility_id": "48360"
+  },
+  {
+    "callsign": "WPXG-TV",
+    "community_served_city": "CONCORD",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Mystery, SCRIPPS News, Bounce, IonPlus, Jewlery TV, HSN",
+    "tv_virtual_channel": "21",
+    "facility_id": "48406"
+  },
+  {
+    "callsign": "WIPL",
+    "community_served_city": "LEWISTON",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV Bounce Grit IONPlus",
+    "tv_virtual_channel": "35",
+    "facility_id": "48408"
+  },
+  {
+    "callsign": "WNJB",
+    "community_served_city": "NEW BRUNSWICK",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "58",
+    "facility_id": "48457"
+  },
+  {
+    "callsign": "WNJT",
+    "community_served_city": "TRENTON",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "52",
+    "facility_id": "48465"
+  },
+  {
+    "callsign": "WNJN",
+    "community_served_city": "MONTCLAIR",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "50",
+    "facility_id": "48477"
+  },
+  {
+    "callsign": "WNJS",
+    "community_served_city": "CAMDEN",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "48481"
+  },
+  {
+    "callsign": "KFDR",
+    "community_served_city": "JEFFERSON CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "CTN",
+    "tv_virtual_channel": "25",
+    "facility_id": "48521"
+  },
+  {
+    "callsign": "KNLC",
+    "community_served_city": "ST. LOUIS",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "24",
+    "facility_id": "48525"
+  },
+  {
+    "callsign": "KBIM-TV",
+    "community_served_city": "ROSWELL",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "48556"
+  },
+  {
+    "callsign": "KRQE",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "48575"
+  },
+  {
+    "callsign": "KREZ-TV",
+    "community_served_city": "DURANGO",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "48589"
+  },
+  {
+    "callsign": "WPXM-TV",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Grit, Laff, SCRIPPS News, HSN, Jewelry TV, Mystery",
+    "tv_virtual_channel": "35",
+    "facility_id": "48608"
+  },
+  {
+    "callsign": "KSFY-TV",
+    "community_served_city": "SIOUX FALLS",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/MeTV",
+    "tv_virtual_channel": "13",
+    "facility_id": "48658"
+  },
+  {
+    "callsign": "DKABY-TV",
+    "community_served_city": "ABERDEEN",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "48659"
+  },
+  {
+    "callsign": "KPRY-TV",
+    "community_served_city": "PIERRE",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/ABC/FOX",
+    "tv_virtual_channel": "4",
+    "facility_id": "48660"
+  },
+  {
+    "callsign": "WSAV-TV",
+    "community_served_city": "SAVANNAH",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "48662"
+  },
+  {
+    "callsign": "KOLD-TV",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, MeTV, Independent",
+    "tv_virtual_channel": "13",
+    "facility_id": "48663"
+  },
+  {
+    "callsign": "WECT",
+    "community_served_city": "WILMINGTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "48666"
+  },
+  {
+    "callsign": "WJTV",
+    "community_served_city": "JACKSON",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "48667"
+  },
+  {
+    "callsign": "WHLT",
+    "community_served_city": "HATTIESBURG",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "48668"
+  },
+  {
+    "callsign": "WHNT-TV",
+    "community_served_city": "HUNTSVILLE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "48693"
+  },
+  {
+    "callsign": "WPWR-TV",
+    "community_served_city": "GARY",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX PLUS/MY NETWORK",
+    "tv_virtual_channel": "50",
+    "facility_id": "48772"
+  },
+  {
+    "callsign": "WUVG-DT",
+    "community_served_city": "ATHENS",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "UNIVISION",
+    "tv_virtual_channel": "34",
+    "facility_id": "48813"
+  },
+  {
+    "callsign": "KCRP-CD",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "41",
+    "facility_id": "48833"
+  },
+  {
+    "callsign": "KXLK-CD",
+    "community_served_city": "AUSTIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "40",
+    "facility_id": "48836"
+  },
+  {
+    "callsign": "KCOR-CD",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "34",
+    "facility_id": "48837"
+  },
+  {
+    "callsign": "KNOE-TV",
+    "community_served_city": "MONROE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "48975"
+  },
+  {
+    "callsign": "KRDK-TV",
+    "community_served_city": "VALLEY CITY",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "49134"
+  },
+  {
+    "callsign": "KTLN-TV",
+    "community_served_city": "PALO ALTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Heroes & Icons",
+    "tv_virtual_channel": "68",
+    "facility_id": "49153"
+  },
+  {
+    "callsign": "WCCB",
+    "community_served_city": "CHARLOTTE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "The CW (primary channel); MeTV (subchannel)",
+    "tv_virtual_channel": "18",
+    "facility_id": "49157"
+  },
+  {
+    "callsign": "WDGA-CD",
+    "community_served_city": "DALTON",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "43",
+    "facility_id": "49235"
+  },
+  {
+    "callsign": "WDNN-CD",
+    "community_served_city": "CHATTANOOGA",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "49",
+    "facility_id": "49236"
+  },
+  {
+    "callsign": "KFFV",
+    "community_served_city": "SEATTLE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "44",
+    "facility_id": "49264"
+  },
+  {
+    "callsign": "KNOP-TV",
+    "community_served_city": "NORTH PLATTE",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/FOX/ION/Outlaw/The 365",
+    "tv_virtual_channel": "2",
+    "facility_id": "49273"
+  },
+  {
+    "callsign": "KERA-TV",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "49324"
+  },
+  {
+    "callsign": "KDTN",
+    "community_served_city": "DENTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "2",
+    "facility_id": "49326"
+  },
+  {
+    "callsign": "KXAS-TV",
+    "community_served_city": "FORT WORTH",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "49330"
+  },
+  {
+    "callsign": "KTKA-TV",
+    "community_served_city": "TOPEKA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC -CW Plus",
+    "tv_virtual_channel": "49",
+    "facility_id": "49397"
+  },
+  {
+    "callsign": "WEAO",
+    "community_served_city": "AKRON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "49",
+    "facility_id": "49421"
+  },
+  {
+    "callsign": "WNEO",
+    "community_served_city": "ALLIANCE",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "45",
+    "facility_id": "49439"
+  },
+  {
+    "callsign": "KAWE",
+    "community_served_city": "BEMIDJI",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "49578"
+  },
+  {
+    "callsign": "KAWB",
+    "community_served_city": "BRAINERD",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "49579"
+  },
+  {
+    "callsign": "KTVF",
+    "community_served_city": "FAIRBANKS",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "49621"
+  },
+  {
+    "callsign": "KTVA",
+    "community_served_city": "ANCHORAGE",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "Rewind TV",
+    "tv_virtual_channel": "11",
+    "facility_id": "49632"
+  },
+  {
+    "callsign": "WJFW-TV",
+    "community_served_city": "RHINELANDER",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "12",
+    "facility_id": "49699"
+  },
+  {
+    "callsign": "WSEE-TV",
+    "community_served_city": "ERIE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, The CW",
+    "tv_virtual_channel": "35",
+    "facility_id": "49711"
+  },
+  {
+    "callsign": "WAPT",
+    "community_served_city": "JACKSON",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "16",
+    "facility_id": "49712"
+  },
+  {
+    "callsign": "WZZM",
+    "community_served_city": "GRAND RAPIDS",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "49713"
+  },
+  {
+    "callsign": "KCBY-TV",
+    "community_served_city": "COOS BAY",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "49750"
+  },
+  {
+    "callsign": "KBOI-TV",
+    "community_served_city": "BOISE",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "49760"
+  },
+  {
+    "callsign": "KVAL-TV",
+    "community_served_city": "EUGENE",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "49766"
+  },
+  {
+    "callsign": "WYIN",
+    "community_served_city": "GARY",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "56",
+    "facility_id": "49803"
+  },
+  {
+    "callsign": "KVIA-TV",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "49832"
+  },
+  {
+    "callsign": "KPBT-TV",
+    "community_served_city": "ODESSA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "50044"
+  },
+  {
+    "callsign": "WPXQ-TV",
+    "community_served_city": "NEWPORT",
+    "community_served_state": "RI",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Laff, SCRIPPS News, Bounce, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "69",
+    "facility_id": "50063"
+  },
+  {
+    "callsign": "WOUC-TV",
+    "community_served_city": "CAMBRIDGE",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "44",
+    "facility_id": "50141"
+  },
+  {
+    "callsign": "WOUB-TV",
+    "community_served_city": "ATHENS",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "50147"
+  },
+  {
+    "callsign": "KOCB",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "34",
+    "facility_id": "50170"
+  },
+  {
+    "callsign": "KAUT-TV",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "43",
+    "facility_id": "50182"
+  },
+  {
+    "callsign": "KWET",
+    "community_served_city": "CHEYENNE",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "50194"
+  },
+  {
+    "callsign": "KOET",
+    "community_served_city": "EUFAULA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "50198"
+  },
+  {
+    "callsign": "KETA-TV",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "50205"
+  },
+  {
+    "callsign": "WZDC-CD",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "44",
+    "facility_id": "50347"
+  },
+  {
+    "callsign": "KOAB-TV",
+    "community_served_city": "BEND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "50588"
+  },
+  {
+    "callsign": "KOPB-TV",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "50589"
+  },
+  {
+    "callsign": "KOAC-TV",
+    "community_served_city": "CORVALLIS",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "50590"
+  },
+  {
+    "callsign": "KEPB-TV",
+    "community_served_city": "EUGENE",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "28",
+    "facility_id": "50591"
+  },
+  {
+    "callsign": "KTVR",
+    "community_served_city": "LA GRANDE",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "50592"
+  },
+  {
+    "callsign": "KPTV",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "FOX (D1), COZI TV (D2), DABL (D3), OXYGEN (D4)",
+    "tv_virtual_channel": "12",
+    "facility_id": "50633"
+  },
+  {
+    "callsign": "WJAR",
+    "community_served_city": "PROVIDENCE",
+    "community_served_state": "RI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "50780"
+  },
+  {
+    "callsign": "WCMH-TV",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "50781"
+  },
+  {
+    "callsign": "WNCN",
+    "community_served_city": "GOLDSBORO",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "17",
+    "facility_id": "50782"
+  },
+  {
+    "callsign": "KOZJ",
+    "community_served_city": "JOPLIN",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "51101"
+  },
+  {
+    "callsign": "KOZK",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "51102"
+  },
+  {
+    "callsign": "WXIA-TV",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "51163"
+  },
+  {
+    "callsign": "KOFY-TV",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Merit Street, Grit, PosiTV",
+    "tv_virtual_channel": "20",
+    "facility_id": "51189"
+  },
+  {
+    "callsign": "KDFX-CD",
+    "community_served_city": "INDIO/PALM SPRINGS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "33",
+    "facility_id": "51207"
+  },
+  {
+    "callsign": "KECY-TV",
+    "community_served_city": "EL CENTRO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX/ABC/CW/TELEMUNDO/NOSEY/CONFESS",
+    "tv_virtual_channel": "9",
+    "facility_id": "51208"
+  },
+  {
+    "callsign": "KUAM-TV",
+    "community_served_city": "HAGATNA",
+    "community_served_state": "GU",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "51233"
+  },
+  {
+    "callsign": "KALO",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "38",
+    "facility_id": "51241"
+  },
+  {
+    "callsign": "WBEC-TV",
+    "community_served_city": "BOCA RATON",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "63",
+    "facility_id": "51349"
+  },
+  {
+    "callsign": "K09YZ-D",
+    "community_served_city": "BEEVILLE-REFUGIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo, Independent",
+    "tv_virtual_channel": "9",
+    "facility_id": "51373"
+  },
+  {
+    "callsign": "K31KK-D",
+    "community_served_city": "KINGSVILLE-ALICE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo, Independent",
+    "tv_virtual_channel": "20",
+    "facility_id": "51374"
+  },
+  {
+    "callsign": "K22JA-D",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo, Independent",
+    "tv_virtual_channel": "47",
+    "facility_id": "51375"
+  },
+  {
+    "callsign": "KFSF-DT",
+    "community_served_city": "VALLEJO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "66",
+    "facility_id": "51429"
+  },
+  {
+    "callsign": "KFDA-TV",
+    "community_served_city": "AMARILLO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "51466"
+  },
+  {
+    "callsign": "KZBZ-CD",
+    "community_served_city": "CLOVIS",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "26",
+    "facility_id": "51469"
+  },
+  {
+    "callsign": "KLDO-TV",
+    "community_served_city": "LAREDO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "27",
+    "facility_id": "51479"
+  },
+  {
+    "callsign": "KMPH-TV",
+    "community_served_city": "VISALIA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "26",
+    "facility_id": "51488"
+  },
+  {
+    "callsign": "KPTM",
+    "community_served_city": "OMAHA",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "KPTM D1 - FOX; KPTM D2 - DABL/MyNet; KPTM D3 - The CW; KPTM D4 - Comet",
+    "tv_virtual_channel": "42",
+    "facility_id": "51491"
+  },
+  {
+    "callsign": "KREN-TV",
+    "community_served_city": "RENO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "27",
+    "facility_id": "51493"
+  },
+  {
+    "callsign": "KMAX-TV",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "31",
+    "facility_id": "51499"
+  },
+  {
+    "callsign": "KBFX-CD",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "58",
+    "facility_id": "51501"
+  },
+  {
+    "callsign": "KCWI-TV",
+    "community_served_city": "AMES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "23",
+    "facility_id": "51502"
+  },
+  {
+    "callsign": "KTXA",
+    "community_served_city": "FORT WORTH",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "21",
+    "facility_id": "51517"
+  },
+  {
+    "callsign": "KMYS",
+    "community_served_city": "KERRVILLE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "DABL",
+    "tv_virtual_channel": "35",
+    "facility_id": "51518"
+  },
+  {
+    "callsign": "WDCA",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "MNT",
+    "tv_virtual_channel": "20",
+    "facility_id": "51567"
+  },
+  {
+    "callsign": "WTXF-TV",
+    "community_served_city": "PHILADELPHIA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "29",
+    "facility_id": "51568"
+  },
+  {
+    "callsign": "KTXH",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MY NET",
+    "tv_virtual_channel": "20",
+    "facility_id": "51569"
+  },
+  {
+    "callsign": "WKBD-TV",
+    "community_served_city": "DETROIT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "50",
+    "facility_id": "51570"
+  },
+  {
+    "callsign": "WTVQ-DT",
+    "community_served_city": "LEXINGTON",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "36",
+    "facility_id": "51597"
+  },
+  {
+    "callsign": "KALB-TV",
+    "community_served_city": "ALEXANDRIA",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "KALB/NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "51598"
+  },
+  {
+    "callsign": "KEVC-CD",
+    "community_served_city": "INDIO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "5",
+    "facility_id": "51656"
+  },
+  {
+    "callsign": "KINT-TV",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "26",
+    "facility_id": "51708"
+  },
+  {
+    "callsign": "WNEU",
+    "community_served_city": "MERRIMACK",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "60",
+    "facility_id": "51864"
+  },
+  {
+    "callsign": "WMNT-CD",
+    "community_served_city": "TOLEDO",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "My Network TV",
+    "tv_virtual_channel": "48",
+    "facility_id": "51913"
+  },
+  {
+    "callsign": "KKPM-CD",
+    "community_served_city": "YUBA CITY",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "28",
+    "facility_id": "51930"
+  },
+  {
+    "callsign": "WPXA-TV",
+    "community_served_city": "ROME",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Laff, Mystery, IONPlus, SCRIPPS News, Jewelry TV, HSN",
+    "tv_virtual_channel": "14",
+    "facility_id": "51969"
+  },
+  {
+    "callsign": "WHPX-TV",
+    "community_served_city": "NEW LONDON",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "26",
+    "facility_id": "51980"
+  },
+  {
+    "callsign": "WPPX-TV",
+    "community_served_city": "WILMINGTON",
+    "community_served_state": "DE",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Laff, IONPlus, SCRIPPS News, Jewelry TV, QVC, HSN",
+    "tv_virtual_channel": "61",
+    "facility_id": "51984"
+  },
+  {
+    "callsign": "WPBF",
+    "community_served_city": "TEQUESTA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "25",
+    "facility_id": "51988"
+  },
+  {
+    "callsign": "WPSD-TV",
+    "community_served_city": "PADUCAH",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "51991"
+  },
+  {
+    "callsign": "KMLU",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV, Heroes & Icons, Movies, Start TV,  MeTV Toons,",
+    "tv_virtual_channel": "11",
+    "facility_id": "52046"
+  },
+  {
+    "callsign": "WAPA-TV",
+    "community_served_city": "SAN JUAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "52073"
+  },
+  {
+    "callsign": "WQMY",
+    "community_served_city": "WILLIAMSPORT",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "53",
+    "facility_id": "52075"
+  },
+  {
+    "callsign": "WTVK",
+    "community_served_city": "OSWEGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "59",
+    "facility_id": "52280"
+  },
+  {
+    "callsign": "WQRF-TV",
+    "community_served_city": "ROCKFORD",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "39",
+    "facility_id": "52408"
+  },
+  {
+    "callsign": "WPEC",
+    "community_served_city": "WEST PALM BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "52527"
+  },
+  {
+    "callsign": "KRDO-TV",
+    "community_served_city": "COLORADO SPRINGS",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "52579"
+  },
+  {
+    "callsign": "KLML",
+    "community_served_city": "GRAND JUNCTION",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "Court TV",
+    "tv_virtual_channel": "20",
+    "facility_id": "52593"
+  },
+  {
+    "callsign": "WPXK-TV",
+    "community_served_city": "JELLICO",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Laff, Mystery, SCRIPPS News, Jewelry TV, QVC, HSN, QVC2",
+    "tv_virtual_channel": "54",
+    "facility_id": "52628"
+  },
+  {
+    "callsign": "KCNZ-CD",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "LATV",
+    "tv_virtual_channel": "28",
+    "facility_id": "52887"
+  },
+  {
+    "callsign": "KDJT-CD",
+    "community_served_city": "SALINAS/MONTEREY,ETC",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "UNIMAS",
+    "tv_virtual_channel": "33",
+    "facility_id": "52888"
+  },
+  {
+    "callsign": "KEZT-CD",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "23",
+    "facility_id": "52891"
+  },
+  {
+    "callsign": "KLAX-TV",
+    "community_served_city": "ALEXANDRIA",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV and ION",
+    "tv_virtual_channel": "31",
+    "facility_id": "52907"
+  },
+  {
+    "callsign": "KSPX-TV",
+    "community_served_city": "SACRAMENTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Laff, Bounce, IONPlus, SCRIPPS News, Jewelry TV, HSN, HSN2",
+    "tv_virtual_channel": "29",
+    "facility_id": "52953"
+  },
+  {
+    "callsign": "KFTU-CD",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "34",
+    "facility_id": "53004"
+  },
+  {
+    "callsign": "WPXT",
+    "community_served_city": "PORTLAND",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "Maine's CW",
+    "tv_virtual_channel": "51",
+    "facility_id": "53065"
+  },
+  {
+    "callsign": "WPLG",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "10",
+    "facility_id": "53113"
+  },
+  {
+    "callsign": "WDIV-TV",
+    "community_served_city": "DETROIT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "53114"
+  },
+  {
+    "callsign": "WFSB",
+    "community_served_city": "HARTFORD",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "CBS (DT1 & DT4); ION MYSTERY (DT2); LAFF TV (DT3); WWAX (DT4)",
+    "tv_virtual_channel": "3",
+    "facility_id": "53115"
+  },
+  {
+    "callsign": "WJXT",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "53116"
+  },
+  {
+    "callsign": "KPRC-TV",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "53117"
+  },
+  {
+    "callsign": "KSAT-TV",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "53118"
+  },
+  {
+    "callsign": "KSRE",
+    "community_served_city": "MINOT",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "53313"
+  },
+  {
+    "callsign": "KJRE",
+    "community_served_city": "ELLENDALE",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "53315"
+  },
+  {
+    "callsign": "KWSE",
+    "community_served_city": "WILLISTON",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "53318"
+  },
+  {
+    "callsign": "KGFE",
+    "community_served_city": "GRAND FORKS",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "53320"
+  },
+  {
+    "callsign": "KFME",
+    "community_served_city": "FARGO",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "53321"
+  },
+  {
+    "callsign": "KBME-TV",
+    "community_served_city": "BISMARCK",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "53324"
+  },
+  {
+    "callsign": "KDSE",
+    "community_served_city": "DICKINSON",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "53329"
+  },
+  {
+    "callsign": "KIEM-TV",
+    "community_served_city": "EUREKA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC: ION",
+    "tv_virtual_channel": "3",
+    "facility_id": "53382"
+  },
+  {
+    "callsign": "WKCF",
+    "community_served_city": "CLERMONT",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CW, ESTRELLA, TRUE CRIME NETWORK",
+    "tv_virtual_channel": "18",
+    "facility_id": "53465"
+  },
+  {
+    "callsign": "WXXV-TV",
+    "community_served_city": "GULFPORT",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "FOX; NBC; CW",
+    "tv_virtual_channel": "25",
+    "facility_id": "53517"
+  },
+  {
+    "callsign": "KRPV-DT",
+    "community_served_city": "ROSWELL",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "27",
+    "facility_id": "53539"
+  },
+  {
+    "callsign": "KMLM-DT",
+    "community_served_city": "ODESSA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "42",
+    "facility_id": "53541"
+  },
+  {
+    "callsign": "KPTB-DT",
+    "community_served_city": "LUBBOCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "16",
+    "facility_id": "53544"
+  },
+  {
+    "callsign": "KBCB",
+    "community_served_city": "BELLINGHAM",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "24",
+    "facility_id": "53586"
+  },
+  {
+    "callsign": "WQLN",
+    "community_served_city": "ERIE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "54",
+    "facility_id": "53716"
+  },
+  {
+    "callsign": "WCNY-TV",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "53734"
+  },
+  {
+    "callsign": "WMOR-TV",
+    "community_served_city": "LAKELAND",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "32",
+    "facility_id": "53819"
+  },
+  {
+    "callsign": "KYOU-TV",
+    "community_served_city": "OTTUMWA",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, NBC, CW",
+    "tv_virtual_channel": "15",
+    "facility_id": "53820"
+  },
+  {
+    "callsign": "KCPT",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "53843"
+  },
+  {
+    "callsign": "KXLN-DT",
+    "community_served_city": "ROSENBERG",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "45",
+    "facility_id": "53847"
+  },
+  {
+    "callsign": "WIPR-TV",
+    "community_served_city": "SAN JUAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "53859"
+  },
+  {
+    "callsign": "WIPM-TV",
+    "community_served_city": "MAYAGUEZ",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "3",
+    "facility_id": "53863"
+  },
+  {
+    "callsign": "KETV",
+    "community_served_city": "OMAHA",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Me-TV",
+    "tv_virtual_channel": "7",
+    "facility_id": "53903"
+  },
+  {
+    "callsign": "WYFF",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "53905"
+  },
+  {
+    "callsign": "DKOCT",
+    "community_served_city": "CARLSBAD",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "53908"
+  },
+  {
+    "callsign": "DKOVT",
+    "community_served_city": "SILVER CITY",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "10",
+    "facility_id": "53911"
+  },
+  {
+    "callsign": "WXII-TV",
+    "community_served_city": "WINSTON-SALEM",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/MeTV/Story",
+    "tv_virtual_channel": "12",
+    "facility_id": "53921"
+  },
+  {
+    "callsign": "KOAT-TV",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, True Crime Network",
+    "tv_virtual_channel": "7",
+    "facility_id": "53928"
+  },
+  {
+    "callsign": "WGAL",
+    "community_served_city": "LANCASTER",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "53930"
+  },
+  {
+    "callsign": "WLKY",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, MeTV",
+    "tv_virtual_channel": "32",
+    "facility_id": "53939"
+  },
+  {
+    "callsign": "KLJB",
+    "community_served_city": "DAVENPORT",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "18",
+    "facility_id": "54011"
+  },
+  {
+    "callsign": "WKBW-TV",
+    "community_served_city": "BUFFALO",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "54176"
+  },
+  {
+    "callsign": "WGEM-TV",
+    "community_served_city": "QUINCY",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "54275"
+  },
+  {
+    "callsign": "WNOL-TV",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "38",
+    "facility_id": "54280"
+  },
+  {
+    "callsign": "WDEF-TV",
+    "community_served_city": "CHATTANOOGA",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "54385"
+  },
+  {
+    "callsign": "KMYT-TV",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "MY (41.1), Cozi TV (41.2), Start TV (41.3), Heroes & Icons (41.4), MeTV Toons (41.5)",
+    "tv_virtual_channel": "41",
+    "facility_id": "54420"
+  },
+  {
+    "callsign": "WRFB",
+    "community_served_city": "CAROLINA",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "52",
+    "facility_id": "54443"
+  },
+  {
+    "callsign": "WLXI",
+    "community_served_city": "GREENSBORO",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "61",
+    "facility_id": "54452"
+  },
+  {
+    "callsign": "WPGA-TV",
+    "community_served_city": "PERRY",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "58",
+    "facility_id": "54728"
+  },
+  {
+    "callsign": "WAWD",
+    "community_served_city": "FORT WALTON BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "58",
+    "facility_id": "54938"
+  },
+  {
+    "callsign": "WRBW",
+    "community_served_city": "ORLANDO",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "MYNET",
+    "tv_virtual_channel": "65",
+    "facility_id": "54940"
+  },
+  {
+    "callsign": "WRDC",
+    "community_served_city": "DURHAM",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "My Network",
+    "tv_virtual_channel": "28",
+    "facility_id": "54963"
+  },
+  {
+    "callsign": "KJTV-TV",
+    "community_served_city": "LUBBOCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "34",
+    "facility_id": "55031"
+  },
+  {
+    "callsign": "KASY-TV",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "50",
+    "facility_id": "55049"
+  },
+  {
+    "callsign": "KXTQ-CD",
+    "community_served_city": "LUBBOCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "46",
+    "facility_id": "55055"
+  },
+  {
+    "callsign": "KTEL-CD",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "47",
+    "facility_id": "55056"
+  },
+  {
+    "callsign": "KXLA",
+    "community_served_city": "RANCHO PALOS VERDES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "44",
+    "facility_id": "55083"
+  },
+  {
+    "callsign": "WARP-CD",
+    "community_served_city": "TAMPA-ST. PETERSBURG",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "20",
+    "facility_id": "55106"
+  },
+  {
+    "callsign": "WTVE",
+    "community_served_city": "WILLOW GROVE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "IND 1/1/24 - 6/30/24, SHOP LC 7/1/24 - 12/31/24",
+    "tv_virtual_channel": "51",
+    "facility_id": "55305"
+  },
+  {
+    "callsign": "WLYH",
+    "community_served_city": "RED LION",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "49",
+    "facility_id": "55350"
+  },
+  {
+    "callsign": "KNRR",
+    "community_served_city": "PEMBINA",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "12",
+    "facility_id": "55362"
+  },
+  {
+    "callsign": "KJRR",
+    "community_served_city": "JAMESTOWN",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "7",
+    "facility_id": "55364"
+  },
+  {
+    "callsign": "KBRR",
+    "community_served_city": "THIEF RIVER FALLS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "10",
+    "facility_id": "55370"
+  },
+  {
+    "callsign": "KVRR",
+    "community_served_city": "FARGO",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "15",
+    "facility_id": "55372"
+  },
+  {
+    "callsign": "KDLV-TV",
+    "community_served_city": "MITCHELL",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/ABC/FOX",
+    "tv_virtual_channel": "5",
+    "facility_id": "55375"
+  },
+  {
+    "callsign": "KDLT-TV",
+    "community_served_city": "SIOUX FALLS",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/ANTENNA/FOX/COZI & COURT TV",
+    "tv_virtual_channel": "46",
+    "facility_id": "55379"
+  },
+  {
+    "callsign": "KEET",
+    "community_served_city": "EUREKA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "55435"
+  },
+  {
+    "callsign": "WRDQ",
+    "community_served_city": "ORLANDO",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent, Court TV, Telemundo, HSN",
+    "tv_virtual_channel": "27",
+    "facility_id": "55454"
+  },
+  {
+    "callsign": "KRWG-TV",
+    "community_served_city": "LAS CRUCES",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "55516"
+  },
+  {
+    "callsign": "KNME-TV",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "55528"
+  },
+  {
+    "callsign": "KETK-TV",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "56",
+    "facility_id": "55643"
+  },
+  {
+    "callsign": "KYTX",
+    "community_served_city": "NACOGDOCHES",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "55644"
+  },
+  {
+    "callsign": "KXMD-TV",
+    "community_served_city": "WILLISTON",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "11",
+    "facility_id": "55683"
+  },
+  {
+    "callsign": "KXMA-TV",
+    "community_served_city": "DICKINSON",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "2",
+    "facility_id": "55684"
+  },
+  {
+    "callsign": "KXMC-TV",
+    "community_served_city": "MINOT",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "13",
+    "facility_id": "55685"
+  },
+  {
+    "callsign": "KXMB-TV",
+    "community_served_city": "BISMARCK",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "12",
+    "facility_id": "55686"
+  },
+  {
+    "callsign": "KYVV-TV",
+    "community_served_city": "DEL RIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Merit Street",
+    "tv_virtual_channel": "10",
+    "facility_id": "55762"
+  },
+  {
+    "callsign": "KTVZ",
+    "community_served_city": "BEND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, FOX, CW",
+    "tv_virtual_channel": "21",
+    "facility_id": "55907"
+  },
+  {
+    "callsign": "KIDK",
+    "community_served_city": "IDAHO FALLS",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "DABL",
+    "tv_virtual_channel": "3",
+    "facility_id": "56028"
+  },
+  {
+    "callsign": "KEPR-TV",
+    "community_served_city": "PASCO",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "56029"
+  },
+  {
+    "callsign": "KLEW-TV",
+    "community_served_city": "LEWISTON",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "56032"
+  },
+  {
+    "callsign": "KIMA-TV",
+    "community_served_city": "YAKIMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "56033"
+  },
+  {
+    "callsign": "KGPE",
+    "community_served_city": "FRESNO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "47",
+    "facility_id": "56034"
+  },
+  {
+    "callsign": "KFXV",
+    "community_served_city": "HARLINGEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "60",
+    "facility_id": "56079"
+  },
+  {
+    "callsign": "WSBE-TV",
+    "community_served_city": "PROVIDENCE",
+    "community_served_state": "RI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "56092"
+  },
+  {
+    "callsign": "KWHY",
+    "community_served_city": "GARDEN GROVE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "63",
+    "facility_id": "56384"
+  },
+  {
+    "callsign": "WTTV",
+    "community_served_city": "BLOOMINGTON",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "56523"
+  },
+  {
+    "callsign": "KDNL-TV",
+    "community_served_city": "ST. LOUIS",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "30",
+    "facility_id": "56524"
+  },
+  {
+    "callsign": "WTTK",
+    "community_served_city": "KOKOMO",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "29",
+    "facility_id": "56526"
+  },
+  {
+    "callsign": "KDSM-TV",
+    "community_served_city": "DES MOINES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "17",
+    "facility_id": "56527"
+  },
+  {
+    "callsign": "KABB",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "29",
+    "facility_id": "56528"
+  },
+  {
+    "callsign": "WLOS",
+    "community_served_city": "ASHEVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "56537"
+  },
+  {
+    "callsign": "WMYA-TV",
+    "community_served_city": "ANDERSON",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "DABL",
+    "tv_virtual_channel": "40",
+    "facility_id": "56548"
+  },
+  {
+    "callsign": "WSYX",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "56549"
+  },
+  {
+    "callsign": "KOVR",
+    "community_served_city": "STOCKTON",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "56550"
+  },
+  {
+    "callsign": "WGWW",
+    "community_served_city": "ANNISTON",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "Heroes and Icons",
+    "tv_virtual_channel": "40",
+    "facility_id": "56642"
+  },
+  {
+    "callsign": "KWPX-TV",
+    "community_served_city": "BELLEVUE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Bounce, Grit, IONPlus, SCRIPPS News, Jewelry TV, QVC",
+    "tv_virtual_channel": "33",
+    "facility_id": "56852"
+  },
+  {
+    "callsign": "KCEC",
+    "community_served_city": "BOULDER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "14",
+    "facility_id": "57219"
+  },
+  {
+    "callsign": "KLUZ-TV",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "14",
+    "facility_id": "57220"
+  },
+  {
+    "callsign": "WRBU",
+    "community_served_city": "EAST ST. LOUIS",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Laff, IONPlus, SCRIPPS News, JewelryTV, QVC, HSN",
+    "tv_virtual_channel": "46",
+    "facility_id": "57221"
+  },
+  {
+    "callsign": "WXXI-TV",
+    "community_served_city": "ROCHESTER",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "57274"
+  },
+  {
+    "callsign": "WAAY-TV",
+    "community_served_city": "HUNTSVILLE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "31",
+    "facility_id": "57292"
+  },
+  {
+    "callsign": "KRSU-TV",
+    "community_served_city": "CLAREMORE",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "35",
+    "facility_id": "57431"
+  },
+  {
+    "callsign": "KTLD-CD",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "3 ANGELS BROADCASTING NETWORK",
+    "tv_virtual_channel": "8",
+    "facility_id": "57456"
+  },
+  {
+    "callsign": "K17JI-D",
+    "community_served_city": "FRESNO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "3 ANGELS BROADCASTING NETWORK",
+    "tv_virtual_channel": "12",
+    "facility_id": "57457"
+  },
+  {
+    "callsign": "WPTZ",
+    "community_served_city": "PLATTSBURGH",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "57476"
+  },
+  {
+    "callsign": "KKYK-CD",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "30",
+    "facility_id": "57548"
+  },
+  {
+    "callsign": "WJHL-TV",
+    "community_served_city": "JOHNSON CITY",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS/ABC TRICITIES",
+    "tv_virtual_channel": "11",
+    "facility_id": "57826"
+  },
+  {
+    "callsign": "WTVR-TV",
+    "community_served_city": "RICHMOND",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, Antenna TV, Court TV, ION Television, Newsy, HSN",
+    "tv_virtual_channel": "6",
+    "facility_id": "57832"
+  },
+  {
+    "callsign": "WUTR",
+    "community_served_city": "UTICA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "20",
+    "facility_id": "57837"
+  },
+  {
+    "callsign": "WNCT-TV",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "57838"
+  },
+  {
+    "callsign": "WSLS-TV",
+    "community_served_city": "ROANOKE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "57840"
+  },
+  {
+    "callsign": "KUPX-TV",
+    "community_served_city": "PROVO",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "16",
+    "facility_id": "57884"
+  },
+  {
+    "callsign": "KRCB",
+    "community_served_city": "COTATI",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "57945"
+  },
+  {
+    "callsign": "WGXA",
+    "community_served_city": "MACON",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "WGXA D1 - FOX; WGXA D2 - ABC; WGXA D3 - Comet",
+    "tv_virtual_channel": "24",
+    "facility_id": "58262"
+  },
+  {
+    "callsign": "KKAP",
+    "community_served_city": "LITTLE ROCK",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "36",
+    "facility_id": "58267"
+  },
+  {
+    "callsign": "WJPX",
+    "community_served_city": "SAN JUAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "24",
+    "facility_id": "58340"
+  },
+  {
+    "callsign": "WKPV",
+    "community_served_city": "PONCE",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "20",
+    "facility_id": "58341"
+  },
+  {
+    "callsign": "WJWN-TV",
+    "community_served_city": "SAN SEBASTIAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "38",
+    "facility_id": "58342"
+  },
+  {
+    "callsign": "KEDT",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "16",
+    "facility_id": "58408"
+  },
+  {
+    "callsign": "KOAM-TV",
+    "community_served_city": "PITTSBURG",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, FOX, MeTV, and Heroes & Icons",
+    "tv_virtual_channel": "7",
+    "facility_id": "58552"
+  },
+  {
+    "callsign": "KIDY",
+    "community_served_city": "SAN ANGELO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "6",
+    "facility_id": "58560"
+  },
+  {
+    "callsign": "KCVU",
+    "community_served_city": "PARADISE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "30",
+    "facility_id": "58605"
+  },
+  {
+    "callsign": "KGMC",
+    "community_served_city": "MERCED",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Estrella TV",
+    "tv_virtual_channel": "43",
+    "facility_id": "58608"
+  },
+  {
+    "callsign": "KUVS-DT",
+    "community_served_city": "MODESTO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "19",
+    "facility_id": "58609"
+  },
+  {
+    "callsign": "KBVU",
+    "community_served_city": "EUREKA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "29",
+    "facility_id": "58618"
+  },
+  {
+    "callsign": "KAYU-TV",
+    "community_served_city": "SPOKANE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, Antenna TV,",
+    "tv_virtual_channel": "28",
+    "facility_id": "58684"
+  },
+  {
+    "callsign": "DWNYS-TV",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "MYTV",
+    "tv_virtual_channel": "43",
+    "facility_id": "58725"
+  },
+  {
+    "callsign": "KVCR-DT",
+    "community_served_city": "SAN BERNARDINO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "58795"
+  },
+  {
+    "callsign": "KSWB-TV",
+    "community_served_city": "SAN DIEGO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "69",
+    "facility_id": "58827"
+  },
+  {
+    "callsign": "KPXB-TV",
+    "community_served_city": "CONROE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Laff, IONPlus, SCRIPPS News, Jewelry TV, CourtTV, Grit",
+    "tv_virtual_channel": "49",
+    "facility_id": "58835"
+  },
+  {
+    "callsign": "KPJK",
+    "community_served_city": "SAN MATEO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "60",
+    "facility_id": "58912"
+  },
+  {
+    "callsign": "KSKT-CD",
+    "community_served_city": "SAN MARCOS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "43",
+    "facility_id": "58927"
+  },
+  {
+    "callsign": "KPXN-TV",
+    "community_served_city": "SAN BERNARDINO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, IONPlus, Laff, Bounce, Jewelry TV, HSN",
+    "tv_virtual_channel": "30",
+    "facility_id": "58978"
+  },
+  {
+    "callsign": "KFRE-TV",
+    "community_served_city": "SANGER",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "59",
+    "facility_id": "59013"
+  },
+  {
+    "callsign": "KOAA-TV",
+    "community_served_city": "PUEBLO",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "59014"
+  },
+  {
+    "callsign": "WRCB",
+    "community_served_city": "CHATTANOOGA",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "59137"
+  },
+  {
+    "callsign": "KTVN",
+    "community_served_city": "RENO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "59139"
+  },
+  {
+    "callsign": "KIVI-TV",
+    "community_served_city": "NAMPA",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "59255"
+  },
+  {
+    "callsign": "WGTQ",
+    "community_served_city": "SAULT STE. MARIE",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "59279"
+  },
+  {
+    "callsign": "WGTU",
+    "community_served_city": "TRAVERSE CITY",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "29",
+    "facility_id": "59280"
+  },
+  {
+    "callsign": "WBUP",
+    "community_served_city": "ISHPEMING",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "10",
+    "facility_id": "59281"
+  },
+  {
+    "callsign": "KNIN-TV",
+    "community_served_city": "CALDWELL",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "9",
+    "facility_id": "59363"
+  },
+  {
+    "callsign": "WCPO-TV",
+    "community_served_city": "CINCINNATI",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "59438"
+  },
+  {
+    "callsign": "KJRH-TV",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "59439"
+  },
+  {
+    "callsign": "KNXV-TV",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "15",
+    "facility_id": "59440"
+  },
+  {
+    "callsign": "WEWS-TV",
+    "community_served_city": "CLEVELAND",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "5",
+    "facility_id": "59441"
+  },
+  {
+    "callsign": "WMAR-TV",
+    "community_served_city": "BALTIMORE",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "2",
+    "facility_id": "59442"
+  },
+  {
+    "callsign": "WPTV-TV",
+    "community_served_city": "WEST PALM BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "5",
+    "facility_id": "59443"
+  },
+  {
+    "callsign": "KSHB-TV",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "41",
+    "facility_id": "59444"
+  },
+  {
+    "callsign": "KCSG",
+    "community_served_city": "CEDAR CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "8",
+    "facility_id": "59494"
+  },
+  {
+    "callsign": "KTAB-TV",
+    "community_served_city": "ABILENE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "32",
+    "facility_id": "59988"
+  },
+  {
+    "callsign": "WACX",
+    "community_served_city": "LEESBURG",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "55",
+    "facility_id": "60018"
+  },
+  {
+    "callsign": "KHTV-CD",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV Plus",
+    "tv_virtual_channel": "48",
+    "facility_id": "60026"
+  },
+  {
+    "callsign": "WVPT",
+    "community_served_city": "STAUNTON",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "51",
+    "facility_id": "60111"
+  },
+  {
+    "callsign": "WJAN-CD",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "41",
+    "facility_id": "60165"
+  },
+  {
+    "callsign": "KRNV-DT",
+    "community_served_city": "RENO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "60307"
+  },
+  {
+    "callsign": "WSTE-DT",
+    "community_served_city": "PONCE",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "7",
+    "facility_id": "60341"
+  },
+  {
+    "callsign": "KHBS",
+    "community_served_city": "FORT SMITH",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, CW, MeTV",
+    "tv_virtual_channel": "40",
+    "facility_id": "60353"
+  },
+  {
+    "callsign": "KHOG-TV",
+    "community_served_city": "FAYETTEVILLE",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, CW, MeTV",
+    "tv_virtual_channel": "29",
+    "facility_id": "60354"
+  },
+  {
+    "callsign": "WOST",
+    "community_served_city": "MAYAGUEZ",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "CRTV NETWORK",
+    "tv_virtual_channel": "14",
+    "facility_id": "60357"
+  },
+  {
+    "callsign": "KYLE-TV",
+    "community_served_city": "BRYAN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetwork",
+    "tv_virtual_channel": "28",
+    "facility_id": "60384"
+  },
+  {
+    "callsign": "KVDF-CD",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "31",
+    "facility_id": "60464"
+  },
+  {
+    "callsign": "KTNL-TV",
+    "community_served_city": "SITKA",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "13",
+    "facility_id": "60519"
+  },
+  {
+    "callsign": "KUBD",
+    "community_served_city": "KETCHIKAN",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CBS, My Network,",
+    "tv_virtual_channel": "4",
+    "facility_id": "60520"
+  },
+  {
+    "callsign": "KSTR-DT",
+    "community_served_city": "IRVING",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "49",
+    "facility_id": "60534"
+  },
+  {
+    "callsign": "WAMI-DT",
+    "community_served_city": "HOLLYWOOD",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "UNIMAS",
+    "tv_virtual_channel": "69",
+    "facility_id": "60536"
+  },
+  {
+    "callsign": "KFTH-DT",
+    "community_served_city": "ALVIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "67",
+    "facility_id": "60537"
+  },
+  {
+    "callsign": "WXFT-DT",
+    "community_served_city": "AURORA",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "UniMas",
+    "tv_virtual_channel": "60",
+    "facility_id": "60539"
+  },
+  {
+    "callsign": "KFTR-DT",
+    "community_served_city": "ONTARIO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "46",
+    "facility_id": "60549"
+  },
+  {
+    "callsign": "WUNI",
+    "community_served_city": "MARLBOROUGH",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "66",
+    "facility_id": "60551"
+  },
+  {
+    "callsign": "WUTB",
+    "community_served_city": "BALTIMORE",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "TBD",
+    "tv_virtual_channel": "24",
+    "facility_id": "60552"
+  },
+  {
+    "callsign": "WFTY-DT",
+    "community_served_city": "SMITHTOWN",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "TRUE CRIME NETWORK",
+    "tv_virtual_channel": "67",
+    "facility_id": "60553"
+  },
+  {
+    "callsign": "WFUT-DT",
+    "community_served_city": "NEWARK",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "UNIMAS",
+    "tv_virtual_channel": "68",
+    "facility_id": "60555"
+  },
+  {
+    "callsign": "WQHS-DT",
+    "community_served_city": "CLEVELAND",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "61",
+    "facility_id": "60556"
+  },
+  {
+    "callsign": "WVEA-TV",
+    "community_served_city": "TAMPA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "50",
+    "facility_id": "60559"
+  },
+  {
+    "callsign": "WUVP-DT",
+    "community_served_city": "VINELAND",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "UNIVISION",
+    "tv_virtual_channel": "65",
+    "facility_id": "60560"
+  },
+  {
+    "callsign": "WIWN",
+    "community_served_city": "FOND DU LAC",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "Cozi TV",
+    "tv_virtual_channel": "68",
+    "facility_id": "60571"
+  },
+  {
+    "callsign": "KEYT-TV",
+    "community_served_city": "SANTA BARBARA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "3",
+    "facility_id": "60637"
+  },
+  {
+    "callsign": "KSBB-CD",
+    "community_served_city": "SANTA BARBARA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "MyNet",
+    "tv_virtual_channel": "17",
+    "facility_id": "60639"
+  },
+  {
+    "callsign": "WETM-TV",
+    "community_served_city": "ELMIRA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "18",
+    "facility_id": "60653"
+  },
+  {
+    "callsign": "WKTV",
+    "community_served_city": "UTICA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CBS,  METV",
+    "tv_virtual_channel": "2",
+    "facility_id": "60654"
+  },
+  {
+    "callsign": "KOOD",
+    "community_served_city": "HAYS",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "60675"
+  },
+  {
+    "callsign": "KSWK",
+    "community_served_city": "LAKIN",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "60683"
+  },
+  {
+    "callsign": "KCSD-TV",
+    "community_served_city": "SIOUX FALLS",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "60728"
+  },
+  {
+    "callsign": "KDRV",
+    "community_served_city": "MEDFORD",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "60736"
+  },
+  {
+    "callsign": "KDKF",
+    "community_served_city": "KLAMATH FALLS",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "31",
+    "facility_id": "60740"
+  },
+  {
+    "callsign": "KCHF",
+    "community_served_city": "SANTA FE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "11",
+    "facility_id": "60793"
+  },
+  {
+    "callsign": "KYNM-CD",
+    "community_served_city": "ALBUQUERQUE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "The Family Channel; JTV; NTD; Heartland TV; KCHF TV - Son Broadcasting Inc; IJN",
+    "tv_virtual_channel": "30",
+    "facility_id": "60795"
+  },
+  {
+    "callsign": "WPGD-TV",
+    "community_served_city": "HENDERSONVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "50",
+    "facility_id": "60820"
+  },
+  {
+    "callsign": "WELF-TV",
+    "community_served_city": "DALTON",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "23",
+    "facility_id": "60825"
+  },
+  {
+    "callsign": "WMPV-TV",
+    "community_served_city": "MOBILE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "21",
+    "facility_id": "60827"
+  },
+  {
+    "callsign": "WMCF-TV",
+    "community_served_city": "MONTGOMERY",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "45",
+    "facility_id": "60829"
+  },
+  {
+    "callsign": "WBUY-TV",
+    "community_served_city": "HOLLY SPRINGS",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "40",
+    "facility_id": "60830"
+  },
+  {
+    "callsign": "WBPH-TV",
+    "community_served_city": "BETHLEHEM",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "60",
+    "facility_id": "60850"
+  },
+  {
+    "callsign": "WNEH",
+    "community_served_city": "GREENWOOD",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "38",
+    "facility_id": "60931"
+  },
+  {
+    "callsign": "WOLO-TV",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, MeTV, H&I, QVC, Start-TV, DABL, HSN, Story TV, MeTV Toons",
+    "tv_virtual_channel": "25",
+    "facility_id": "60963"
+  },
+  {
+    "callsign": "WEBA-TV",
+    "community_served_city": "ALLENDALE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "14",
+    "facility_id": "61003"
+  },
+  {
+    "callsign": "WHMC",
+    "community_served_city": "CONWAY",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "23",
+    "facility_id": "61004"
+  },
+  {
+    "callsign": "WITV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "61005"
+  },
+  {
+    "callsign": "WJWJ-TV",
+    "community_served_city": "BEAUFORT",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "16",
+    "facility_id": "61007"
+  },
+  {
+    "callsign": "WJPM-TV",
+    "community_served_city": "FLORENCE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "33",
+    "facility_id": "61008"
+  },
+  {
+    "callsign": "WNSC-TV",
+    "community_served_city": "ROCK HILL",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "30",
+    "facility_id": "61009"
+  },
+  {
+    "callsign": "WNTV",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "61010"
+  },
+  {
+    "callsign": "WRET-TV",
+    "community_served_city": "SPARTANBURG",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "49",
+    "facility_id": "61011"
+  },
+  {
+    "callsign": "WRJA-TV",
+    "community_served_city": "SUMTER",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "61012"
+  },
+  {
+    "callsign": "WRLK-TV",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "35",
+    "facility_id": "61013"
+  },
+  {
+    "callsign": "KZSD-TV",
+    "community_served_city": "MARTIN",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "61062"
+  },
+  {
+    "callsign": "KQSD-TV",
+    "community_served_city": "LOWRY",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "61063"
+  },
+  {
+    "callsign": "KDSD-TV",
+    "community_served_city": "ABERDEEN",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "16",
+    "facility_id": "61064"
+  },
+  {
+    "callsign": "KTSD-TV",
+    "community_served_city": "PIERRE",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "61066"
+  },
+  {
+    "callsign": "KESD-TV",
+    "community_served_city": "BROOKINGS",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "61067"
+  },
+  {
+    "callsign": "KBHE-TV",
+    "community_served_city": "RAPID CITY",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "61068"
+  },
+  {
+    "callsign": "KPSD-TV",
+    "community_served_city": "EAGLE BUTTE",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "61071"
+  },
+  {
+    "callsign": "KUSD-TV",
+    "community_served_city": "VERMILLION",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "61072"
+  },
+  {
+    "callsign": "WXEL-TV",
+    "community_served_city": "BOYNTON BEACH",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "42",
+    "facility_id": "61084"
+  },
+  {
+    "callsign": "WMGM-TV",
+    "community_served_city": "WILDWOOD",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "TRUE CRIME NETWORK",
+    "tv_virtual_channel": "40",
+    "facility_id": "61111"
+  },
+  {
+    "callsign": "KPXL-TV",
+    "community_served_city": "UVALDE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Laff, Mystery, IONPlus, SCRIPPS News, Jewelry TV, HSN, HSN2",
+    "tv_virtual_channel": "26",
+    "facility_id": "61173"
+  },
+  {
+    "callsign": "KBTV-TV",
+    "community_served_city": "PORT ARTHUR",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "DABL",
+    "tv_virtual_channel": "4",
+    "facility_id": "61214"
+  },
+  {
+    "callsign": "WHIZ-TV",
+    "community_served_city": "ZANESVILLE",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "18",
+    "facility_id": "61216"
+  },
+  {
+    "callsign": "WNKY",
+    "community_served_city": "BOWLING GREEN",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "40",
+    "facility_id": "61217"
+  },
+  {
+    "callsign": "WWSB",
+    "community_served_city": "SARASOTA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "40",
+    "facility_id": "61251"
+  },
+  {
+    "callsign": "KFTS",
+    "community_served_city": "KLAMATH FALLS",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "61335"
+  },
+  {
+    "callsign": "KSYS",
+    "community_served_city": "MEDFORD",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "61350"
+  },
+  {
+    "callsign": "WXCW",
+    "community_served_city": "NAPLES",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "46",
+    "facility_id": "61504"
+  },
+  {
+    "callsign": "KPIC",
+    "community_served_city": "ROSEBURG",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "61551"
+  },
+  {
+    "callsign": "WVEO",
+    "community_served_city": "AGUADILLA",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "MegaTV",
+    "tv_virtual_channel": "18",
+    "facility_id": "61573"
+  },
+  {
+    "callsign": "KSPS-TV",
+    "community_served_city": "SPOKANE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "61956"
+  },
+  {
+    "callsign": "KVLY-TV",
+    "community_served_city": "FARGO",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "61961"
+  },
+  {
+    "callsign": "KXLY-TV",
+    "community_served_city": "SPOKANE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "4",
+    "facility_id": "61978"
+  },
+  {
+    "callsign": "WRSP-TV",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "55",
+    "facility_id": "62009"
+  },
+  {
+    "callsign": "WPBS-TV",
+    "community_served_city": "WATERTOWN",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "16",
+    "facility_id": "62136"
+  },
+  {
+    "callsign": "WNPI-DT",
+    "community_served_city": "NORWOOD",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "62137"
+  },
+  {
+    "callsign": "KETC",
+    "community_served_city": "ST. LOUIS",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ETV",
+    "tv_virtual_channel": "9",
+    "facility_id": "62182"
+  },
+  {
+    "callsign": "WIYC",
+    "community_served_city": "TROY",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "COZI",
+    "tv_virtual_channel": "67",
+    "facility_id": "62207"
+  },
+  {
+    "callsign": "WICZ-TV",
+    "community_served_city": "BINGHAMTON",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, MyNetwork, ION",
+    "tv_virtual_channel": "40",
+    "facility_id": "62210"
+  },
+  {
+    "callsign": "WYDC",
+    "community_served_city": "CORNING",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "48",
+    "facility_id": "62219"
+  },
+  {
+    "callsign": "KOBR",
+    "community_served_city": "ROSWELL",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "62272"
+  },
+  {
+    "callsign": "KXVA",
+    "community_served_city": "ABILENE",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "15",
+    "facility_id": "62293"
+  },
+  {
+    "callsign": "KTLM",
+    "community_served_city": "RIO GRANDE CITY",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "40",
+    "facility_id": "62354"
+  },
+  {
+    "callsign": "KUID-TV",
+    "community_served_city": "MOSCOW",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "62382"
+  },
+  {
+    "callsign": "WGCU",
+    "community_served_city": "FORT MYERS",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "30",
+    "facility_id": "62388"
+  },
+  {
+    "callsign": "KCDT",
+    "community_served_city": "COEUR D'ALENE",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "62424"
+  },
+  {
+    "callsign": "KIPT",
+    "community_served_city": "TWIN FALLS",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "62427"
+  },
+  {
+    "callsign": "KISU-TV",
+    "community_served_city": "POCATELLO",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "62430"
+  },
+  {
+    "callsign": "KAID",
+    "community_served_city": "BOISE",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "62442"
+  },
+  {
+    "callsign": "KCKA",
+    "community_served_city": "CENTRALIA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "62468"
+  },
+  {
+    "callsign": "KBTC-TV",
+    "community_served_city": "TACOMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "28",
+    "facility_id": "62469"
+  },
+  {
+    "callsign": "WLEF-TV",
+    "community_served_city": "PARK FALLS",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "63046"
+  },
+  {
+    "callsign": "WCAU",
+    "community_served_city": "PHILADELPHIA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "63153"
+  },
+  {
+    "callsign": "WTVJ",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "63154"
+  },
+  {
+    "callsign": "KCDO-TV",
+    "community_served_city": "STERLING",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "3",
+    "facility_id": "63158"
+  },
+  {
+    "callsign": "WIBW-TV",
+    "community_served_city": "TOPEKA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "63160"
+  },
+  {
+    "callsign": "KGWL-TV",
+    "community_served_city": "LANDER",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "63162"
+  },
+  {
+    "callsign": "KMIZ",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "17",
+    "facility_id": "63164"
+  },
+  {
+    "callsign": "KCOY-TV",
+    "community_served_city": "SANTA MARIA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "12",
+    "facility_id": "63165"
+  },
+  {
+    "callsign": "KGWN-TV",
+    "community_served_city": "CHEYENNE",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS / NBC / CW",
+    "tv_virtual_channel": "5",
+    "facility_id": "63166"
+  },
+  {
+    "callsign": "KGWR-TV",
+    "community_served_city": "ROCK SPRINGS",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "63170"
+  },
+  {
+    "callsign": "KGWC-TV",
+    "community_served_city": "CASPER",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "14",
+    "facility_id": "63177"
+  },
+  {
+    "callsign": "KSTF",
+    "community_served_city": "SCOTTSBLUFF",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "CBS / NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "63182"
+  },
+  {
+    "callsign": "WGTA",
+    "community_served_city": "TOCCOA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "32",
+    "facility_id": "63329"
+  },
+  {
+    "callsign": "KOLO-TV",
+    "community_served_city": "RENO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "63331"
+  },
+  {
+    "callsign": "KBLR",
+    "community_served_city": "PARADISE",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "39",
+    "facility_id": "63768"
+  },
+  {
+    "callsign": "WSVN",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "7",
+    "facility_id": "63840"
+  },
+  {
+    "callsign": "KENV-DT",
+    "community_served_city": "ELKO",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "10",
+    "facility_id": "63845"
+  },
+  {
+    "callsign": "DKWNV",
+    "community_served_city": "WINNEMUCCA",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "63846"
+  },
+  {
+    "callsign": "KILM",
+    "community_served_city": "INGLEWOOD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "SCRIPPS News, Bounce, LAFF",
+    "tv_virtual_channel": "64",
+    "facility_id": "63865"
+  },
+  {
+    "callsign": "WSST-TV",
+    "community_served_city": "CORDELE",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "55",
+    "facility_id": "63867"
+  },
+  {
+    "callsign": "KUVE-DT",
+    "community_served_city": "GREEN VALLEY",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "46",
+    "facility_id": "63927"
+  },
+  {
+    "callsign": "WDKY-TV",
+    "community_served_city": "DANVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "56",
+    "facility_id": "64017"
+  },
+  {
+    "callsign": "WPCH-TV",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "17",
+    "facility_id": "64033"
+  },
+  {
+    "callsign": "WSPX-TV",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Grit, Mystery, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "56",
+    "facility_id": "64352"
+  },
+  {
+    "callsign": "KCWE",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "CW/True Crime Network",
+    "tv_virtual_channel": "29",
+    "facility_id": "64444"
+  },
+  {
+    "callsign": "KHVO",
+    "community_served_city": "HILO",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC (D1), METV (D2)",
+    "tv_virtual_channel": "13",
+    "facility_id": "64544"
+  },
+  {
+    "callsign": "WKOW",
+    "community_served_city": "MADISON",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC (27.1), Catchy Comedy (27.2), MeTV Toons (27.3), Court TV (27.4), CRIME (27.5)",
+    "tv_virtual_channel": "27",
+    "facility_id": "64545"
+  },
+  {
+    "callsign": "WAOW",
+    "community_served_city": "WAUSAU",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC 9.1, Catchy Comedy 9.2, MeTV Toons 9.3, Court TV 9.4, True Crime 9.5",
+    "tv_virtual_channel": "9",
+    "facility_id": "64546"
+  },
+  {
+    "callsign": "WGRZ",
+    "community_served_city": "BUFFALO",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "64547"
+  },
+  {
+    "callsign": "KITV",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC (D1), METV (D2)",
+    "tv_virtual_channel": "4",
+    "facility_id": "64548"
+  },
+  {
+    "callsign": "WXOW",
+    "community_served_city": "LA CROSSE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Catchy TV, This TV thru 5/24/24, then MeTV Toons Eff 5/29/24, Court TV, Justice Networks, The Grio",
+    "tv_virtual_channel": "19",
+    "facility_id": "64549"
+  },
+  {
+    "callsign": "WQOW",
+    "community_served_city": "EAU CLAIRE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Catchy TV, This TV thru 5/24/24,  MeTV Toons Eff 5/29/24, Court TV, Justice Networks, The Grio",
+    "tv_virtual_channel": "18",
+    "facility_id": "64550"
+  },
+  {
+    "callsign": "KMAU",
+    "community_served_city": "WAILUKU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC (D1), METV (D2)",
+    "tv_virtual_channel": "12",
+    "facility_id": "64551"
+  },
+  {
+    "callsign": "WFTS-TV",
+    "community_served_city": "TAMPA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "28",
+    "facility_id": "64588"
+  },
+  {
+    "callsign": "WFLA-TV",
+    "community_served_city": "TAMPA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "64592"
+  },
+  {
+    "callsign": "DKFYF",
+    "community_served_city": "FAIRBANKS",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "7",
+    "facility_id": "64597"
+  },
+  {
+    "callsign": "WRAZ",
+    "community_served_city": "RALEIGH",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "50",
+    "facility_id": "64611"
+  },
+  {
+    "callsign": "WQPX-TV",
+    "community_served_city": "SCRANTON",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Court TV, Grit, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "64",
+    "facility_id": "64690"
+  },
+  {
+    "callsign": "WORA-TV",
+    "community_served_city": "MAYAGUEZ",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "5",
+    "facility_id": "64865"
+  },
+  {
+    "callsign": "KORO",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "28",
+    "facility_id": "64877"
+  },
+  {
+    "callsign": "KVDA",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "60",
+    "facility_id": "64969"
+  },
+  {
+    "callsign": "WSCV",
+    "community_served_city": "FORT LAUDERDALE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "TELEMUNDO",
+    "tv_virtual_channel": "51",
+    "facility_id": "64971"
+  },
+  {
+    "callsign": "KEJT-CD",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "50",
+    "facility_id": "64974"
+  },
+  {
+    "callsign": "WKAQ-TV",
+    "community_served_city": "SAN JUAN",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "2",
+    "facility_id": "64983"
+  },
+  {
+    "callsign": "KTMD",
+    "community_served_city": "GALVESTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "47",
+    "facility_id": "64984"
+  },
+  {
+    "callsign": "KSTS",
+    "community_served_city": "SAN JOSE",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "48",
+    "facility_id": "64987"
+  },
+  {
+    "callsign": "WTLV",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "12",
+    "facility_id": "65046"
+  },
+  {
+    "callsign": "WGPX-TV",
+    "community_served_city": "BURLINGTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "16",
+    "facility_id": "65074"
+  },
+  {
+    "callsign": "WHDF",
+    "community_served_city": "FLORENCE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "15",
+    "facility_id": "65128"
+  },
+  {
+    "callsign": "WQCW",
+    "community_served_city": "PORTSMOUTH",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "30",
+    "facility_id": "65130"
+  },
+  {
+    "callsign": "WISC-TV",
+    "community_served_city": "MADISON",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "65143"
+  },
+  {
+    "callsign": "WBBJ-TV",
+    "community_served_city": "JACKSON",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC (main) CBS (multicast)",
+    "tv_virtual_channel": "7",
+    "facility_id": "65204"
+  },
+  {
+    "callsign": "WAWV-TV",
+    "community_served_city": "TERRE HAUTE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "38",
+    "facility_id": "65247"
+  },
+  {
+    "callsign": "KAMU-TV",
+    "community_served_city": "COLLEGE STATION",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "15",
+    "facility_id": "65301"
+  },
+  {
+    "callsign": "KTTZ-TV",
+    "community_served_city": "LUBBOCK",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "65355"
+  },
+  {
+    "callsign": "KFDX-TV",
+    "community_served_city": "WICHITA FALLS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "65370"
+  },
+  {
+    "callsign": "WVBT",
+    "community_served_city": "VIRGINIA BEACH",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "43",
+    "facility_id": "65387"
+  },
+  {
+    "callsign": "KBFD-DT",
+    "community_served_city": "HONOLULU",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "32",
+    "facility_id": "65395"
+  },
+  {
+    "callsign": "KAKE",
+    "community_served_city": "WICHITA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, MeTV",
+    "tv_virtual_channel": "10",
+    "facility_id": "65522"
+  },
+  {
+    "callsign": "KLBY",
+    "community_served_city": "COLBY",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, MeTV",
+    "tv_virtual_channel": "4",
+    "facility_id": "65523"
+  },
+  {
+    "callsign": "KRON-TV",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "4",
+    "facility_id": "65526"
+  },
+  {
+    "callsign": "WOWT",
+    "community_served_city": "OMAHA",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "65528"
+  },
+  {
+    "callsign": "KUPK",
+    "community_served_city": "GARDEN CITY",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, MeTV",
+    "tv_virtual_channel": "13",
+    "facility_id": "65535"
+  },
+  {
+    "callsign": "KOMU-TV",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "65583"
+  },
+  {
+    "callsign": "WUSA",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "65593"
+  },
+  {
+    "callsign": "WCET",
+    "community_served_city": "CINCINNATI",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "48",
+    "facility_id": "65666"
+  },
+  {
+    "callsign": "WTCI",
+    "community_served_city": "CHATTANOOGA",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "45",
+    "facility_id": "65667"
+  },
+  {
+    "callsign": "WETA-TV",
+    "community_served_city": "WASHINGTON",
+    "community_served_state": "DC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "65670"
+  },
+  {
+    "callsign": "WISN-TV",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/ True Crime Network",
+    "tv_virtual_channel": "12",
+    "facility_id": "65680"
+  },
+  {
+    "callsign": "WTAE-TV",
+    "community_served_city": "PITTSBURGH",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "4",
+    "facility_id": "65681"
+  },
+  {
+    "callsign": "WCVB-TV",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, MeTV",
+    "tv_virtual_channel": "5",
+    "facility_id": "65684"
+  },
+  {
+    "callsign": "KMBC-TV",
+    "community_served_city": "KANSAS CITY",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC/ME-TV",
+    "tv_virtual_channel": "9",
+    "facility_id": "65686"
+  },
+  {
+    "callsign": "WDTN",
+    "community_served_city": "DAYTON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "65690"
+  },
+  {
+    "callsign": "WBAL-TV",
+    "community_served_city": "BALTIMORE",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "65696"
+  },
+  {
+    "callsign": "WJET-TV",
+    "community_served_city": "ERIE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "24",
+    "facility_id": "65749"
+  },
+  {
+    "callsign": "WKPD",
+    "community_served_city": "PADUCAH",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "29",
+    "facility_id": "65758"
+  },
+  {
+    "callsign": "WWJS",
+    "community_served_city": "HICKORY",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "14",
+    "facility_id": "65919"
+  },
+  {
+    "callsign": "WMPT",
+    "community_served_city": "ANNAPOLIS",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "65942"
+  },
+  {
+    "callsign": "WWPB",
+    "community_served_city": "HAGERSTOWN",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "31",
+    "facility_id": "65943"
+  },
+  {
+    "callsign": "WMPB",
+    "community_served_city": "BALTIMORE",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "67",
+    "facility_id": "65944"
+  },
+  {
+    "callsign": "KTIV",
+    "community_served_city": "SIOUX CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CW, Me-TV",
+    "tv_virtual_channel": "4",
+    "facility_id": "66170"
+  },
+  {
+    "callsign": "WREG-TV",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "66174"
+  },
+  {
+    "callsign": "WOSU-TV",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "34",
+    "facility_id": "66185"
+  },
+  {
+    "callsign": "DWPBO",
+    "community_served_city": "PORTSMOUTH",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "42",
+    "facility_id": "66190"
+  },
+  {
+    "callsign": "KOED-TV",
+    "community_served_city": "TULSA",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "66195"
+  },
+  {
+    "callsign": "WPSU-TV",
+    "community_served_city": "CLEARFIELD",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "66219"
+  },
+  {
+    "callsign": "WHO-DT",
+    "community_served_city": "DES MOINES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "13",
+    "facility_id": "66221"
+  },
+  {
+    "callsign": "KFOR-TV",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "66222"
+  },
+  {
+    "callsign": "KIFI-TV",
+    "community_served_city": "IDAHO FALLS",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "66258"
+  },
+  {
+    "callsign": "WGTE-TV",
+    "community_served_city": "TOLEDO",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "30",
+    "facility_id": "66285"
+  },
+  {
+    "callsign": "WLRN-TV",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "17",
+    "facility_id": "66358"
+  },
+  {
+    "callsign": "WVPY",
+    "community_served_city": "NEW MARKET",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "42",
+    "facility_id": "66378"
+  },
+  {
+    "callsign": "WSPA-TV",
+    "community_served_city": "SPARTANBURG",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "66391"
+  },
+  {
+    "callsign": "WMBB",
+    "community_served_city": "PANAMA CITY",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "66398"
+  },
+  {
+    "callsign": "KIMT",
+    "community_served_city": "MASON CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "66402"
+  },
+  {
+    "callsign": "WBTW",
+    "community_served_city": "FLORENCE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "13",
+    "facility_id": "66407"
+  },
+  {
+    "callsign": "KWCH-DT",
+    "community_served_city": "HUTCHINSON",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "66413"
+  },
+  {
+    "callsign": "KBSD-DT",
+    "community_served_city": "ENSIGN",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "66414"
+  },
+  {
+    "callsign": "KBSH-DT",
+    "community_served_city": "HAYS",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "66415"
+  },
+  {
+    "callsign": "KBSL-DT",
+    "community_served_city": "GOODLAND",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "66416"
+  },
+  {
+    "callsign": "KFSM-TV",
+    "community_served_city": "FORT SMITH",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "66469"
+  },
+  {
+    "callsign": "WTIU",
+    "community_served_city": "BLOOMINGTON",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "30",
+    "facility_id": "66536"
+  },
+  {
+    "callsign": "KUON-TV",
+    "community_served_city": "LINCOLN",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "66589"
+  },
+  {
+    "callsign": "KUFM-TV",
+    "community_served_city": "MISSOULA",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "66611"
+  },
+  {
+    "callsign": "KIRO-TV",
+    "community_served_city": "SEATTLE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS (7.1), COZITV (7.2), LAFF (7.3), TELEMUNDO (7.4)",
+    "tv_virtual_channel": "7",
+    "facility_id": "66781"
+  },
+  {
+    "callsign": "KUGB-CD",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CRTV NETWORK",
+    "tv_virtual_channel": "28",
+    "facility_id": "66790"
+  },
+  {
+    "callsign": "WOAY-TV",
+    "community_served_city": "OAK HILL",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "4",
+    "facility_id": "66804"
+  },
+  {
+    "callsign": "WTWC-TV",
+    "community_served_city": "TALLAHASSEE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "40",
+    "facility_id": "66908"
+  },
+  {
+    "callsign": "K21DO-D",
+    "community_served_city": "PALM SPRINGS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "21",
+    "facility_id": "67013"
+  },
+  {
+    "callsign": "WBKB-TV",
+    "community_served_city": "ALPENA",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "67048"
+  },
+  {
+    "callsign": "WPXV-TV",
+    "community_served_city": "NORFOLK",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "49",
+    "facility_id": "67077"
+  },
+  {
+    "callsign": "KINC",
+    "community_served_city": "LAS VEGAS",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "15",
+    "facility_id": "67089"
+  },
+  {
+    "callsign": "WVSN",
+    "community_served_city": "HUMACAO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "68",
+    "facility_id": "67190"
+  },
+  {
+    "callsign": "KSNT",
+    "community_served_city": "TOPEKA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "27",
+    "facility_id": "67335"
+  },
+  {
+    "callsign": "KWOG",
+    "community_served_city": "SPRINGDALE",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "57",
+    "facility_id": "67347"
+  },
+  {
+    "callsign": "KAIL",
+    "community_served_city": "FRESNO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "7",
+    "facility_id": "67494"
+  },
+  {
+    "callsign": "WOPX-TV",
+    "community_served_city": "MELBOURNE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Grit, IONPlus, SCRIPPS News, Jewelry TV, QVC, HSN",
+    "tv_virtual_channel": "56",
+    "facility_id": "67602"
+  },
+  {
+    "callsign": "KTSM-TV",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "9",
+    "facility_id": "67760"
+  },
+  {
+    "callsign": "KSNF",
+    "community_served_city": "JOPLIN",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "16",
+    "facility_id": "67766"
+  },
+  {
+    "callsign": "WTLJ",
+    "community_served_city": "MUSKEGON",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "54",
+    "facility_id": "67781"
+  },
+  {
+    "callsign": "WNYO-TV",
+    "community_served_city": "BUFFALO",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "49",
+    "facility_id": "67784"
+  },
+  {
+    "callsign": "WTCT",
+    "community_served_city": "MARION",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "27",
+    "facility_id": "67786"
+  },
+  {
+    "callsign": "WINM",
+    "community_served_city": "ANGOLA",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "63",
+    "facility_id": "67787"
+  },
+  {
+    "callsign": "WAQP",
+    "community_served_city": "SAGINAW",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "49",
+    "facility_id": "67792"
+  },
+  {
+    "callsign": "WTSF",
+    "community_served_city": "ASHLAND",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "61",
+    "facility_id": "67798"
+  },
+  {
+    "callsign": "WNIN",
+    "community_served_city": "EVANSVILLE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "67802"
+  },
+  {
+    "callsign": "WNDT-CD",
+    "community_served_city": "MANHATTAN",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "First Nations Experience",
+    "tv_virtual_channel": "14",
+    "facility_id": "67866"
+  },
+  {
+    "callsign": "KPAZ-TV",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "21",
+    "facility_id": "67868"
+  },
+  {
+    "callsign": "WKOI-TV",
+    "community_served_city": "RICHMOND",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "43",
+    "facility_id": "67869"
+  },
+  {
+    "callsign": "KTBN-TV",
+    "community_served_city": "SANTA ANA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "40",
+    "facility_id": "67884"
+  },
+  {
+    "callsign": "WDLI-TV",
+    "community_served_city": "CANTON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Bounce/Scripps News/Laff",
+    "tv_virtual_channel": "17",
+    "facility_id": "67893"
+  },
+  {
+    "callsign": "KDTX-TV",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "58",
+    "facility_id": "67910"
+  },
+  {
+    "callsign": "KTBW-TV",
+    "community_served_city": "TACOMA",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "20",
+    "facility_id": "67950"
+  },
+  {
+    "callsign": "WHFT-TV",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "45",
+    "facility_id": "67971"
+  },
+  {
+    "callsign": "WTBY-TV",
+    "community_served_city": "JERSEY CITY",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "54",
+    "facility_id": "67993"
+  },
+  {
+    "callsign": "KTBO-TV",
+    "community_served_city": "OKLAHOMA CITY",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "14",
+    "facility_id": "67999"
+  },
+  {
+    "callsign": "WCLJ-TV",
+    "community_served_city": "BLOOMINGTON",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "Bounce/Scripps News/Court TV",
+    "tv_virtual_channel": "42",
+    "facility_id": "68007"
+  },
+  {
+    "callsign": "WHSG-TV",
+    "community_served_city": "MONROE",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "63",
+    "facility_id": "68058"
+  },
+  {
+    "callsign": "WJMB-CD",
+    "community_served_city": "BUTLER",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "60",
+    "facility_id": "68393"
+  },
+  {
+    "callsign": "WMVH-CD",
+    "community_served_city": "CHARLEROI",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "26",
+    "facility_id": "68394"
+  },
+  {
+    "callsign": "WKHU-CD",
+    "community_served_city": "KITTANNING",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "TIMELESS TV",
+    "tv_virtual_channel": "60",
+    "facility_id": "68401"
+  },
+  {
+    "callsign": "KKDJ-CD",
+    "community_served_city": "VISALIA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Family TV",
+    "tv_virtual_channel": "8",
+    "facility_id": "68406"
+  },
+  {
+    "callsign": "WWKH-CD",
+    "community_served_city": "UNIONTOWN",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "MAGNIFICENT MOVIES NETWORK",
+    "tv_virtual_channel": "35",
+    "facility_id": "68409"
+  },
+  {
+    "callsign": "WBMM",
+    "community_served_city": "TUSKEGEE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "22",
+    "facility_id": "68427"
+  },
+  {
+    "callsign": "WXMI",
+    "community_served_city": "GRAND RAPIDS",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX; Antenna TV; Bounce TV; ION PLUS; GetTV; QVC",
+    "tv_virtual_channel": "17",
+    "facility_id": "68433"
+  },
+  {
+    "callsign": "WLMT",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "30",
+    "facility_id": "68518"
+  },
+  {
+    "callsign": "WJKT",
+    "community_served_city": "JACKSON",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "16",
+    "facility_id": "68519"
+  },
+  {
+    "callsign": "KRHD-CD",
+    "community_served_city": "BRYAN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "40",
+    "facility_id": "68538"
+  },
+  {
+    "callsign": "KLTV",
+    "community_served_city": "TYLER",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "68540"
+  },
+  {
+    "callsign": "KTRE",
+    "community_served_city": "LUFKIN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "68541"
+  },
+  {
+    "callsign": "WLBT",
+    "community_served_city": "JACKSON",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "68542"
+  },
+  {
+    "callsign": "WMLW-TV",
+    "community_served_city": "RACINE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "49",
+    "facility_id": "68545"
+  },
+  {
+    "callsign": "WWRS-TV",
+    "community_served_city": "MAYVILLE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "52",
+    "facility_id": "68547"
+  },
+  {
+    "callsign": "WOHL-CD",
+    "community_served_city": "LIMA",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, CBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "68549"
+  },
+  {
+    "callsign": "WTVT",
+    "community_served_city": "TAMPA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "13",
+    "facility_id": "68569"
+  },
+  {
+    "callsign": "KTVD",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "My Network TV",
+    "tv_virtual_channel": "20",
+    "facility_id": "68581"
+  },
+  {
+    "callsign": "KTCA-TV",
+    "community_served_city": "ST. PAUL",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "68594"
+  },
+  {
+    "callsign": "KTCI-TV",
+    "community_served_city": "ST. PAUL",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "17",
+    "facility_id": "68597"
+  },
+  {
+    "callsign": "K17GD-D",
+    "community_served_city": "PASO ROBLES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "17",
+    "facility_id": "68666"
+  },
+  {
+    "callsign": "KPXC-TV",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "59",
+    "facility_id": "68695"
+  },
+  {
+    "callsign": "KCWY-DT",
+    "community_served_city": "CASPER",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CW",
+    "tv_virtual_channel": "13",
+    "facility_id": "68713"
+  },
+  {
+    "callsign": "KUHM-TV",
+    "community_served_city": "HELENA",
+    "community_served_state": "MT",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "10",
+    "facility_id": "68717"
+  },
+  {
+    "callsign": "KTFN",
+    "community_served_city": "EL PASO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "65",
+    "facility_id": "68753"
+  },
+  {
+    "callsign": "KPXD-TV",
+    "community_served_city": "ARLINGTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN2, HSN",
+    "tv_virtual_channel": "68",
+    "facility_id": "68834"
+  },
+  {
+    "callsign": "WWNY-TV",
+    "community_served_city": "CARTHAGE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "68851"
+  },
+  {
+    "callsign": "KEYC-TV",
+    "community_served_city": "MANKATO",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "68853"
+  },
+  {
+    "callsign": "KMSP-TV",
+    "community_served_city": "MINNEAPOLIS",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "9",
+    "facility_id": "68883"
+  },
+  {
+    "callsign": "KUTP",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "MNT",
+    "tv_virtual_channel": "45",
+    "facility_id": "68886"
+  },
+  {
+    "callsign": "KTVX",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "4",
+    "facility_id": "68889"
+  },
+  {
+    "callsign": "WILL-TV",
+    "community_served_city": "URBANA",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "68939"
+  },
+  {
+    "callsign": "WUNC-TV",
+    "community_served_city": "CHAPEL HILL",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "69080"
+  },
+  {
+    "callsign": "WUNE-TV",
+    "community_served_city": "LINVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "17",
+    "facility_id": "69114"
+  },
+  {
+    "callsign": "WUNG-TV",
+    "community_served_city": "CONCORD",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "58",
+    "facility_id": "69124"
+  },
+  {
+    "callsign": "WUNK-TV",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "69149"
+  },
+  {
+    "callsign": "KTSC",
+    "community_served_city": "PUEBLO",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "69170"
+  },
+  {
+    "callsign": "WENH-TV",
+    "community_served_city": "DURHAM",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "69237"
+  },
+  {
+    "callsign": "KUHT",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "69269"
+  },
+  {
+    "callsign": "WEKW-TV",
+    "community_served_city": "KEENE",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "52",
+    "facility_id": "69271"
+  },
+  {
+    "callsign": "DWCMZ-TV",
+    "community_served_city": "FLINT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "28",
+    "facility_id": "69273"
+  },
+  {
+    "callsign": "WUND-TV",
+    "community_served_city": "EDENTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "69292"
+  },
+  {
+    "callsign": "WUNF-TV",
+    "community_served_city": "ASHEVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "33",
+    "facility_id": "69300"
+  },
+  {
+    "callsign": "KUAC-TV",
+    "community_served_city": "FAIRBANKS",
+    "community_served_state": "AK",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "69315"
+  },
+  {
+    "callsign": "WLED-TV",
+    "community_served_city": "LITTLETON",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "49",
+    "facility_id": "69328"
+  },
+  {
+    "callsign": "WUNJ-TV",
+    "community_served_city": "WILMINGTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "39",
+    "facility_id": "69332"
+  },
+  {
+    "callsign": "WEDQ",
+    "community_served_city": "TAMPA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "16",
+    "facility_id": "69338"
+  },
+  {
+    "callsign": "WUNL-TV",
+    "community_served_city": "WINSTON-SALEM",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "26",
+    "facility_id": "69360"
+  },
+  {
+    "callsign": "KUED",
+    "community_served_city": "SALT LAKE CITY",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "69396"
+  },
+  {
+    "callsign": "WUNP-TV",
+    "community_served_city": "ROANOKE RAPIDS",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "36",
+    "facility_id": "69397"
+  },
+  {
+    "callsign": "WUNU",
+    "community_served_city": "LUMBERTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "31",
+    "facility_id": "69416"
+  },
+  {
+    "callsign": "WUFT",
+    "community_served_city": "GAINESVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "69440"
+  },
+  {
+    "callsign": "WUNM-TV",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "69444"
+  },
+  {
+    "callsign": "WSCG",
+    "community_served_city": "BAXLEY",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "34",
+    "facility_id": "69446"
+  },
+  {
+    "callsign": "WCTE",
+    "community_served_city": "COOKEVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "69479"
+  },
+  {
+    "callsign": "KZJL",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "EstrellaTV",
+    "tv_virtual_channel": "61",
+    "facility_id": "69531"
+  },
+  {
+    "callsign": "WFDC-DT",
+    "community_served_city": "ARLINGTON",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "UNIVISION",
+    "tv_virtual_channel": "14",
+    "facility_id": "69532"
+  },
+  {
+    "callsign": "WCCU",
+    "community_served_city": "URBANA",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "27",
+    "facility_id": "69544"
+  },
+  {
+    "callsign": "KZJO",
+    "community_served_city": "SEATTLE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "My Network TV",
+    "tv_virtual_channel": "22",
+    "facility_id": "69571"
+  },
+  {
+    "callsign": "KUEN",
+    "community_served_city": "OGDEN",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "69582"
+  },
+  {
+    "callsign": "WOAI-TV",
+    "community_served_city": "SAN ANTONIO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "69618"
+  },
+  {
+    "callsign": "KPYX",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "44",
+    "facility_id": "69619"
+  },
+  {
+    "callsign": "KHSV",
+    "community_served_city": "LAS VEGAS",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "21",
+    "facility_id": "69677"
+  },
+  {
+    "callsign": "KNVO",
+    "community_served_city": "MCALLEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "48",
+    "facility_id": "69692"
+  },
+  {
+    "callsign": "KUTF",
+    "community_served_city": "LOGAN",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "12",
+    "facility_id": "69694"
+  },
+  {
+    "callsign": "KVPT",
+    "community_served_city": "FRESNO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "69733"
+  },
+  {
+    "callsign": "KBBV-CD",
+    "community_served_city": "BAKERSFIELD",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "TELEXITOS",
+    "tv_virtual_channel": "19",
+    "facility_id": "69735"
+  },
+  {
+    "callsign": "KVER-CD",
+    "community_served_city": "INDIO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "4",
+    "facility_id": "69753"
+  },
+  {
+    "callsign": "WPKD-TV",
+    "community_served_city": "JEANNETTE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "19",
+    "facility_id": "69880"
+  },
+  {
+    "callsign": "WVTB",
+    "community_served_city": "ST. JOHNSBURY",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "69940"
+  },
+  {
+    "callsign": "DDWVTA",
+    "community_served_city": "WINDSOR",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "41",
+    "facility_id": "69943"
+  },
+  {
+    "callsign": "WETK",
+    "community_served_city": "BURLINGTON",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "33",
+    "facility_id": "69944"
+  },
+  {
+    "callsign": "WVER",
+    "community_served_city": "RUTLAND",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "28",
+    "facility_id": "69946"
+  },
+  {
+    "callsign": "WVLA-TV",
+    "community_served_city": "BATON ROUGE",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "33",
+    "facility_id": "70021"
+  },
+  {
+    "callsign": "KMOV",
+    "community_served_city": "ST. LOUIS",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "D1-CBS, D2- MyNet,  D-2 First Alert Weather Now , D3- COZI TV, D4- ION MYSTERY",
+    "tv_virtual_channel": "4",
+    "facility_id": "70034"
+  },
+  {
+    "callsign": "WHEC-TV",
+    "community_served_city": "ROCHESTER",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "70041"
+  },
+  {
+    "callsign": "WSNS-TV",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "TELEMUNDO",
+    "tv_virtual_channel": "44",
+    "facility_id": "70119"
+  },
+  {
+    "callsign": "WBDT",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "26",
+    "facility_id": "70138"
+  },
+  {
+    "callsign": "WYCW",
+    "community_served_city": "ASHEVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "62",
+    "facility_id": "70149"
+  },
+  {
+    "callsign": "WTHR",
+    "community_served_city": "INDIANAPOLIS",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "13",
+    "facility_id": "70162"
+  },
+  {
+    "callsign": "WRIW-CD",
+    "community_served_city": "PROVIDENCE",
+    "community_served_state": "RI",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "51",
+    "facility_id": "70184"
+  },
+  {
+    "callsign": "WPXR-TV",
+    "community_served_city": "ROANOKE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Laff, Mystery, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "38",
+    "facility_id": "70251"
+  },
+  {
+    "callsign": "WTJX-TV",
+    "community_served_city": "CHARLOTTE AMALIE",
+    "community_served_state": "VI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "70287"
+  },
+  {
+    "callsign": "WVIR-TV",
+    "community_served_city": "CHARLOTTESVILLE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CW, TRUE CRIME",
+    "tv_virtual_channel": "29",
+    "facility_id": "70309"
+  },
+  {
+    "callsign": "KSLA",
+    "community_served_city": "SHREVEPORT",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "70482"
+  },
+  {
+    "callsign": "WVPX-TV",
+    "community_served_city": "AKRON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "23",
+    "facility_id": "70491"
+  },
+  {
+    "callsign": "KUBE-TV",
+    "community_served_city": "BAYTOWN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC",
+    "tv_virtual_channel": "57",
+    "facility_id": "70492"
+  },
+  {
+    "callsign": "WZME",
+    "community_served_city": "BRIDGEPORT",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "Story Television",
+    "tv_virtual_channel": "43",
+    "facility_id": "70493"
+  },
+  {
+    "callsign": "WSEC",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "14",
+    "facility_id": "70536"
+  },
+  {
+    "callsign": "WMEC",
+    "community_served_city": "MACOMB",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "70537"
+  },
+  {
+    "callsign": "KREG-TV",
+    "community_served_city": "GLENWOOD SPRINGS",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "3",
+    "facility_id": "70578"
+  },
+  {
+    "callsign": "KREY-TV",
+    "community_served_city": "MONTROSE",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "70579"
+  },
+  {
+    "callsign": "WDTV",
+    "community_served_city": "WESTON",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "CBS,CW, H&I",
+    "tv_virtual_channel": "5",
+    "facility_id": "70592"
+  },
+  {
+    "callsign": "KREX-TV",
+    "community_served_city": "GRAND JUNCTION",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "70596"
+  },
+  {
+    "callsign": "WFTX-TV",
+    "community_served_city": "CAPE CORAL",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "36",
+    "facility_id": "70649"
+  },
+  {
+    "callsign": "WOGX",
+    "community_served_city": "OCALA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "51",
+    "facility_id": "70651"
+  },
+  {
+    "callsign": "WTHI-TV",
+    "community_served_city": "TERRE HAUTE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "70655"
+  },
+  {
+    "callsign": "WAGA-TV",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "5",
+    "facility_id": "70689"
+  },
+  {
+    "callsign": "DWAGT",
+    "community_served_city": "AUGUSTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/CW",
+    "tv_virtual_channel": "26",
+    "facility_id": "70699"
+  },
+  {
+    "callsign": "WALB",
+    "community_served_city": "ALBANY",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "70713"
+  },
+  {
+    "callsign": "WFXL",
+    "community_served_city": "ALBANY",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "31",
+    "facility_id": "70815"
+  },
+  {
+    "callsign": "WAND",
+    "community_served_city": "DECATUR",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, COZI TV, DEFY TV, ION PLUS, ION TV, AND MeTV",
+    "tv_virtual_channel": "17",
+    "facility_id": "70852"
+  },
+  {
+    "callsign": "KFXK-TV",
+    "community_served_city": "LONGVIEW",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "51",
+    "facility_id": "70917"
+  },
+  {
+    "callsign": "KTWU",
+    "community_served_city": "TOPEKA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "70938"
+  },
+  {
+    "callsign": "KTNW",
+    "community_served_city": "RICHLAND",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "31",
+    "facility_id": "71023"
+  },
+  {
+    "callsign": "KWSU-TV",
+    "community_served_city": "PULLMAN",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "71024"
+  },
+  {
+    "callsign": "WATE-TV",
+    "community_served_city": "KNOXVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "6",
+    "facility_id": "71082"
+  },
+  {
+    "callsign": "WBBH-TV",
+    "community_served_city": "FORT MYERS",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "20",
+    "facility_id": "71085"
+  },
+  {
+    "callsign": "WNGT-CD",
+    "community_served_city": "RALEIGH",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "Catchy Comedy",
+    "tv_virtual_channel": "34",
+    "facility_id": "71089"
+  },
+  {
+    "callsign": "WAVY-TV",
+    "community_served_city": "PORTSMOUTH",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "10",
+    "facility_id": "71127"
+  },
+  {
+    "callsign": "WBNS-TV",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "71217"
+  },
+  {
+    "callsign": "WBOC-TV",
+    "community_served_city": "SALISBURY",
+    "community_served_state": "MD",
+    "active_ind": "Y",
+    "network_affiliation": "CBS/FOX/Antenna TV",
+    "tv_virtual_channel": "16",
+    "facility_id": "71218"
+  },
+  {
+    "callsign": "WBOY-TV",
+    "community_served_city": "CLARKSBURG",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, ABC",
+    "tv_virtual_channel": "12",
+    "facility_id": "71220"
+  },
+  {
+    "callsign": "WBRC",
+    "community_served_city": "BIRMINGHAM",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "6",
+    "facility_id": "71221"
+  },
+  {
+    "callsign": "WBRE-TV",
+    "community_served_city": "WILKES-BARRE",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "28",
+    "facility_id": "71225"
+  },
+  {
+    "callsign": "WPXC-TV",
+    "community_served_city": "BRUNSWICK",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Mystery, Grit, Laff, SCRIPPS News, Jewelry TV, QVC, QVC2",
+    "tv_virtual_channel": "21",
+    "facility_id": "71236"
+  },
+  {
+    "callsign": "DWCGV-TV",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "MYTV",
+    "tv_virtual_channel": "24",
+    "facility_id": "71278"
+  },
+  {
+    "callsign": "WCHS-TV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "WCHS D1 - ABC; WCHS D2 -FOX: WCHS D3 - Antenna TV",
+    "tv_virtual_channel": "8",
+    "facility_id": "71280"
+  },
+  {
+    "callsign": "WKMG-TV",
+    "community_served_city": "ORLANDO",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "71293"
+  },
+  {
+    "callsign": "WCSC-TV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "71297"
+  },
+  {
+    "callsign": "WDBB",
+    "community_served_city": "BESSEMER",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "The CW Network",
+    "tv_virtual_channel": "17",
+    "facility_id": "71325"
+  },
+  {
+    "callsign": "WDBD",
+    "community_served_city": "JACKSON",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "40",
+    "facility_id": "71326"
+  },
+  {
+    "callsign": "WDBJ",
+    "community_served_city": "ROANOKE",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, H&I, True Crime Network",
+    "tv_virtual_channel": "7",
+    "facility_id": "71329"
+  },
+  {
+    "callsign": "WIRT-DT",
+    "community_served_city": "HIBBING",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "DT.1 ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "71336"
+  },
+  {
+    "callsign": "WDIO-DT",
+    "community_served_city": "DULUTH",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "DT.1 ABC",
+    "tv_virtual_channel": "10",
+    "facility_id": "71338"
+  },
+  {
+    "callsign": "WDSI-TV",
+    "community_served_city": "CHATTANOOGA",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "TRUECRIME TV",
+    "tv_virtual_channel": "61",
+    "facility_id": "71353"
+  },
+  {
+    "callsign": "WDSU",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "71357"
+  },
+  {
+    "callsign": "WEAR-TV",
+    "community_served_city": "PENSACOLA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "3",
+    "facility_id": "71363"
+  },
+  {
+    "callsign": "WDJT-TV",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "58",
+    "facility_id": "71427"
+  },
+  {
+    "callsign": "WCIU-TV",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "26",
+    "facility_id": "71428"
+  },
+  {
+    "callsign": "WENY-TV",
+    "community_served_city": "ELMIRA",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC (Main), CBS (Multicast)",
+    "tv_virtual_channel": "36",
+    "facility_id": "71508"
+  },
+  {
+    "callsign": "KWCM-TV",
+    "community_served_city": "APPLETON",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "10",
+    "facility_id": "71549"
+  },
+  {
+    "callsign": "KSMN",
+    "community_served_city": "WORTHINGTON",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "71558"
+  },
+  {
+    "callsign": "WQEC",
+    "community_served_city": "QUINCY",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "71561"
+  },
+  {
+    "callsign": "WRXY-TV",
+    "community_served_city": "TICE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Network Affiliation CTN",
+    "tv_virtual_channel": "49",
+    "facility_id": "71580"
+  },
+  {
+    "callsign": "KCNS",
+    "community_served_city": "SAN FRANCISCO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC",
+    "tv_virtual_channel": "38",
+    "facility_id": "71586"
+  },
+  {
+    "callsign": "WLJT",
+    "community_served_city": "LEXINGTON",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "11",
+    "facility_id": "71645"
+  },
+  {
+    "callsign": "WVPB-TV",
+    "community_served_city": "HUNTINGTON",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "33",
+    "facility_id": "71657"
+  },
+  {
+    "callsign": "WNPB-TV",
+    "community_served_city": "MORGANTOWN",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "71676"
+  },
+  {
+    "callsign": "WSWP-TV",
+    "community_served_city": "GRANDVIEW",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "71680"
+  },
+  {
+    "callsign": "WOLE-DT",
+    "community_served_city": "AGUADILLA",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "12",
+    "facility_id": "71725"
+  },
+  {
+    "callsign": "WKYU-TV",
+    "community_served_city": "BOWLING GREEN",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "24",
+    "facility_id": "71861"
+  },
+  {
+    "callsign": "WZPX-TV",
+    "community_served_city": "BATTLE CREEK",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "43",
+    "facility_id": "71871"
+  },
+  {
+    "callsign": "WNLO",
+    "community_served_city": "BUFFALO",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "23",
+    "facility_id": "71905"
+  },
+  {
+    "callsign": "WNED-TV",
+    "community_served_city": "BUFFALO",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "17",
+    "facility_id": "71928"
+  },
+  {
+    "callsign": "WEVV-TV",
+    "community_served_city": "EVANSVILLE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "44",
+    "facility_id": "72041"
+  },
+  {
+    "callsign": "WEYI-TV",
+    "community_served_city": "SAGINAW",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "25",
+    "facility_id": "72052"
+  },
+  {
+    "callsign": "WSBS-TV",
+    "community_served_city": "KEY WEST",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "MegaTV",
+    "tv_virtual_channel": "22",
+    "facility_id": "72053"
+  },
+  {
+    "callsign": "WFAA",
+    "community_served_city": "DALLAS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "72054"
+  },
+  {
+    "callsign": "WFLI-TV",
+    "community_served_city": "CLEVELAND",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "53",
+    "facility_id": "72060"
+  },
+  {
+    "callsign": "WFMJ-TV",
+    "community_served_city": "YOUNGSTOWN",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "21",
+    "facility_id": "72062"
+  },
+  {
+    "callsign": "WFMY-TV",
+    "community_served_city": "GREENSBORO",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "72064"
+  },
+  {
+    "callsign": "WFTV",
+    "community_served_city": "ORLANDO",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Laff, Ion Mystery",
+    "tv_virtual_channel": "9",
+    "facility_id": "72076"
+  },
+  {
+    "callsign": "WGBY-TV",
+    "community_served_city": "SPRINGFIELD",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "57",
+    "facility_id": "72096"
+  },
+  {
+    "callsign": "WGBX-TV",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "44",
+    "facility_id": "72098"
+  },
+  {
+    "callsign": "WGBH-TV",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "2",
+    "facility_id": "72099"
+  },
+  {
+    "callsign": "WGHP",
+    "community_served_city": "HIGH POINT",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "8",
+    "facility_id": "72106"
+  },
+  {
+    "callsign": "WGN-TV",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "9",
+    "facility_id": "72115"
+  },
+  {
+    "callsign": "WGNO",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "26",
+    "facility_id": "72119"
+  },
+  {
+    "callsign": "WANF",
+    "community_served_city": "ATLANTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "46",
+    "facility_id": "72120"
+  },
+  {
+    "callsign": "WWJ-TV",
+    "community_served_city": "DETROIT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "62",
+    "facility_id": "72123"
+  },
+  {
+    "callsign": "WHDH",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "7",
+    "facility_id": "72145"
+  },
+  {
+    "callsign": "WHNS",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "21",
+    "facility_id": "72300"
+  },
+  {
+    "callsign": "WNCF",
+    "community_served_city": "MONTGOMERY",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "32",
+    "facility_id": "72307"
+  },
+  {
+    "callsign": "WHP-TV",
+    "community_served_city": "HARRISBURG",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "72313"
+  },
+  {
+    "callsign": "WHTM-TV",
+    "community_served_city": "HARRISBURG",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC Television Network",
+    "tv_virtual_channel": "27",
+    "facility_id": "72326"
+  },
+  {
+    "callsign": "WDPB",
+    "community_served_city": "SEAFORD",
+    "community_served_state": "DE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "64",
+    "facility_id": "72335"
+  },
+  {
+    "callsign": "WHYY-TV",
+    "community_served_city": "WILMINGTON",
+    "community_served_state": "DE",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "72338"
+  },
+  {
+    "callsign": "WVCY-TV",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "30",
+    "facility_id": "72342"
+  },
+  {
+    "callsign": "KSCW-DT",
+    "community_served_city": "WICHITA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "33",
+    "facility_id": "72348"
+  },
+  {
+    "callsign": "KSNW",
+    "community_served_city": "WICHITA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "72358"
+  },
+  {
+    "callsign": "KSNC",
+    "community_served_city": "GREAT BEND",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "2",
+    "facility_id": "72359"
+  },
+  {
+    "callsign": "KSNG",
+    "community_served_city": "GARDEN CITY",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "72361"
+  },
+  {
+    "callsign": "KSNK",
+    "community_served_city": "MCCOOK",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "8",
+    "facility_id": "72362"
+  },
+  {
+    "callsign": "KAZT-CD",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "27",
+    "facility_id": "72618"
+  },
+  {
+    "callsign": "WSFX-TV",
+    "community_served_city": "WILMINGTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "26",
+    "facility_id": "72871"
+  },
+  {
+    "callsign": "WTVO",
+    "community_served_city": "ROCKFORD",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "17",
+    "facility_id": "72945"
+  },
+  {
+    "callsign": "WBNX-TV",
+    "community_served_city": "AKRON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "55",
+    "facility_id": "72958"
+  },
+  {
+    "callsign": "WBXX-TV",
+    "community_served_city": "CROSSVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "20",
+    "facility_id": "72971"
+  },
+  {
+    "callsign": "WHRM-TV",
+    "community_served_city": "WAUSAU",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "73036"
+  },
+  {
+    "callsign": "WCWF",
+    "community_served_city": "SURING",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "14",
+    "facility_id": "73042"
+  },
+  {
+    "callsign": "WITF-TV",
+    "community_served_city": "HARRISBURG",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "33",
+    "facility_id": "73083"
+  },
+  {
+    "callsign": "KAVU-TV",
+    "community_served_city": "VICTORIA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "25",
+    "facility_id": "73101"
+  },
+  {
+    "callsign": "WITI",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "Fox",
+    "tv_virtual_channel": "6",
+    "facility_id": "73107"
+  },
+  {
+    "callsign": "WSYR-TV",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "73113"
+  },
+  {
+    "callsign": "WJAC-TV",
+    "community_served_city": "JOHNSTOWN",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "73120"
+  },
+  {
+    "callsign": "WJBK",
+    "community_served_city": "DETROIT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "2",
+    "facility_id": "73123"
+  },
+  {
+    "callsign": "WJCT",
+    "community_served_city": "JACKSONVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "7",
+    "facility_id": "73130"
+  },
+  {
+    "callsign": "WJHG-TV",
+    "community_served_city": "PANAMA CITY",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "7",
+    "facility_id": "73136"
+  },
+  {
+    "callsign": "WJW",
+    "community_served_city": "CLEVELAND",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "8",
+    "facility_id": "73150"
+  },
+  {
+    "callsign": "WJZY",
+    "community_served_city": "BELMONT",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "46",
+    "facility_id": "73152"
+  },
+  {
+    "callsign": "WKBN-TV",
+    "community_served_city": "YOUNGSTOWN",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "73153"
+  },
+  {
+    "callsign": "WKEF",
+    "community_served_city": "DAYTON",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "22",
+    "facility_id": "73155"
+  },
+  {
+    "callsign": "WKRG-TV",
+    "community_served_city": "MOBILE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "5",
+    "facility_id": "73187"
+  },
+  {
+    "callsign": "WKRN-TV",
+    "community_served_city": "NASHVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "2",
+    "facility_id": "73188"
+  },
+  {
+    "callsign": "WLPX-TV",
+    "community_served_city": "CHARLESTON",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "ION,Court TV, Bounce, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "29",
+    "facility_id": "73189"
+  },
+  {
+    "callsign": "WKYC",
+    "community_served_city": "CLEVELAND",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "3",
+    "facility_id": "73195"
+  },
+  {
+    "callsign": "WLEX-TV",
+    "community_served_city": "LEXINGTON",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC; Grit; Bounce; Court TV; QVC2",
+    "tv_virtual_channel": "18",
+    "facility_id": "73203"
+  },
+  {
+    "callsign": "WLFI-TV",
+    "community_served_city": "LAFAYETTE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "73204"
+  },
+  {
+    "callsign": "WLFL",
+    "community_served_city": "RALEIGH",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "22",
+    "facility_id": "73205"
+  },
+  {
+    "callsign": "WLNY-TV",
+    "community_served_city": "RIVERHEAD",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "55",
+    "facility_id": "73206"
+  },
+  {
+    "callsign": "WLS-TV",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "7",
+    "facility_id": "73226"
+  },
+  {
+    "callsign": "WLTV-DT",
+    "community_served_city": "MIAMI",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "UNIVISION",
+    "tv_virtual_channel": "23",
+    "facility_id": "73230"
+  },
+  {
+    "callsign": "WLVI",
+    "community_served_city": "CAMBRIDGE",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "56",
+    "facility_id": "73238"
+  },
+  {
+    "callsign": "WMDN",
+    "community_served_city": "MERIDIAN",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, Bounce, MeTV",
+    "tv_virtual_channel": "24",
+    "facility_id": "73255"
+  },
+  {
+    "callsign": "WMHT",
+    "community_served_city": "SCHENECTADY",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "17",
+    "facility_id": "73263"
+  },
+  {
+    "callsign": "WCWN",
+    "community_served_city": "SCHENECTADY",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "45",
+    "facility_id": "73264"
+  },
+  {
+    "callsign": "WMTW",
+    "community_served_city": "POLAND SPRING",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "73288"
+  },
+  {
+    "callsign": "WMUR-TV",
+    "community_served_city": "MANCHESTER",
+    "community_served_state": "NH",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, MeTV",
+    "tv_virtual_channel": "9",
+    "facility_id": "73292"
+  },
+  {
+    "callsign": "WNAB",
+    "community_served_city": "NASHVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "58",
+    "facility_id": "73310"
+  },
+  {
+    "callsign": "WNAC-TV",
+    "community_served_city": "PROVIDENCE",
+    "community_served_state": "RI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, CW, Antenna TV",
+    "tv_virtual_channel": "64",
+    "facility_id": "73311"
+  },
+  {
+    "callsign": "WPXH-TV",
+    "community_served_city": "HOOVER",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "44",
+    "facility_id": "73312"
+  },
+  {
+    "callsign": "WNEP-TV",
+    "community_served_city": "SCRANTON",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "16",
+    "facility_id": "73318"
+  },
+  {
+    "callsign": "WQAD-TV",
+    "community_served_city": "MOLINE",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "73319"
+  },
+  {
+    "callsign": "WNJU",
+    "community_served_city": "LINDEN",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "47",
+    "facility_id": "73333"
+  },
+  {
+    "callsign": "WNJX-TV",
+    "community_served_city": "MAYAGUEZ",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "73336"
+  },
+  {
+    "callsign": "WNNE",
+    "community_served_city": "MONTPELIER",
+    "community_served_state": "VT",
+    "active_ind": "Y",
+    "network_affiliation": "CW NETWORK",
+    "tv_virtual_channel": "31",
+    "facility_id": "73344"
+  },
+  {
+    "callsign": "WNWO-TV",
+    "community_served_city": "TOLEDO",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "24",
+    "facility_id": "73354"
+  },
+  {
+    "callsign": "WPXN-TV",
+    "community_served_city": "NEW YORK",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Grit, Laff, IONPlus, Court TV, Jewelry TV, QVC",
+    "tv_virtual_channel": "31",
+    "facility_id": "73356"
+  },
+  {
+    "callsign": "WNYT",
+    "community_served_city": "ALBANY",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "13",
+    "facility_id": "73363"
+  },
+  {
+    "callsign": "WHAM-TV",
+    "community_served_city": "ROCHESTER",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "73371"
+  },
+  {
+    "callsign": "WSWB",
+    "community_served_city": "SCRANTON",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "38",
+    "facility_id": "73374"
+  },
+  {
+    "callsign": "WOLF-TV",
+    "community_served_city": "HAZLETON",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "56",
+    "facility_id": "73375"
+  },
+  {
+    "callsign": "WCOV-TV",
+    "community_served_city": "MONTGOMERY",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "20",
+    "facility_id": "73642"
+  },
+  {
+    "callsign": "WBNA",
+    "community_served_city": "LOUISVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "21",
+    "facility_id": "73692"
+  },
+  {
+    "callsign": "KFAA-TV",
+    "community_served_city": "DECATUR",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "29",
+    "facility_id": "73701"
+  },
+  {
+    "callsign": "KSHV-TV",
+    "community_served_city": "SHREVEPORT",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "MNT",
+    "tv_virtual_channel": "45",
+    "facility_id": "73706"
+  },
+  {
+    "callsign": "KPDF-CD",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "VISION LATINA",
+    "tv_virtual_channel": "41",
+    "facility_id": "73764"
+  },
+  {
+    "callsign": "WPGH-TV",
+    "community_served_city": "PITTSBURGH",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "53",
+    "facility_id": "73875"
+  },
+  {
+    "callsign": "WPHL-TV",
+    "community_served_city": "PHILADELPHIA",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "The CW",
+    "tv_virtual_channel": "17",
+    "facility_id": "73879"
+  },
+  {
+    "callsign": "WPIX",
+    "community_served_city": "NEW YORK",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "11",
+    "facility_id": "73881"
+  },
+  {
+    "callsign": "WORO-DT",
+    "community_served_city": "FAJARDO",
+    "community_served_state": "PR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "13",
+    "facility_id": "73901"
+  },
+  {
+    "callsign": "WPTA",
+    "community_served_city": "FORT WAYNE",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, NBC, MyTV",
+    "tv_virtual_channel": "21",
+    "facility_id": "73905"
+  },
+  {
+    "callsign": "WPNT",
+    "community_served_city": "PITTSBURGH",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "22",
+    "facility_id": "73907"
+  },
+  {
+    "callsign": "WPXI",
+    "community_served_city": "PITTSBURGH",
+    "community_served_state": "PA",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, Me-TV, Laff-TV",
+    "tv_virtual_channel": "11",
+    "facility_id": "73910"
+  },
+  {
+    "callsign": "WRDW-TV",
+    "community_served_city": "AUGUSTA",
+    "community_served_state": "GA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, MyNet, True Crime Network, Cozi",
+    "tv_virtual_channel": "12",
+    "facility_id": "73937"
+  },
+  {
+    "callsign": "WREX",
+    "community_served_city": "ROCKFORD",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC(13.1), MeTV Toons(13.2 as of 08/07/2024), MeTV(13.3), CourtTV(13.4), True Crime Network(13.5), CBS(23.10)",
+    "tv_virtual_channel": "13",
+    "facility_id": "73940"
+  },
+  {
+    "callsign": "WRGB",
+    "community_served_city": "SCHENECTADY",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "73942"
+  },
+  {
+    "callsign": "WROC-TV",
+    "community_served_city": "ROCHESTER",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "73964"
+  },
+  {
+    "callsign": "WSBK-TV",
+    "community_served_city": "BOSTON",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "38",
+    "facility_id": "73982"
+  },
+  {
+    "callsign": "WSBT-TV",
+    "community_served_city": "SOUTH BEND",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "22",
+    "facility_id": "73983"
+  },
+  {
+    "callsign": "WSET-TV",
+    "community_served_city": "LYNCHBURG",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "73988"
+  },
+  {
+    "callsign": "KPOB-TV",
+    "community_served_city": "POPLAR BLUFF",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Heroes & Icons, True Crime, Court, ION",
+    "tv_virtual_channel": "15",
+    "facility_id": "73998"
+  },
+  {
+    "callsign": "WSIL-TV",
+    "community_served_city": "HARRISBURG",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Heroes & Icons, True Crime, Court, ION",
+    "tv_virtual_channel": "3",
+    "facility_id": "73999"
+  },
+  {
+    "callsign": "WSJV",
+    "community_served_city": "ELKHART",
+    "community_served_state": "IN",
+    "active_ind": "Y",
+    "network_affiliation": "Heroes & Icons, True Crime, Quest, Dabl",
+    "tv_virtual_channel": "28",
+    "facility_id": "74007"
+  },
+  {
+    "callsign": "WSKG-TV",
+    "community_served_city": "BINGHAMTON",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "46",
+    "facility_id": "74034"
+  },
+  {
+    "callsign": "WSOC-TV",
+    "community_served_city": "CHARLOTTE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ABC (9.1), Telemundo (9.2), GetTV (9.3). Comet (9.4)",
+    "tv_virtual_channel": "9",
+    "facility_id": "74070"
+  },
+  {
+    "callsign": "WPXW-TV",
+    "community_served_city": "MANASSAS",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Bounce, Court TV, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN",
+    "tv_virtual_channel": "66",
+    "facility_id": "74091"
+  },
+  {
+    "callsign": "WSYM-TV",
+    "community_served_city": "LANSING",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "47",
+    "facility_id": "74094"
+  },
+  {
+    "callsign": "WTMJ-TV",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "4",
+    "facility_id": "74098"
+  },
+  {
+    "callsign": "KTNV-TV",
+    "community_served_city": "LAS VEGAS",
+    "community_served_state": "NV",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "74100"
+  },
+  {
+    "callsign": "WTNH",
+    "community_served_city": "NEW HAVEN",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "74109"
+  },
+  {
+    "callsign": "WTOG",
+    "community_served_city": "ST. PETERSBURG",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "44",
+    "facility_id": "74112"
+  },
+  {
+    "callsign": "WTOV-TV",
+    "community_served_city": "STEUBENVILLE",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "WTOV D1 - NBC; WTOV D2 - FOX; WTOV D3 - Comet",
+    "tv_virtual_channel": "9",
+    "facility_id": "74122"
+  },
+  {
+    "callsign": "WTTE",
+    "community_served_city": "COLUMBUS",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "TBD",
+    "tv_virtual_channel": "28",
+    "facility_id": "74137"
+  },
+  {
+    "callsign": "WTTO",
+    "community_served_city": "HOMEWOOD",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "The CW Network",
+    "tv_virtual_channel": "21",
+    "facility_id": "74138"
+  },
+  {
+    "callsign": "WTVA",
+    "community_served_city": "TUPELO",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, ABC",
+    "tv_virtual_channel": "9",
+    "facility_id": "74148"
+  },
+  {
+    "callsign": "WTVG",
+    "community_served_city": "TOLEDO",
+    "community_served_state": "OH",
+    "active_ind": "Y",
+    "network_affiliation": "abc",
+    "tv_virtual_channel": "13",
+    "facility_id": "74150"
+  },
+  {
+    "callsign": "WTVH",
+    "community_served_city": "SYRACUSE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "CBS, Charge, TBD",
+    "tv_virtual_channel": "5",
+    "facility_id": "74151"
+  },
+  {
+    "callsign": "WRNN-TV",
+    "community_served_city": "NEW ROCHELLE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC",
+    "tv_virtual_channel": "48",
+    "facility_id": "74156"
+  },
+  {
+    "callsign": "WVEC",
+    "community_served_city": "HAMPTON",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "13",
+    "facility_id": "74167"
+  },
+  {
+    "callsign": "WVNS-TV",
+    "community_served_city": "LEWISBURG",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "59",
+    "facility_id": "74169"
+  },
+  {
+    "callsign": "WVIT",
+    "community_served_city": "NEW BRITAIN",
+    "community_served_state": "CT",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "30",
+    "facility_id": "74170"
+  },
+  {
+    "callsign": "WVTM-TV",
+    "community_served_city": "BIRMINGHAM",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC/MeTV",
+    "tv_virtual_channel": "13",
+    "facility_id": "74173"
+  },
+  {
+    "callsign": "WVTV",
+    "community_served_city": "MILWAUKEE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "18",
+    "facility_id": "74174"
+  },
+  {
+    "callsign": "WVVA",
+    "community_served_city": "BLUEFIELD",
+    "community_served_state": "WV",
+    "active_ind": "Y",
+    "network_affiliation": "NBC CW METV",
+    "tv_virtual_channel": "6",
+    "facility_id": "74176"
+  },
+  {
+    "callsign": "WWL-TV",
+    "community_served_city": "NEW ORLEANS",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "4",
+    "facility_id": "74192"
+  },
+  {
+    "callsign": "WWMT",
+    "community_served_city": "KALAMAZOO",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "3",
+    "facility_id": "74195"
+  },
+  {
+    "callsign": "WWOR-TV",
+    "community_served_city": "SECAUCUS",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "MyNetworkTV",
+    "tv_virtual_channel": "9",
+    "facility_id": "74197"
+  },
+  {
+    "callsign": "WMYD",
+    "community_served_city": "DETROIT",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "20",
+    "facility_id": "74211"
+  },
+  {
+    "callsign": "WXTV-DT",
+    "community_served_city": "PATERSON",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "41",
+    "facility_id": "74215"
+  },
+  {
+    "callsign": "KFNB",
+    "community_served_city": "CASPER",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "20",
+    "facility_id": "74256"
+  },
+  {
+    "callsign": "WRIC-TV",
+    "community_served_city": "PETERSBURG",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "8",
+    "facility_id": "74416"
+  },
+  {
+    "callsign": "WBAY-TV",
+    "community_served_city": "GREEN BAY",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC, Catchy Comedy",
+    "tv_virtual_channel": "2",
+    "facility_id": "74417"
+  },
+  {
+    "callsign": "DWCDC-TV",
+    "community_served_city": "ADAMS",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "19",
+    "facility_id": "74419"
+  },
+  {
+    "callsign": "WLNS-TV",
+    "community_served_city": "LANSING",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "74420"
+  },
+  {
+    "callsign": "WTEN",
+    "community_served_city": "ALBANY",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "10",
+    "facility_id": "74422"
+  },
+  {
+    "callsign": "WKBT-DT",
+    "community_served_city": "LA CROSSE",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS",
+    "tv_virtual_channel": "8",
+    "facility_id": "74424"
+  },
+  {
+    "callsign": "DKSWT",
+    "community_served_city": "YUMA",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "11",
+    "facility_id": "74449"
+  },
+  {
+    "callsign": "WPHY-CD",
+    "community_served_city": "TRENTON",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "25",
+    "facility_id": "74464"
+  },
+  {
+    "callsign": "DDWAZE-TV",
+    "community_served_city": "MADISONVILLE",
+    "community_served_state": "KY",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "19",
+    "facility_id": "74592"
+  },
+  {
+    "callsign": "WBKP",
+    "community_served_city": "CALUMET",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "5",
+    "facility_id": "76001"
+  },
+  {
+    "callsign": "KWBQ",
+    "community_served_city": "SANTA FE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "19",
+    "facility_id": "76268"
+  },
+  {
+    "callsign": "WSKY-TV",
+    "community_served_city": "MANTEO",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "76324"
+  },
+  {
+    "callsign": "KMTW",
+    "community_served_city": "HUTCHINSON",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "Dabl & TBD",
+    "tv_virtual_channel": "36",
+    "facility_id": "77063"
+  },
+  {
+    "callsign": "KPTH",
+    "community_served_city": "SIOUX CITY",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "44",
+    "facility_id": "77451"
+  },
+  {
+    "callsign": "KPCB-DT",
+    "community_served_city": "SNYDER",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "17",
+    "facility_id": "77452"
+  },
+  {
+    "callsign": "KTUZ-TV",
+    "community_served_city": "SHAWNEE",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "TELEMUNDO",
+    "tv_virtual_channel": "30",
+    "facility_id": "77480"
+  },
+  {
+    "callsign": "KPXO-TV",
+    "community_served_city": "KANEOHE",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "66",
+    "facility_id": "77483"
+  },
+  {
+    "callsign": "WVUA",
+    "community_served_city": "TUSCALOOSA",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "COZI TV",
+    "tv_virtual_channel": "23",
+    "facility_id": "77496"
+  },
+  {
+    "callsign": "KPNZ",
+    "community_served_city": "OGDEN",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "24",
+    "facility_id": "77512"
+  },
+  {
+    "callsign": "WYCI",
+    "community_served_city": "SARANAC LAKE",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "MYNET",
+    "tv_virtual_channel": "40",
+    "facility_id": "77515"
+  },
+  {
+    "callsign": "KLCW-TV",
+    "community_served_city": "WOLFFORTH",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "22",
+    "facility_id": "77719"
+  },
+  {
+    "callsign": "WYOW",
+    "community_served_city": "EAGLE RIVER",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "34",
+    "facility_id": "77789"
+  },
+  {
+    "callsign": "KUVE-CD",
+    "community_served_city": "TUCSON",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "38",
+    "facility_id": "78036"
+  },
+  {
+    "callsign": "KWBM",
+    "community_served_city": "HARRISON",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "31",
+    "facility_id": "78314"
+  },
+  {
+    "callsign": "KQCW-DT",
+    "community_served_city": "MUSKOGEE",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "19",
+    "facility_id": "78322"
+  },
+  {
+    "callsign": "WSKA",
+    "community_served_city": "CORNING",
+    "community_served_state": "NY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "30",
+    "facility_id": "78908"
+  },
+  {
+    "callsign": "KVUI",
+    "community_served_city": "POCATELLO",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "31",
+    "facility_id": "78910"
+  },
+  {
+    "callsign": "KDMI",
+    "community_served_city": "DES MOINES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "56",
+    "facility_id": "78915"
+  },
+  {
+    "callsign": "KQUP",
+    "community_served_city": "PULLMAN",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "24",
+    "facility_id": "78921"
+  },
+  {
+    "callsign": "KDCK",
+    "community_served_city": "DODGE CITY",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "21",
+    "facility_id": "79258"
+  },
+  {
+    "callsign": "KFTU-DT",
+    "community_served_city": "DOUGLAS",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "3",
+    "facility_id": "81441"
+  },
+  {
+    "callsign": "KPTF-DT",
+    "community_served_city": "FARWELL",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "18",
+    "facility_id": "81445"
+  },
+  {
+    "callsign": "KUNP",
+    "community_served_city": "LA GRANDE",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "16",
+    "facility_id": "81447"
+  },
+  {
+    "callsign": "WZMQ",
+    "community_served_city": "MARQUETTE",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV (Main), CBS (Multicast)",
+    "tv_virtual_channel": "19",
+    "facility_id": "81448"
+  },
+  {
+    "callsign": "KUTH-DT",
+    "community_served_city": "PROVO",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "32",
+    "facility_id": "81451"
+  },
+  {
+    "callsign": "KTAZ",
+    "community_served_city": "PHOENIX",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "39",
+    "facility_id": "81458"
+  },
+  {
+    "callsign": "KNBN",
+    "community_served_city": "RAPID CITY",
+    "community_served_state": "SD",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "21",
+    "facility_id": "81464"
+  },
+  {
+    "callsign": "WMOW",
+    "community_served_city": "CRANDON",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ABC 4.1, Catchy Comedy 4.2, MeTV Toons 4.3, CourtTV 4.4, and True Crime 4.5",
+    "tv_virtual_channel": "4",
+    "facility_id": "81503"
+  },
+  {
+    "callsign": "KPXJ",
+    "community_served_city": "MINDEN",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "21",
+    "facility_id": "81507"
+  },
+  {
+    "callsign": "WEPX-TV",
+    "community_served_city": "GREENVILLE",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Grit, Laff, IONPlus, SCRIPPS News, Jewelry TV, HSN, QVC",
+    "tv_virtual_channel": "38",
+    "facility_id": "81508"
+  },
+  {
+    "callsign": "KFPX-TV",
+    "community_served_city": "NEWTON",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Laff, Mystery, IONPlus, SCRIPPS News, Jewelry TV, HSN, HSN2",
+    "tv_virtual_channel": "39",
+    "facility_id": "81509"
+  },
+  {
+    "callsign": "KXNW",
+    "community_served_city": "EUREKA SPRINGS",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "My Network",
+    "tv_virtual_channel": "34",
+    "facility_id": "81593"
+  },
+  {
+    "callsign": "WBIF",
+    "community_served_city": "MARIANNA",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "51",
+    "facility_id": "81594"
+  },
+  {
+    "callsign": "DKWWF",
+    "community_served_city": "WATERLOO",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "RTN",
+    "tv_virtual_channel": "22",
+    "facility_id": "81595"
+  },
+  {
+    "callsign": "WFBD",
+    "community_served_city": "DESTIN",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "48",
+    "facility_id": "81669"
+  },
+  {
+    "callsign": "WTWV",
+    "community_served_city": "MEMPHIS",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "REL",
+    "tv_virtual_channel": "14",
+    "facility_id": "81692"
+  },
+  {
+    "callsign": "KGPX-TV",
+    "community_served_city": "SPOKANE",
+    "community_served_state": "WA",
+    "active_ind": "Y",
+    "network_affiliation": "ION",
+    "tv_virtual_channel": "34",
+    "facility_id": "81694"
+  },
+  {
+    "callsign": "WVLR",
+    "community_served_city": "TAZEWELL",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "48",
+    "facility_id": "81750"
+  },
+  {
+    "callsign": "WMWC-TV",
+    "community_served_city": "GALESBURG",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "53",
+    "facility_id": "81946"
+  },
+  {
+    "callsign": "KLWB",
+    "community_served_city": "NEW IBERIA",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV Network",
+    "tv_virtual_channel": "50",
+    "facility_id": "82476"
+  },
+  {
+    "callsign": "WTPC-TV",
+    "community_served_city": "VIRGINIA BEACH",
+    "community_served_state": "VA",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "21",
+    "facility_id": "82574"
+  },
+  {
+    "callsign": "KPTW",
+    "community_served_city": "CASPER",
+    "community_served_state": "WY",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "6",
+    "facility_id": "82575"
+  },
+  {
+    "callsign": "KUES",
+    "community_served_city": "RICHFIELD",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "82576"
+  },
+  {
+    "callsign": "KUEW",
+    "community_served_city": "ST. GEORGE",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "18",
+    "facility_id": "82585"
+  },
+  {
+    "callsign": "KNDB",
+    "community_served_city": "BISMARCK",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "26",
+    "facility_id": "82611"
+  },
+  {
+    "callsign": "KRTN-TV",
+    "community_served_city": "DURANGO",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "TBD",
+    "tv_virtual_channel": "33",
+    "facility_id": "82613"
+  },
+  {
+    "callsign": "KNDM",
+    "community_served_city": "MINOT",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "24",
+    "facility_id": "82615"
+  },
+  {
+    "callsign": "DKEFB",
+    "community_served_city": "AMES",
+    "community_served_state": "IA",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "34",
+    "facility_id": "82619"
+  },
+  {
+    "callsign": "WBSF",
+    "community_served_city": "BAY CITY",
+    "community_served_state": "MI",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "46",
+    "facility_id": "82627"
+  },
+  {
+    "callsign": "KRII",
+    "community_served_city": "CHISHOLM",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, CBS, My9, H&I",
+    "tv_virtual_channel": "11",
+    "facility_id": "82698"
+  },
+  {
+    "callsign": "WTLF",
+    "community_served_city": "TALLAHASSEE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "24",
+    "facility_id": "82735"
+  },
+  {
+    "callsign": "KSCC",
+    "community_served_city": "CORPUS CHRISTI",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "38",
+    "facility_id": "82910"
+  },
+  {
+    "callsign": "KKAI",
+    "community_served_city": "KAILUA",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "50",
+    "facility_id": "83180"
+  },
+  {
+    "callsign": "KOCW",
+    "community_served_city": "HOISINGTON",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "14",
+    "facility_id": "83181"
+  },
+  {
+    "callsign": "WZVI",
+    "community_served_city": "CHARLOTTE AMALIE",
+    "community_served_state": "VI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "43",
+    "facility_id": "83270"
+  },
+  {
+    "callsign": "WCVI-TV",
+    "community_served_city": "CHRISTIANSTED",
+    "community_served_state": "VI",
+    "active_ind": "Y",
+    "network_affiliation": "CBS (Main), ABC (Multicast)",
+    "tv_virtual_channel": "39",
+    "facility_id": "83304"
+  },
+  {
+    "callsign": "KBLN-TV",
+    "community_served_city": "GRANTS PASS",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "3ABN",
+    "tv_virtual_channel": "30",
+    "facility_id": "83306"
+  },
+  {
+    "callsign": "DWKDH",
+    "community_served_city": "HOUSTON",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "45",
+    "facility_id": "83310"
+  },
+  {
+    "callsign": "KDTP",
+    "community_served_city": "HOLBROOK",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "11",
+    "facility_id": "83491"
+  },
+  {
+    "callsign": "KTEL-TV",
+    "community_served_city": "CARLSBAD",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "25",
+    "facility_id": "83707"
+  },
+  {
+    "callsign": "KFTC",
+    "community_served_city": "BEMIDJI",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "MNT",
+    "tv_virtual_channel": "26",
+    "facility_id": "83714"
+  },
+  {
+    "callsign": "KEYU",
+    "community_served_city": "BORGER",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "31",
+    "facility_id": "83715"
+  },
+  {
+    "callsign": "WDPM-DT",
+    "community_served_city": "MOBILE",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "18",
+    "facility_id": "83740"
+  },
+  {
+    "callsign": "WUNW",
+    "community_served_city": "CANTON",
+    "community_served_state": "NC",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "27",
+    "facility_id": "83822"
+  },
+  {
+    "callsign": "KVME-TV",
+    "community_served_city": "BISHOP",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "JTV",
+    "tv_virtual_channel": "20",
+    "facility_id": "83825"
+  },
+  {
+    "callsign": "KCEB",
+    "community_served_city": "LONGVIEW",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "CRTV NETWORK",
+    "tv_virtual_channel": "54",
+    "facility_id": "83913"
+  },
+  {
+    "callsign": "WHDT",
+    "community_served_city": "STUART",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "59",
+    "facility_id": "83929"
+  },
+  {
+    "callsign": "WKNX-TV",
+    "community_served_city": "KNOXVILLE",
+    "community_served_state": "TN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "7",
+    "facility_id": "83931"
+  },
+  {
+    "callsign": "WFNA",
+    "community_served_city": "GULF SHORES",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "55",
+    "facility_id": "83943"
+  },
+  {
+    "callsign": "KGLA-DT",
+    "community_served_city": "HAMMOND",
+    "community_served_state": "LA",
+    "active_ind": "Y",
+    "network_affiliation": "Telemundo",
+    "tv_virtual_channel": "42",
+    "facility_id": "83945"
+  },
+  {
+    "callsign": "WNBW-DT",
+    "community_served_city": "GAINESVILLE",
+    "community_served_state": "FL",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "9",
+    "facility_id": "83965"
+  },
+  {
+    "callsign": "WMBF-TV",
+    "community_served_city": "MYRTLE BEACH",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "32",
+    "facility_id": "83969"
+  },
+  {
+    "callsign": "KFJX",
+    "community_served_city": "PITTSBURG",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "FOX, CW, START TV, DABL",
+    "tv_virtual_channel": "14",
+    "facility_id": "83992"
+  },
+  {
+    "callsign": "WPFO",
+    "community_served_city": "WATERVILLE",
+    "community_served_state": "ME",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "23",
+    "facility_id": "84088"
+  },
+  {
+    "callsign": "KRWB-TV",
+    "community_served_city": "ROSWELL",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "CW",
+    "tv_virtual_channel": "21",
+    "facility_id": "84157"
+  },
+  {
+    "callsign": "DKEJB",
+    "community_served_city": "EL DORADO",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "MY NETWORK TV",
+    "tv_virtual_channel": "43",
+    "facility_id": "84164"
+  },
+  {
+    "callsign": "KNMD-TV",
+    "community_served_city": "SANTA FE",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "9",
+    "facility_id": "84215"
+  },
+  {
+    "callsign": "KRMU",
+    "community_served_city": "DURANGO",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "20",
+    "facility_id": "84224"
+  },
+  {
+    "callsign": "KOCM",
+    "community_served_city": "NORMAN",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "46",
+    "facility_id": "84225"
+  },
+  {
+    "callsign": "WLOO",
+    "community_served_city": "VICKSBURG",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "MY Network",
+    "tv_virtual_channel": "35",
+    "facility_id": "84253"
+  },
+  {
+    "callsign": "DKCBU",
+    "community_served_city": "PRICE",
+    "community_served_state": "UT",
+    "active_ind": "Y",
+    "network_affiliation": "DAYSTAR",
+    "tv_virtual_channel": "3",
+    "facility_id": "84277"
+  },
+  {
+    "callsign": "DWVIF",
+    "community_served_city": "CHRISTIANSTED",
+    "community_served_state": "VI",
+    "active_ind": "Y",
+    "network_affiliation": "IND",
+    "tv_virtual_channel": "15",
+    "facility_id": "84407"
+  },
+  {
+    "callsign": "KWWT",
+    "community_served_city": "ODESSA",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "MY NETWORK TV",
+    "tv_virtual_channel": "30",
+    "facility_id": "84410"
+  },
+  {
+    "callsign": "KFXL-TV",
+    "community_served_city": "LINCOLN",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "51",
+    "facility_id": "84453"
+  },
+  {
+    "callsign": "WBIH",
+    "community_served_city": "SELMA",
+    "community_served_state": "AL",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "29",
+    "facility_id": "84802"
+  },
+  {
+    "callsign": "DKOBG-TV",
+    "community_served_city": "SILVER CITY",
+    "community_served_state": "NM",
+    "active_ind": "Y",
+    "network_affiliation": "NBC",
+    "tv_virtual_channel": "6",
+    "facility_id": "85114"
+  },
+  {
+    "callsign": "DWFXS-DT",
+    "community_served_city": "WITTENBERG",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "55",
+    "facility_id": "86204"
+  },
+  {
+    "callsign": "KPIF",
+    "community_served_city": "POCATELLO",
+    "community_served_state": "ID",
+    "active_ind": "Y",
+    "network_affiliation": "Grit",
+    "tv_virtual_channel": "15",
+    "facility_id": "86205"
+  },
+  {
+    "callsign": "DKCPM",
+    "community_served_city": "GRAND FORKS",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "MYTV",
+    "tv_virtual_channel": "27",
+    "facility_id": "86208"
+  },
+  {
+    "callsign": "KUPB",
+    "community_served_city": "MIDLAND",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "18",
+    "facility_id": "86263"
+  },
+  {
+    "callsign": "WTPX-TV",
+    "community_served_city": "ANTIGO",
+    "community_served_state": "WI",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Grit, Mystery, Laff, Bounce, SCRIPPS News, Jewelry TV, HSN, QVC2",
+    "tv_virtual_channel": "46",
+    "facility_id": "86496"
+  },
+  {
+    "callsign": "KUOK",
+    "community_served_city": "WOODWARD",
+    "community_served_state": "OK",
+    "active_ind": "Y",
+    "network_affiliation": "UNIVISION/UNIMAS/",
+    "tv_virtual_channel": "35",
+    "facility_id": "86532"
+  },
+  {
+    "callsign": "KMYA-DT",
+    "community_served_city": "CAMDEN",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "ME-TV",
+    "tv_virtual_channel": "49",
+    "facility_id": "86534"
+  },
+  {
+    "callsign": "WJLP",
+    "community_served_city": "MIDDLETOWN TOWNSHIP",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "MeTV",
+    "tv_virtual_channel": "33",
+    "facility_id": "86537"
+  },
+  {
+    "callsign": "KUPU",
+    "community_served_city": "WAIMANALO",
+    "community_served_state": "HI",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "56",
+    "facility_id": "89714"
+  },
+  {
+    "callsign": "KETZ",
+    "community_served_city": "EL DORADO",
+    "community_served_state": "AR",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "12",
+    "facility_id": "92872"
+  },
+  {
+    "callsign": "KNIC-DT",
+    "community_served_city": "BLANCO",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Unimas",
+    "tv_virtual_channel": "17",
+    "facility_id": "125710"
+  },
+  {
+    "callsign": "KCGE",
+    "community_served_city": "CROOKSTON",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "16",
+    "facility_id": "132606"
+  },
+  {
+    "callsign": "DKTUW",
+    "community_served_city": "SCOTTSBLUFF",
+    "community_served_state": "NE",
+    "active_ind": "Y",
+    "network_affiliation": "RTN",
+    "tv_virtual_channel": "16",
+    "facility_id": "136747"
+  },
+  {
+    "callsign": "WRBJ-TV",
+    "community_served_city": "MAGEE",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "34",
+    "facility_id": "136749"
+  },
+  {
+    "callsign": "WZRB",
+    "community_served_city": "COLUMBIA",
+    "community_served_state": "SC",
+    "active_ind": "Y",
+    "network_affiliation": "ION, Court TV, Mystery, Grit, IONPlus, SCRIPPS News, Jewelry TV, QVC2, HSN2",
+    "tv_virtual_channel": "47",
+    "facility_id": "136750"
+  },
+  {
+    "callsign": "WNYA",
+    "community_served_city": "PITTSFIELD",
+    "community_served_state": "MA",
+    "active_ind": "Y",
+    "network_affiliation": "My Network",
+    "tv_virtual_channel": "51",
+    "facility_id": "136751"
+  },
+  {
+    "callsign": "WRPT",
+    "community_served_city": "HIBBING",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "31",
+    "facility_id": "159007"
+  },
+  {
+    "callsign": "KMDE",
+    "community_served_city": "DEVILS LAKE",
+    "community_served_state": "ND",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "25",
+    "facility_id": "162016"
+  },
+  {
+    "callsign": "KWKS",
+    "community_served_city": "COLBY",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "PBS",
+    "tv_virtual_channel": "19",
+    "facility_id": "162115"
+  },
+  {
+    "callsign": "KRBK",
+    "community_served_city": "OSAGE BEACH",
+    "community_served_state": "MO",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "49",
+    "facility_id": "166319"
+  },
+  {
+    "callsign": "KVSN-DT",
+    "community_served_city": "PUEBLO",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "48",
+    "facility_id": "166331"
+  },
+  {
+    "callsign": "KDCU-DT",
+    "community_served_city": "DERBY",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "Univision",
+    "tv_virtual_channel": "46",
+    "facility_id": "166332"
+  },
+  {
+    "callsign": "KPJR-TV",
+    "community_served_city": "GREELEY",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "TBN",
+    "tv_virtual_channel": "38",
+    "facility_id": "166510"
+  },
+  {
+    "callsign": "KCWV",
+    "community_served_city": "DULUTH",
+    "community_served_state": "MN",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "27",
+    "facility_id": "166511"
+  },
+  {
+    "callsign": "WWJX",
+    "community_served_city": "JACKSON",
+    "community_served_state": "MS",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "51",
+    "facility_id": "166512"
+  },
+  {
+    "callsign": "KOHD",
+    "community_served_city": "BEND",
+    "community_served_state": "OR",
+    "active_ind": "Y",
+    "network_affiliation": "ABC",
+    "tv_virtual_channel": "51",
+    "facility_id": "166534"
+  },
+  {
+    "callsign": "KSQA",
+    "community_served_city": "TOPEKA",
+    "community_served_state": "KS",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "22",
+    "facility_id": "166546"
+  },
+  {
+    "callsign": "KNLA-CD",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "20",
+    "facility_id": "167309"
+  },
+  {
+    "callsign": "WPSJ-CD",
+    "community_served_city": "HAMMONTON",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "LATV NETWORK",
+    "tv_virtual_channel": "8",
+    "facility_id": "167543"
+  },
+  {
+    "callsign": "KMMD-CD",
+    "community_served_city": "SALINAS",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CourtTV, Grit, LAFF, Mistery",
+    "tv_virtual_channel": "39",
+    "facility_id": "167838"
+  },
+  {
+    "callsign": "KQMM-CD",
+    "community_served_city": "SANTA MARIA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "CRTV NETWORK",
+    "tv_virtual_channel": "29",
+    "facility_id": "167844"
+  },
+  {
+    "callsign": "KJTV-CD",
+    "community_served_city": "WOLFFORTH",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "33",
+    "facility_id": "168090"
+  },
+  {
+    "callsign": "WPVN-CD",
+    "community_served_city": "CHICAGO",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "VISION LATINA",
+    "tv_virtual_channel": "24",
+    "facility_id": "168237"
+  },
+  {
+    "callsign": "KMPH-CD",
+    "community_served_city": "MERCED-MARIPOSA",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "FOX",
+    "tv_virtual_channel": "49",
+    "facility_id": "168338"
+  },
+  {
+    "callsign": "K04QP-D",
+    "community_served_city": "CASAS ADOBES",
+    "community_served_state": "AZ",
+    "active_ind": "Y",
+    "network_affiliation": "NBC, COZI",
+    "tv_virtual_channel": "4",
+    "facility_id": "168403"
+  },
+  {
+    "callsign": "KPLE-CD",
+    "community_served_city": "KILLEEN",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "TCT Network",
+    "tv_virtual_channel": "30",
+    "facility_id": "168452"
+  },
+  {
+    "callsign": "K24HH-D",
+    "community_served_city": "WICHITA FALLS",
+    "community_served_state": "TX",
+    "active_ind": "Y",
+    "network_affiliation": "NRB",
+    "tv_virtual_channel": "24",
+    "facility_id": "168560"
+  },
+  {
+    "callsign": "KSBS-CD",
+    "community_served_city": "DENVER",
+    "community_served_state": "CO",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "10",
+    "facility_id": "168750"
+  },
+  {
+    "callsign": "WMDE",
+    "community_served_city": "DOVER",
+    "community_served_state": "DE",
+    "active_ind": "Y",
+    "network_affiliation": "Shop LC",
+    "tv_virtual_channel": "36",
+    "facility_id": "189357"
+  },
+  {
+    "callsign": "WACP",
+    "community_served_city": "ATLANTIC CITY",
+    "community_served_state": "NJ",
+    "active_ind": "Y",
+    "network_affiliation": "Independent",
+    "tv_virtual_channel": "4",
+    "facility_id": "189358"
+  },
+  {
+    "callsign": "KSFV-CD",
+    "community_served_city": "LOS ANGELES",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "JTV",
+    "tv_virtual_channel": "6",
+    "facility_id": "191101"
+  },
+  {
+    "callsign": "KPOM-CD",
+    "community_served_city": "ONTARIO",
+    "community_served_state": "CA",
+    "active_ind": "Y",
+    "network_affiliation": "Catchy Comedy",
+    "tv_virtual_channel": "14",
+    "facility_id": "191793"
+  },
+  {
+    "callsign": "WSLN",
+    "community_served_city": "FREEPORT",
+    "community_served_state": "IL",
+    "active_ind": "Y",
+    "network_affiliation": "CW Plus",
+    "tv_virtual_channel": "19",
+    "facility_id": "776220"
+  }
+]

--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1650116",
+  "version": "1.26.1720023",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/plugins/stream-mapparr/plugin.py
+++ b/plugins/stream-mapparr/plugin.py
@@ -78,7 +78,7 @@ class PluginConfig:
     """
 
     # === PLUGIN METADATA ===
-    PLUGIN_VERSION = "1.26.1650116"
+    PLUGIN_VERSION = "1.26.1720023"
     FUZZY_MATCHER_MIN_VERSION = "25.358.0200"  # Requires custom ignore tags Unicode fix
 
     # Match sensitivity presets (maps select value to threshold number)
@@ -2191,6 +2191,45 @@ class Plugin:
         # This is mostly a placeholder if needed for string-based checks
         return None
 
+    def _extract_paren_callsign(self, channel_name):
+        """Extract a US TV callsign carried in PARENTHESES in the channel name,
+        e.g. 'ABC - AL Montgomery (WNCF)' -> 'WNCF', '... (WWL)' -> 'WWL',
+        '... (WFAA-TV)' -> 'WFAA'. Returns the base callsign (suffix stripped),
+        uppercased, or None.
+
+        Parenthesized callsigns are the reliable OTA signal baked into
+        Dispatcharr affiliate channel names; looser callsign positions are
+        intentionally ignored here to avoid misclassifying premium channels.
+        This lets OTA callsign matching work even when US_channels.json has no
+        broadcast/callsign entry for the channel. bug-063.
+        """
+        if not channel_name:
+            return None
+        m = re.search(r'\(([KW][A-Z]{2,3})(?:-(?:TV|CD|LP|DT|LD))?\)',
+                      channel_name, re.IGNORECASE)
+        if not m:
+            return None
+        callsign = m.group(1).upper()
+        if callsign in ('WEST', 'EAST', 'KIDS', 'WILD'):
+            return None
+        return callsign
+
+    def _resolve_ota_callsign(self, channel_name):
+        """Resolve an OTA callsign for a Dispatcharr channel name.
+
+        Prefers a callsign validated against the FCC station table
+        (networks.json, via fuzzy_matcher.match_broadcast_channel) — that is the
+        authoritative signal and rejects spurious callsign-shaped words in
+        premium channel names. Falls back to a parenthesized callsign in the
+        name for legitimate stations that are absent from the FCC table. Returns
+        the callsign (uppercase) or None. bug-063.
+        """
+        if self.fuzzy_matcher:
+            callsign, station = self.fuzzy_matcher.match_broadcast_channel(channel_name)
+            if station is not None:
+                return callsign
+        return self._extract_paren_callsign(channel_name)
+
     def _parse_callsign(self, callsign):
         """Extract clean callsign, removing suffixes after dash."""
         if not callsign:
@@ -2200,49 +2239,55 @@ class Plugin:
         return callsign.upper()
 
     def _build_us_callsign_database(self, logger):
-        """Build lookup dictionary of US OTA callsigns from US_channels.json.
-        
+        """Build lookup dictionary of US OTA callsigns from the FCC station
+        table (networks.json).
+
+        The per-country US_channels.json carries only premium (National/
+        Regional) entries with no callsigns, so the OTA callsign authority is
+        networks.json (callsign -> network_affiliation / city / state). bug-063.
+
         Returns:
-            dict: Callsign database mapping base callsigns to channel info
-                  Example: {"WKRG": {"base_name": "WKRG (CBS)", "category": "...", "type": "..."}}
+            dict: base callsign -> {base_name, category, type}
+                  Example: {"WKRG": {"base_name": "WKRG (CBS) Mobile AL", ...}}
         """
         callsign_db = {}
-        
-        # Load US_channels.json
+
         plugin_dir = os.path.dirname(__file__)
-        us_channels_path = os.path.join(plugin_dir, 'US_channels.json')
-        if not os.path.exists(us_channels_path):
-            logger.warning(f"[Stream-Mapparr] US_channels.json not found at {us_channels_path}")
+        stations_path = os.path.join(plugin_dir, 'networks.json')
+        if not os.path.exists(stations_path):
+            logger.warning(f"[Stream-Mapparr] networks.json not found at {stations_path}")
             return callsign_db
-        
+
         try:
-            with open(us_channels_path, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-            
-            channels = data.get('channels', [])
-            logger.info(f"[Stream-Mapparr] Parsing {len(channels)} entries from US_channels.json")
-            
-            for channel in channels:
-                channel_name = channel.get('channel_name', '')
-                
-                # Extract callsign from channel_name
-                callsign = self._extract_us_callsign(channel_name)
-                
-                if callsign:
-                    # Normalize to base callsign (remove suffixes)
-                    base_callsign = self._normalize_us_callsign(callsign)
-                    
-                    # Store in database (first occurrence becomes base_name)
-                    if base_callsign not in callsign_db:
-                        callsign_db[base_callsign] = {
-                            'base_name': channel_name,
-                            'category': channel.get('category', ''),
-                            'type': channel.get('type', '')
-                        }
-            
+            with open(stations_path, 'r', encoding='utf-8') as f:
+                stations = json.load(f)
+
+            logger.info(f"[Stream-Mapparr] Parsing {len(stations)} stations from networks.json")
+
+            for station in stations:
+                callsign = (station.get('callsign') or '').strip()
+                if not callsign:
+                    continue
+
+                # Normalize to base callsign (remove suffixes like -TV, -DT)
+                base_callsign = self._normalize_us_callsign(callsign)
+                if not base_callsign:
+                    continue
+
+                # First occurrence wins (primary station for the callsign).
+                if base_callsign not in callsign_db:
+                    network = (station.get('network_affiliation') or '').strip()
+                    city = (station.get('community_served_city') or '').title()
+                    state = (station.get('community_served_state') or '').upper()
+                    callsign_db[base_callsign] = {
+                        'base_name': f"{callsign} ({network}) {city} {state}".strip(),
+                        'category': network,
+                        'type': 'broadcast (OTA)',
+                    }
+
             logger.info(f"[Stream-Mapparr] Built US callsign database with {len(callsign_db)} unique callsigns")
             return callsign_db
-            
+
         except Exception as e:
             logger.error(f"[Stream-Mapparr] Error building US callsign database: {e}")
             import traceback
@@ -2346,9 +2391,17 @@ class Plugin:
         if "24/7" in channel_name.lower():
             logger.debug(f"[Stream-Mapparr] Cleaned channel name for matching: {cleaned_channel_name}")
 
-        # Check if this channel has a callsign (OTA broadcast channel)
+        # Determine the OTA callsign for this channel. Prefer the database
+        # entry, but fall back to a callsign carried in parentheses in the
+        # Dispatcharr channel name (e.g. "ABC - AL Montgomery (WNCF)") so OTA
+        # affiliates still match by callsign when US_channels.json has no
+        # broadcast/callsign entry for them. bug-063.
         if self._is_ota_channel(channel_info):
             callsign = channel_info['callsign']
+        else:
+            callsign = self._resolve_ota_callsign(channel_name)
+
+        if callsign:
             logger.debug(f"[Stream-Mapparr] Matching OTA channel: {channel_name} using callsign: {callsign}")
 
             matching_streams = []
@@ -4091,8 +4144,17 @@ class Plugin:
 
                             channels_updated += 1
                         else:
-                            if not dry_run and overwrite_streams:
-                                ChannelStream.objects.filter(channel_id=channel_id).delete()
+                            # bug-063: NEVER clear a channel's existing streams when
+                            # nothing matched. A zero-match result (wrong threshold,
+                            # a database/callsign gap, etc.) combined with
+                            # overwrite_streams=True previously deleted every
+                            # channel's streams and assigned nothing in their place,
+                            # wiping working assignments. "Overwrite" only replaces
+                            # when there are actual replacement streams to apply.
+                            logger.debug(
+                                f"[Stream-Mapparr] No streams matched '{channel['name']}' "
+                                f"(ID: {channel_id}); leaving existing streams untouched."
+                            )
                     except Exception as e:
                         logger.error(f"[Stream-Mapparr] Failed to update channel '{channel['name']}': {e}")
                 


### PR DESCRIPTION
## Stream-Mapparr 1.26.1720023

Bugfix release restoring OTA (broadcast) callsign matching and adding a data-loss guard for overwrite runs. Fixes a user-reported issue where running Match & Assign against US: ABC/CBS/FOX/NBC left almost every channel with no streams.

### Changes
- **Overwrite no longer wipes streams on a zero-match run.** A channel that matched 0 streams with `overwrite_streams=True` previously had all its existing streams deleted and nothing assigned. An empty match set now leaves existing streams untouched.
- **OTA affiliates match by callsign again.** New `_resolve_ota_callsign()` resolves the callsign from the FCC station table first, then falls back to a parenthesized callsign in the channel name.
- **Adds `networks.json`** (FCC station table, 1915 stations) — the plugin now loads it as the OTA callsign authority via `_load_broadcast_stations()`. This file was missing from the registry folder, so OTA matching could not work for marketplace installs.

### Files
`plugin.py`, `fuzzy_matcher.py`, `plugin.json` (version 1.26.1650116 → 1.26.1720023), `CHANGELOG.md`, and `networks.json` (new).

Upstream repo: https://github.com/PiratesIRC/Stream-Mapparr · Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.1720023
