### PR TITLE
[twitcharr] Bump version to 1.3.1

### DIFF
--- a/plugins/twitcharr/plugin.json
+++ b/plugins/twitcharr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Twitcharr",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Twitch live-TV plugin for Dispatcharr with automatic channels, streams, XMLTV guide data and Streamlink playback.",
   "author": "eliasbruno124-dev",
   "maintainers": ["eliasbruno124-dev"],


### PR DESCRIPTION
## About this submission

Updates the existing Twitcharr catalog entry from `1.3.0` to `1.3.1`.

This publishes the upstream v1.3.1 release via the existing external `source_url`:

https://github.com/eliasbruno124-dev/Twitcharr/releases/download/v1.3.1/twitcharr.zip

Main changes in this release:
- Fixes Emby playback by using a dedicated OutputProfile for video-first MPEG-TS with AAC audio
- Adds an Emby-safe 30fps fallback quality preset
- Improves adaptive quality selection for Twitch streams
- Reports media-server M3U integration paths for Emby/Jellyfin setup

## Pre-submission checklist

**If this is a new plugin:**
- [ ] Plugin folder is named `lowercase-kebab-case`
- [ ] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
- [ ] My GitHub username is in `author` or `maintainers`
- [ ] `license` is a valid [OSI-approved SPDX identifier](https://spdx.org/licenses/) (e.g. `MIT`, `Apache-2.0`)
- [ ] I have tested the plugin against a running Dispatcharr instance

**If this is an update to an existing plugin:**
- [x] `version` in `plugin.json` is incremented
- [x] I am listed in `author` or `maintainers` of the existing plugin