### PR TITLE
[iptv-checker] Bump to 1.26.1721834 — blank-screen flag + restore, Dispatcharr timezone, group exclude, settings reorg

### DIFF
--- a/plugins/iptv-checker/README.md
+++ b/plugins/iptv-checker/README.md
@@ -24,6 +24,8 @@ Before installing or using this plugin, it is **highly recommended** that you cr
 ## Features
 
 - **Stream Status Checking:** Verify if IPTV streams are alive or dead with smart retry logic
+- **Blank-Screen Detection (opt-in):** Catch streams that pass ffprobe (valid resolution/codec/bitrate) but decode to a pure black picture. When enabled, each alive stream gets a second `ffmpeg blackdetect` pass and is marked **Dead (`Black Screen`)** if it's essentially all black. Blank channels are their own category — own rename tag (`[Blank]`) and own group (`Black Screens`), separate from regular dead (v1.26.1721554+). Fail-open: any ffmpeg problem leaves the stream Alive (v1.26.1702112+)
+- **Restore Recovered Channels (self-healing):** When a previously marked channel comes back **Alive**, strip the plugin's name tags (`[DEAD]`/`[Slow]`/`[Blank]`/quality) and move it back to its **exact original group** — captured automatically when it was first moved. Available as a manual action and a scheduler toggle that runs first each scheduled check (v1.26.1721554+)
 - **Wildcard Group Matching:** Target groups using patterns like `US-*`, `*Sports*`, or `Movies-??`
 - **Automated Scheduler:** Schedule stream checks using cron expressions with timezone support
 - **Post-Check Automation:** Automatically rename, move, delete, export, and webhook after scheduled checks
@@ -108,6 +110,7 @@ To update the plugin:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | Group(s) to Check | string | *(empty = all)* | Comma-separated group names. Supports wildcards: `US-*`, `*Sports*` |
+| Group(s) to EXCLUDE | string | *(empty)* | Comma-separated groups to skip, applied **after** the include filter. Supports wildcards. With a blank "Group(s) to Check" this means "all groups except these". If a group matches both fields, exclude wins. (v1.26.1721733+) |
 | Check Alternative Streams | boolean | true | Check all alternative/backup streams for each channel |
 | Connection Timeout | number | 10 | Seconds to wait for stream connection |
 | Probe Timeout | number | 20 | Seconds to wait for FFprobe stream analysis |
@@ -117,20 +120,36 @@ To update the plugin:
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| Dead Channel Rename Format | string | `{name} [DEAD]` | Format for renaming dead channels |
-| Move Dead Channels to Group | string | `Graveyard` | Group to move dead channels to |
+| Dead Channel Rename Format | string | `{name} [DEAD]` | Format for renaming dead channels (excludes black/blank — see below) |
+| Move Dead Channels to Group | string | `Graveyard` | Group to move dead channels to (excludes black/blank) |
+| Blank-Screen Channel Rename Format | string | `{name} [Blank]` | Format for renaming channels detected as a blank screen |
+| Move Blank-Screen Channels to Group | string | `Black Screens` | Group to move blank-screen channels to |
 | Low Framerate Rename Format | string | `{name} [Slow]` | Format for renaming low FPS channels (<30fps) |
 | Move Low Framerate Group | string | `Slow` | Group to move low framerate channels to |
 | Video Format Suffixes | string | `UHD, FHD, HD, SD, Unknown` | Formats to add as suffixes |
+
+> **Blank-screen is a separate category (v1.26.1721554+).** When blank-screen detection is on, blank channels are renamed/moved by the **blank** actions (`[Blank]` / `Black Screens`) and are **excluded** from the regular Dead rename/move so they aren't double-tagged. They remain `status=Dead`, so **Delete Dead Channels still deletes them.** Existing users who relied on blank streams getting `[DEAD]`/Graveyard should enable the new blank rename/move toggles (or set the Blank-Screen Rename Format to `{name} [DEAD]`).
 
 ### FFprobe Settings
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | FFprobe Path | string | `/usr/local/bin/ffprobe` | Full path to the ffprobe executable |
-| FFprobe Analysis Flags | string | `-show_streams,-show_frames,...` | Comma-separated FFprobe flags |
-| FFprobe Analysis Duration | number | 5 | Seconds of stream to analyze |
+| FFprobe Analysis Flags | string | `-show_streams,-show_packets,-loglevel error` | Comma-separated FFprobe flags. Do **not** add `-show_frames` — it makes ffprobe emit a combined `packets_and_frames` array that breaks the bitrate calc. |
+| FFprobe Analysis Duration | number | 8 | Seconds of stream to analyze |
 | Streamlink-Only Hosts | string | `youtube.com, youtu.be, twitch.tv, kick.com` | Comma-separated host suffixes ffprobe cannot validate (served via Streamlink). Streams matching these hosts are marked **Skipped** instead of **Dead**, so rename/move/delete actions leave them alone. Blank falls back to defaults. |
+
+### Blank-Screen Detection
+
+Optional second pass that decodes a few seconds of each **alive** stream with `ffmpeg`'s `blackdetect` filter and marks it **Dead (`Black Screen`)** if it is a pure black picture. Off by default. Requires `ffmpeg` in the container (see Requirements). Adds ~5–10 s per alive stream when enabled; dead/skipped streams are unaffected.
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| Detect Blank-Screen Streams | boolean | false | Master toggle. When on, every alive stream is decoded with `ffmpeg blackdetect`; pure-black streams become **Dead** with `error_type = Black Screen`. Fail-open: if ffmpeg is missing or errors, the stream stays Alive. Very-dark-but-not-black "no signal" slates are **not** detected. |
+| Blank-Screen Sample (seconds) | number | 6 | How many seconds of video to decode when testing for black. Longer = more reliable but slower. |
+| Continuous Blank Required (seconds) | number | 3 | Minimum continuous run of black video (within the sample) required to flag. Keep a few seconds below the sample to allow for connection/keyframe latency. |
+| Blank-Screen ffmpeg Timeout (seconds) | number | 20 | Hard wall-clock cap on the ffmpeg decode (connection + sampling). If exceeded, the stream is left Alive. |
+| FFmpeg Path | string | `/usr/local/bin/ffmpeg` | Full path to the ffmpeg executable (under **Advanced**). |
 
 ### Parallel Checking
 
@@ -151,19 +170,23 @@ To update the plugin:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | Scheduled Check Times | string | *(empty)* | Cron expression (e.g., `0 4 * * *` for daily at 4 AM). When **Use Windowed Schedule** is on, this becomes the window **start** trigger. |
-| Scheduler Timezone | select | `America/Chicago` | Timezone for the scheduler |
 | Use Windowed Schedule | boolean | false | When on, each cron-fire opens a run window. The check runs until the configured end-of-window, then halts cleanly between streams. The next time the window opens, the run **resumes** from where it left off — already-checked streams are skipped. |
 | Window End Mode | select | `duration` | `duration` = run for N hours; `time` = run until a specific HH:MM (wraps past midnight if earlier than the start). |
 | Window Duration (hours) | number | 4 | Used when Window End Mode = duration. Decimals allowed (e.g. 3.5). |
-| Window End Time | string | `04:00` | Used when Window End Mode = time. 24-hour format in the Scheduler Timezone above. |
+| Window End Time | string | `04:00` | Used when Window End Mode = time. 24-hour format in Dispatcharr's timezone (see note below). |
+
+> **Timezone (v1.26.1721651+):** the scheduler no longer has its own timezone setting — it uses **Dispatcharr → Settings → General → Time Zone**. Set your timezone there and all scheduled/windowed run times follow it. Falls back to `UTC` only if Dispatcharr's timezone can't be read. *(If you previously chose a plugin timezone that differed from Dispatcharr's, your scheduled times now follow Dispatcharr's — adjust the Dispatcharr setting if needed.)*
 | Export CSV for Scheduled Checks | boolean | false | Auto-export results to CSV after scheduled checks |
+| Restore Recovered Channels | boolean | false | Auto-restore channels that are Alive again but were previously marked — strips plugin tags and moves them back to their original group. Runs **first**, before re-marking. |
 | Rename Dead Channels | boolean | false | Auto-rename dead channels after scheduled checks |
 | Rename Low Framerate Channels | boolean | false | Auto-rename slow channels after scheduled checks |
+| Rename Blank-Screen Channels | boolean | false | Auto-rename blank-screen channels after scheduled checks |
 | Add Video Format Suffix | boolean | false | Auto-add format suffix after scheduled checks |
 | Move Dead Channels | boolean | false | Auto-move dead channels after scheduled checks |
 | Move Low Framerate Channels | boolean | false | Auto-move slow channels after scheduled checks |
+| Move Blank-Screen Channels | boolean | false | Auto-move blank-screen channels after scheduled checks |
 | Delete Dead Channels | boolean | false | Auto-delete dead channels after scheduled checks |
-| Send Webhook Notification | boolean | false | Send webhook after scheduled checks |
+| Send Webhook Notification | boolean | false | Send webhook after scheduled checks (payload gains a `restored` count) |
 
 ### Destructive Settings
 
@@ -177,6 +200,7 @@ To update the plugin:
 
 1. **Configure Preferences**
    - Set your **Group(s) to Check** (supports wildcards like `US-*`)
+   - Optionally set **Group(s) to EXCLUDE** to skip groups (applied after the include filter)
    - Configure checking preferences (Alternative Streams, Timeouts, Retries)
    - Optionally enable **Parallel Checking** for faster processing
    - Click **Save Settings**
@@ -187,7 +211,7 @@ To update the plugin:
 
 3. **Configure Schedule** *(Optional)*
    - Set **Scheduled Check Times** using cron format
-   - Select your **Scheduler Timezone**
+   - Set your timezone in **Dispatcharr → Settings → General → Time Zone** (the scheduler uses it automatically)
    - Enable post-check automation options as desired
    - Click **Run** on **Update Schedule** to activate
 
@@ -236,12 +260,15 @@ To update the plugin:
 - **View Last Results:** View summary of the last completed stream check
 
 ### Channel Management
-- **Rename Dead Channels:** Apply rename format to dead streams
-- **Move Dead Channels to Group:** Relocate dead channels
-- **Delete Dead Channels:** Permanently remove dead channels (requires confirmation)
+- **Rename Dead Channels:** Apply rename format to dead streams (excludes black/blank)
+- **Move Dead Channels to Group:** Relocate dead channels (excludes black/blank)
+- **Delete Dead Channels:** Permanently remove dead channels (requires confirmation; includes black/blank)
+- **Rename Blank-Screen Channels:** Apply `[Blank]` format to channels detected as a blank screen
+- **Move Blank-Screen Channels to Group:** Relocate blank-screen channels to the `Black Screens` group
 - **Rename Low Framerate Channels:** Apply rename format to slow streams (<30fps)
 - **Move Low Framerate Channels:** Relocate slow channels
 - **Add Video Format Suffix:** Apply format tags ([UHD], [FHD], [HD], [SD])
+- **Restore Recovered Channels:** For channels Alive again but previously marked, strip all plugin tags from the name and move them back to their **exact original group** (captured when they were first moved). Original group remembered in `/data/iptv_checker_channel_state.json`. If the original group was deleted, the name is still restored.
 
 ### Data & Maintenance
 - **View Results Table:** Detailed tabular format for copy/paste
@@ -258,9 +285,15 @@ Use shell-style wildcards in the Group(s) to Check field:
 - `Movies-??` — matches Movies-US, Movies-UK, etc.
 - Multiple patterns: `US-*, UK-*, *Sports*` (comma-separated)
 
+### Excluding Groups (v1.26.1721733+)
+Use the **Group(s) to EXCLUDE** field to skip groups that would otherwise be checked. Same comma-separated wildcard syntax. Exclude is applied **after** the include filter, so it composes:
+- Check `US-*` but skip the pay-per-view groups → Check `US-*`, Exclude `US-PPV-*`
+- Check everything except one group → leave Check blank, Exclude `Adult`
+- Matching is case-sensitive (same as the include field). If a group matches both fields, **exclude wins**. If the filters leave nothing, the load reports an error rather than silently checking all groups.
+
 ### Automated Scheduling
 - **Cron Support:** Configure checks using standard cron syntax (e.g., `0 4 * * *`)
-- **Timezone Aware:** Schedules run according to your local timezone
+- **Timezone Aware:** Schedules run according to **Dispatcharr's** configured timezone (Settings → General → Time Zone); no separate plugin timezone to keep in sync (v1.26.1721651+)
 - **Post-Check Automation:** Chain any combination of rename, move, delete, export, and webhook actions
 - **Conflict Prevention:** Scheduler queues jobs if a manual check is already running
 
@@ -268,12 +301,12 @@ Use shell-style wildcards in the Group(s) to Check field:
 
 For overnight or off-peak runs, enable **Use Windowed Schedule**. The cron expression becomes the window **start**; the check halts cleanly when the window closes and resumes from the same place the next time the window opens.
 
-**Example — Sun–Thu, 00:00 → 04:00 CST:**
+**Example — Sun–Thu, 00:00 → 04:00 (in Dispatcharr's timezone):**
 
 | Setting | Value |
 |---|---|
 | Scheduled Check Times | `0 0 * * 0-4` |
-| Scheduler Timezone | `America/Chicago` |
+| Dispatcharr Time Zone (Settings → General) | `America/Chicago` |
 | Use Windowed Schedule | ✅ on |
 | Window End Mode | `duration` |
 | Window Duration (hours) | `4` |
@@ -310,9 +343,27 @@ If you see a lot of "Server Error" or "Stream Unreachable" results that turn ali
 - **Safety gates:** Requires typing `DELETE` in the confirmation field AND confirming via dialog
 - Can be automated via scheduler with the same confirmation gate
 
+### Blank-Screen Detection
+- **The problem it solves:** some streams return a perfectly valid signal (resolution, codec, framerate, bitrate) yet only ever display a blank screen. ffprobe can't catch these — it reads metadata, not pixels — so they're reported Alive.
+- **How it works:** when **Detect Blank-Screen Streams** is enabled, every stream that passes ffprobe is decoded for `Blank-Screen Sample (seconds)` with `ffmpeg -vf blackdetect=d=<min>:pic_th=0.98`. If a continuous black run of at least `Continuous Blank Required (seconds)` is found, the stream is reclassified **Dead** with `error_type = Black Screen` and its `stream_stats` are cleared — so it flows through rename/move/delete, CSV, and webhook exactly like any other dead stream.
+- **Fail-open by design:** if ffmpeg is missing, errors, or exceeds `Blank-Screen ffmpeg Timeout (seconds)`, the stream is left **Alive** — a tooling glitch never falsely kills a working channel.
+- **Cost:** ~5–10 s of extra decode per **alive** stream; dead/skipped streams are skipped. Runs on both manual and scheduled checks when enabled, and respects the windowed-schedule boundary.
+- **Tuning false positives:** a channel that's legitimately black for several seconds (fade-from-black intro, station slate) can trip detection. Raise **Continuous Blank Required** or **Sample** seconds if needed. Only pure black is detected; dark-grey/error-card screens are not.
+- **Separate category (v1.26.1721554+):** when detection is on, blank channels are handled by the dedicated **Rename/Move Blank-Screen** actions (`[Blank]` tag, `Black Screens` group) and are **excluded** from the regular Dead rename/move so they aren't double-tagged. They stay `status=Dead`, so **Delete Dead Channels still removes them.**
+
+### Restore Recovered Channels (self-healing)
+- **The problem it solves:** once a channel is renamed `[DEAD]`/`[Slow]`/`[Blank]` and exiled to a Graveyard / Slow / blank-screen group, there was no automatic way back when the stream recovered. It stayed tagged and stranded.
+- **How it works:** for each channel whose latest status is **Alive** but which was previously marked by this plugin (it has a stored original group, or its name still carries a plugin status tag), the restore action strips **all** plugin name tags back to a clean base name and moves it back to its **exact original group**. The original group is captured to `/data/iptv_checker_channel_state.json` the moment a Move action exiles the channel (it never records a managed destination group as the "original", and never overwrites an existing capture).
+- **Eligibility is conservative:** a healthy channel that merely has a `[HD]` quality suffix and was never marked is **not** touched.
+- **Manual or scheduled:** run **Restore Recovered Channels** on demand, or enable the scheduler toggle — it runs **first** each scheduled check (heal before re-marking). The webhook payload gains a `restored` count.
+- **Edge cases:** if the original group was deleted in the meantime, the name is still restored and the channel is left where it is (a warning is logged). Deleting a dead channel prunes its stored state.
+- **Operational note:** a channel parked in a Graveyard / Slow / blank-screen group is only re-checked — and therefore only restorable — if your scan scope **includes** that group. Add the managed groups to your scheduled scan scope (or run a full-scope scan) so self-healing actually fires.
+
 ### Webhook Notifications
-- Sends HTTP POST with JSON payload after scheduled checks complete
-- Configure any URL — works with Discord, Slack, custom endpoints
+- Sends an HTTP POST after scheduled checks complete
+- **Discord:** paste your Discord webhook URL as-is — the plugin auto-detects Discord hosts (`discord.com` / `discordapp.com`) and sends a native message Discord renders directly. No need to append `/slack` or edit the URL.
+- **Custom endpoints / integrations:** non-Discord URLs receive a machine-readable JSON payload (`{plugin, event, total, alive, dead, skipped, timestamp}`; scheduled runs with restore enabled also include `restored`)
+- Sends an explicit `User-Agent` header so Cloudflare-fronted services (like Discord) don't silently reject the request
 - No additional dependencies (uses Python's built-in `urllib`)
 
 ## Troubleshooting
@@ -354,6 +405,7 @@ docker restart dispatcharr
 - **Results:** `/data/iptv_checker_results.json`
 - **Loaded Channels:** `/data/iptv_checker_loaded_channels.json`
 - **Progress State:** `/data/iptv_checker_progress.json`
+- **Channel State (original group for restore):** `/data/iptv_checker_channel_state.json`
 - **Settings:** `/data/iptv_checker_settings.json`
 - **CSV Exports:** `/data/exports/iptv_checker_results_YYYYMMDD_HHMMSS.csv`
 
@@ -374,14 +426,16 @@ Pull requests welcome. To submit changes:
 
 ### To this repo (PiratesIRC/Dispatcharr-IPTV-Checker-Plugin)
 
-1. Bump version: `python3 bump_version.py` (auto-stamps with current UTC day-of-year + HHMM).
-2. Commit, push, tag, and release:
+1. Bump the version (calver `1.26.{DDD}{HHMM}`, UTC) with `python bump_version.py` — it updates `iptv_checker/plugin.json`, `iptv_checker/plugin.py`, and the "Current Version" line in `CLAUDE.md` in one shot, and verifies they agree.
+2. Validate: `python -m pytest tests -q && python -m ruff check .`
+3. Commit, tag, and push:
 
 ```bash
-git tag <version> && git push origin <version>
-gh release create <version> --title "v<version>" --notes "..."
-gh release upload <version> iptv_checker.zip
+git add -A && git commit -m "v<version> — <summary>"
+git tag <version> && git push origin main --tags
 ```
+
+CI (`.github/workflows/ci.yml`) re-runs the checks, builds `iptv_checker-v<version>.zip` (excluding `__pycache__`), and attaches it to the GitHub release automatically when the tag lands. See `DEVELOPMENT.md` for the full workflow.
 
 ### To the upstream marketplace (Dispatcharr/Plugins)
 

--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.1582047",
+  "version": "1.26.1721834",
   "description": "A Dispatcharr Plugin that goes through a playlist to check IPTV channels",
   "author": "PiratesIRC",
   "logo": "logo.png",
@@ -24,6 +24,13 @@
       "help_text": "The name of the Dispatcharr Channel Group(s) to check. Supports wildcards: US-* matches US-Movies, US-Sports, etc. Leave blank to check all groups."
     },
     {
+      "id": "group_names_exclude",
+      "label": "\ud83d\udcc2 Group(s) to EXCLUDE (comma-separated, wildcards supported)",
+      "type": "string",
+      "default": "",
+      "help_text": "Groups to skip even if they match 'Group(s) to Check'. Supports wildcards (e.g. US-PPV-*). Applied AFTER the include filter; with a blank include this means 'all groups except these'. If a group matches both fields, exclude wins. Leave blank to exclude nothing."
+    },
+    {
       "id": "check_alternative_streams",
       "label": "\ud83d\udd04 Check Alternative Streams",
       "type": "boolean",
@@ -41,7 +48,7 @@
       "id": "_section_check_behavior",
       "label": "\ud83d\udd0d Check Behavior",
       "type": "info",
-      "description": "Timeouts, retries, concurrency, cooldown, and ffprobe analysis flags. Keep worker count below your provider's concurrent-connection limit."
+      "description": "Timeouts, retries, concurrency, and cooldown. Keep worker count below your provider's concurrent-connection limit."
     },
     {
       "id": "timeout",
@@ -86,27 +93,44 @@
       "help_text": "Cooldown each worker waits after finishing a stream check, before picking up the next. Prevents provider rate-limiting / slot-reuse errors when your account has a concurrent-connection limit. Default: 2. Retry passes use 3x this value."
     },
     {
-      "id": "ffprobe_flags",
-      "label": "\ud83d\udd0d FFprobe Analysis Flags",
-      "type": "string",
-      "default": "-show_streams,-show_packets,-loglevel error",
-      "placeholder": "-show_streams, -show_packets",
-      "help_text": "Comma-separated ffprobe flags for stream analysis. Options: -show_streams (basic validation), -show_packets (per-packet data; required for video bitrate calculation on live MPEG-TS streams), -loglevel error (errors only). Default: -show_streams,-show_packets,-loglevel error. Note: do not add -show_frames — when both -show_frames and -show_packets are passed, ffprobe returns a combined packets_and_frames array instead of separate packets[], which prevents the bitrate fallback from running."
+      "id": "_section_black_screen",
+      "label": "\u2b1b Blank-Screen Detection",
+      "type": "info",
+      "description": "Optionally decode a few seconds of each Alive stream with ffmpeg and mark it Dead if it is a pure blank (all-black) screen. Costs extra CPU/time per Alive stream."
     },
     {
-      "id": "ffprobe_analysis_duration",
-      "label": "\u23f1\ufe0f FFprobe Analysis Duration (seconds)",
+      "id": "black_screen_detection",
+      "label": "\u2b1b Detect Blank-Screen Streams",
+      "type": "boolean",
+      "default": false,
+      "help_text": "When ON, every stream that passes ffprobe is decoded for a few seconds with ffmpeg's blackdetect filter; pure-blank (all-black) streams are marked Dead and reported under the `Black Screen` error type so rename/move/delete actions handle them. Adds ~5-10s per Alive stream. Fail-open: if ffmpeg is missing or errors, the stream stays Alive. Very-dark-but-not-black 'no signal' slates are NOT detected."
+    },
+    {
+      "id": "black_screen_sample_seconds",
+      "label": "\u2b1b Blank-Screen Sample (seconds)",
       "type": "number",
-      "default": 8,
-      "help_text": "Duration to analyze stream when using -show_frames or -show_packets. Longer duration = more accurate bitrate/GOP analysis but slower checks. Probes that capture fewer than 30 video packets leave video_bitrate unset, so 8s gives slow-start streams enough room to clear the threshold. Default: 8 seconds"
+      "default": 6,
+      "help_text": "How many seconds of video to decode when testing for a blank screen. Longer = more reliable but slower. Default: 6"
     },
     {
-      "id": "streamlink_hosts",
-      "label": "\u23fc Streamlink-Only Hosts (skip ffprobe)",
-      "type": "string",
-      "default": "youtube.com, youtu.be, twitch.tv, kick.com",
-      "placeholder": "youtube.com, twitch.tv",
-      "help_text": "Comma-separated host suffixes that ffprobe cannot validate (served via Streamlink). Streams on these hosts are marked 'Skipped' instead of 'Dead' so rename/move/delete actions leave them alone. Use full domains (e.g. 'youtube.com', not 'youtube'). Leave blank to use the defaults."
+      "id": "black_screen_min_black_seconds",
+      "label": "\u2b1b Continuous Blank Required (seconds)",
+      "type": "number",
+      "default": 3,
+      "help_text": "Minimum continuous run of blank (all-black) video (within the sample) required to flag a stream as blank. Should be a few seconds less than the sample to allow for connection/keyframe latency. Default: 3"
+    },
+    {
+      "id": "black_screen_ffmpeg_timeout",
+      "label": "\u2b1b Blank-Screen ffmpeg Timeout (seconds)",
+      "type": "number",
+      "default": 20,
+      "help_text": "Hard wall-clock cap on the ffmpeg blank-screen decode (connection + sampling). If exceeded, the stream is left Alive. Default: 20"
+    },
+    {
+      "id": "_section_post_check",
+      "type": "info",
+      "label": "\ud83c\udff7\ufe0f Post-Check Actions",
+      "description": "What to do with channels after a check completes: rename / move them by category, and restore recovered ones. Configure the tags and destination groups below; enable auto-apply on a schedule in 'Scheduling & Automation'."
     },
     {
       "id": "_section_dead",
@@ -128,6 +152,27 @@
       "type": "string",
       "default": "Graveyard",
       "help_text": "Enter the name for the group to move dead channels into."
+    },
+    {
+      "id": "_section_black",
+      "label": "\u2b1b Blank-Screen Handling",
+      "type": "info",
+      "description": "How to rename and relocate channels detected as a pure blank (all-black) screen. Requires 'Detect Blank-Screen Streams' to be ON. These channels are handled separately from [DEAD] channels (excluded from the Dead rename/move actions)."
+    },
+    {
+      "id": "black_screen_rename_format",
+      "label": "\u2b1b Blank-Screen Channel Rename Format",
+      "type": "string",
+      "default": "{name} [Blank]",
+      "placeholder": "{name} [Blank]",
+      "help_text": "Format for renaming blank-screen channels. Use {name} as the placeholder. Blank-screen channels are excluded from the Dead rename/move actions so they are not double-tagged."
+    },
+    {
+      "id": "move_black_screen_group",
+      "label": "\u2b1b Move Blank-Screen Channels to Group",
+      "type": "string",
+      "default": "Black Screens",
+      "help_text": "Enter the name for the group to move blank-screen channels into."
     },
     {
       "id": "_section_low_fps",
@@ -164,6 +209,12 @@
       "help_text": "A comma-separated list of formats to add as a suffix (e.g., [HD]) to channel names."
     },
     {
+      "id": "_section_restore",
+      "label": "\u267b\ufe0f Restore Recovered Channels",
+      "type": "info",
+      "description": "Channels that come back Alive can be auto-cleaned: plugin name tags ([DEAD]/[Slow]/[Blank]/quality) are stripped and the channel is moved back to the original group captured when it was first moved. Use the 'Restore Recovered Channels' action or the scheduler toggle. NOTE: a channel parked in a managed group (Graveyard / Slow / blank-screen) is only re-checked (and thus restorable) if your scan scope includes that group."
+    },
+    {
       "id": "_section_webhook",
       "label": "\ud83d\udd17 Webhook",
       "type": "info",
@@ -189,1297 +240,52 @@
       "type": "string",
       "default": "",
       "placeholder": "0 4 * * *,0 3 1 * *",
-      "help_text": "Comma-separated cron expressions. Format: 'minute hour day month weekday' (weekday: 0=Sunday, 6=Saturday). Examples: '0 4 * * *' (daily at 4 AM), '0 3 * * 0' (Sundays at 3 AM), '0 2 */2 * *' (every 2 days at 2 AM). Leave blank to disable scheduling. 💾 After editing this field, click \"💾 Save Schedule\" below to apply the new schedule."
-    },
-    {
-      "id": "scheduler_timezone",
-      "label": "\ud83c\udf0d Scheduler Timezone",
-      "type": "select",
-      "default": "America/Chicago",
-      "options": [
-        {
-          "label": "Africa/Abidjan",
-          "value": "Africa/Abidjan"
-        },
-        {
-          "label": "Africa/Algiers",
-          "value": "Africa/Algiers"
-        },
-        {
-          "label": "Africa/Bissau",
-          "value": "Africa/Bissau"
-        },
-        {
-          "label": "Africa/Cairo",
-          "value": "Africa/Cairo"
-        },
-        {
-          "label": "Africa/Casablanca",
-          "value": "Africa/Casablanca"
-        },
-        {
-          "label": "Africa/Ceuta",
-          "value": "Africa/Ceuta"
-        },
-        {
-          "label": "Africa/El_Aaiun",
-          "value": "Africa/El_Aaiun"
-        },
-        {
-          "label": "Africa/Johannesburg",
-          "value": "Africa/Johannesburg"
-        },
-        {
-          "label": "Africa/Juba",
-          "value": "Africa/Juba"
-        },
-        {
-          "label": "Africa/Khartoum",
-          "value": "Africa/Khartoum"
-        },
-        {
-          "label": "Africa/Lagos",
-          "value": "Africa/Lagos"
-        },
-        {
-          "label": "Africa/Maputo",
-          "value": "Africa/Maputo"
-        },
-        {
-          "label": "Africa/Monrovia",
-          "value": "Africa/Monrovia"
-        },
-        {
-          "label": "Africa/Nairobi",
-          "value": "Africa/Nairobi"
-        },
-        {
-          "label": "Africa/Ndjamena",
-          "value": "Africa/Ndjamena"
-        },
-        {
-          "label": "Africa/Sao_Tome",
-          "value": "Africa/Sao_Tome"
-        },
-        {
-          "label": "Africa/Tripoli",
-          "value": "Africa/Tripoli"
-        },
-        {
-          "label": "Africa/Tunis",
-          "value": "Africa/Tunis"
-        },
-        {
-          "label": "Africa/Windhoek",
-          "value": "Africa/Windhoek"
-        },
-        {
-          "label": "America/Adak",
-          "value": "America/Adak"
-        },
-        {
-          "label": "America/Anchorage",
-          "value": "America/Anchorage"
-        },
-        {
-          "label": "America/Araguaina",
-          "value": "America/Araguaina"
-        },
-        {
-          "label": "America/Argentina/Buenos_Aires",
-          "value": "America/Argentina/Buenos_Aires"
-        },
-        {
-          "label": "America/Argentina/Catamarca",
-          "value": "America/Argentina/Catamarca"
-        },
-        {
-          "label": "America/Argentina/Cordoba",
-          "value": "America/Argentina/Cordoba"
-        },
-        {
-          "label": "America/Argentina/Jujuy",
-          "value": "America/Argentina/Jujuy"
-        },
-        {
-          "label": "America/Argentina/La_Rioja",
-          "value": "America/Argentina/La_Rioja"
-        },
-        {
-          "label": "America/Argentina/Mendoza",
-          "value": "America/Argentina/Mendoza"
-        },
-        {
-          "label": "America/Argentina/Rio_Gallegos",
-          "value": "America/Argentina/Rio_Gallegos"
-        },
-        {
-          "label": "America/Argentina/Salta",
-          "value": "America/Argentina/Salta"
-        },
-        {
-          "label": "America/Argentina/San_Juan",
-          "value": "America/Argentina/San_Juan"
-        },
-        {
-          "label": "America/Argentina/San_Luis",
-          "value": "America/Argentina/San_Luis"
-        },
-        {
-          "label": "America/Argentina/Tucuman",
-          "value": "America/Argentina/Tucuman"
-        },
-        {
-          "label": "America/Argentina/Ushuaia",
-          "value": "America/Argentina/Ushuaia"
-        },
-        {
-          "label": "America/Asuncion",
-          "value": "America/Asuncion"
-        },
-        {
-          "label": "America/Bahia",
-          "value": "America/Bahia"
-        },
-        {
-          "label": "America/Bahia_Banderas",
-          "value": "America/Bahia_Banderas"
-        },
-        {
-          "label": "America/Barbados",
-          "value": "America/Barbados"
-        },
-        {
-          "label": "America/Belem",
-          "value": "America/Belem"
-        },
-        {
-          "label": "America/Belize",
-          "value": "America/Belize"
-        },
-        {
-          "label": "America/Boa_Vista",
-          "value": "America/Boa_Vista"
-        },
-        {
-          "label": "America/Bogota",
-          "value": "America/Bogota"
-        },
-        {
-          "label": "America/Boise",
-          "value": "America/Boise"
-        },
-        {
-          "label": "America/Cambridge_Bay",
-          "value": "America/Cambridge_Bay"
-        },
-        {
-          "label": "America/Campo_Grande",
-          "value": "America/Campo_Grande"
-        },
-        {
-          "label": "America/Cancun",
-          "value": "America/Cancun"
-        },
-        {
-          "label": "America/Caracas",
-          "value": "America/Caracas"
-        },
-        {
-          "label": "America/Cayenne",
-          "value": "America/Cayenne"
-        },
-        {
-          "label": "America/Chicago",
-          "value": "America/Chicago"
-        },
-        {
-          "label": "America/Chihuahua",
-          "value": "America/Chihuahua"
-        },
-        {
-          "label": "America/Ciudad_Juarez",
-          "value": "America/Ciudad_Juarez"
-        },
-        {
-          "label": "America/Costa_Rica",
-          "value": "America/Costa_Rica"
-        },
-        {
-          "label": "America/Coyhaique",
-          "value": "America/Coyhaique"
-        },
-        {
-          "label": "America/Cuiaba",
-          "value": "America/Cuiaba"
-        },
-        {
-          "label": "America/Danmarkshavn",
-          "value": "America/Danmarkshavn"
-        },
-        {
-          "label": "America/Dawson",
-          "value": "America/Dawson"
-        },
-        {
-          "label": "America/Dawson_Creek",
-          "value": "America/Dawson_Creek"
-        },
-        {
-          "label": "America/Denver",
-          "value": "America/Denver"
-        },
-        {
-          "label": "America/Detroit",
-          "value": "America/Detroit"
-        },
-        {
-          "label": "America/Edmonton",
-          "value": "America/Edmonton"
-        },
-        {
-          "label": "America/Eirunepe",
-          "value": "America/Eirunepe"
-        },
-        {
-          "label": "America/El_Salvador",
-          "value": "America/El_Salvador"
-        },
-        {
-          "label": "America/Fort_Nelson",
-          "value": "America/Fort_Nelson"
-        },
-        {
-          "label": "America/Fortaleza",
-          "value": "America/Fortaleza"
-        },
-        {
-          "label": "America/Glace_Bay",
-          "value": "America/Glace_Bay"
-        },
-        {
-          "label": "America/Goose_Bay",
-          "value": "America/Goose_Bay"
-        },
-        {
-          "label": "America/Grand_Turk",
-          "value": "America/Grand_Turk"
-        },
-        {
-          "label": "America/Guatemala",
-          "value": "America/Guatemala"
-        },
-        {
-          "label": "America/Guayaquil",
-          "value": "America/Guayaquil"
-        },
-        {
-          "label": "America/Guyana",
-          "value": "America/Guyana"
-        },
-        {
-          "label": "America/Halifax",
-          "value": "America/Halifax"
-        },
-        {
-          "label": "America/Havana",
-          "value": "America/Havana"
-        },
-        {
-          "label": "America/Hermosillo",
-          "value": "America/Hermosillo"
-        },
-        {
-          "label": "America/Indiana/Indianapolis",
-          "value": "America/Indiana/Indianapolis"
-        },
-        {
-          "label": "America/Indiana/Knox",
-          "value": "America/Indiana/Knox"
-        },
-        {
-          "label": "America/Indiana/Marengo",
-          "value": "America/Indiana/Marengo"
-        },
-        {
-          "label": "America/Indiana/Petersburg",
-          "value": "America/Indiana/Petersburg"
-        },
-        {
-          "label": "America/Indiana/Tell_City",
-          "value": "America/Indiana/Tell_City"
-        },
-        {
-          "label": "America/Indiana/Vevay",
-          "value": "America/Indiana/Vevay"
-        },
-        {
-          "label": "America/Indiana/Vincennes",
-          "value": "America/Indiana/Vincennes"
-        },
-        {
-          "label": "America/Indiana/Winamac",
-          "value": "America/Indiana/Winamac"
-        },
-        {
-          "label": "America/Inuvik",
-          "value": "America/Inuvik"
-        },
-        {
-          "label": "America/Iqaluit",
-          "value": "America/Iqaluit"
-        },
-        {
-          "label": "America/Jamaica",
-          "value": "America/Jamaica"
-        },
-        {
-          "label": "America/Juneau",
-          "value": "America/Juneau"
-        },
-        {
-          "label": "America/Kentucky/Louisville",
-          "value": "America/Kentucky/Louisville"
-        },
-        {
-          "label": "America/Kentucky/Monticello",
-          "value": "America/Kentucky/Monticello"
-        },
-        {
-          "label": "America/La_Paz",
-          "value": "America/La_Paz"
-        },
-        {
-          "label": "America/Lima",
-          "value": "America/Lima"
-        },
-        {
-          "label": "America/Los_Angeles",
-          "value": "America/Los_Angeles"
-        },
-        {
-          "label": "America/Maceio",
-          "value": "America/Maceio"
-        },
-        {
-          "label": "America/Managua",
-          "value": "America/Managua"
-        },
-        {
-          "label": "America/Manaus",
-          "value": "America/Manaus"
-        },
-        {
-          "label": "America/Martinique",
-          "value": "America/Martinique"
-        },
-        {
-          "label": "America/Matamoros",
-          "value": "America/Matamoros"
-        },
-        {
-          "label": "America/Mazatlan",
-          "value": "America/Mazatlan"
-        },
-        {
-          "label": "America/Menominee",
-          "value": "America/Menominee"
-        },
-        {
-          "label": "America/Merida",
-          "value": "America/Merida"
-        },
-        {
-          "label": "America/Metlakatla",
-          "value": "America/Metlakatla"
-        },
-        {
-          "label": "America/Mexico_City",
-          "value": "America/Mexico_City"
-        },
-        {
-          "label": "America/Miquelon",
-          "value": "America/Miquelon"
-        },
-        {
-          "label": "America/Moncton",
-          "value": "America/Moncton"
-        },
-        {
-          "label": "America/Monterrey",
-          "value": "America/Monterrey"
-        },
-        {
-          "label": "America/Montevideo",
-          "value": "America/Montevideo"
-        },
-        {
-          "label": "America/New_York",
-          "value": "America/New_York"
-        },
-        {
-          "label": "America/Nome",
-          "value": "America/Nome"
-        },
-        {
-          "label": "America/Noronha",
-          "value": "America/Noronha"
-        },
-        {
-          "label": "America/North_Dakota/Beulah",
-          "value": "America/North_Dakota/Beulah"
-        },
-        {
-          "label": "America/North_Dakota/Center",
-          "value": "America/North_Dakota/Center"
-        },
-        {
-          "label": "America/North_Dakota/New_Salem",
-          "value": "America/North_Dakota/New_Salem"
-        },
-        {
-          "label": "America/Nuuk",
-          "value": "America/Nuuk"
-        },
-        {
-          "label": "America/Ojinaga",
-          "value": "America/Ojinaga"
-        },
-        {
-          "label": "America/Panama",
-          "value": "America/Panama"
-        },
-        {
-          "label": "America/Paramaribo",
-          "value": "America/Paramaribo"
-        },
-        {
-          "label": "America/Phoenix",
-          "value": "America/Phoenix"
-        },
-        {
-          "label": "America/Port-au-Prince",
-          "value": "America/Port-au-Prince"
-        },
-        {
-          "label": "America/Porto_Velho",
-          "value": "America/Porto_Velho"
-        },
-        {
-          "label": "America/Puerto_Rico",
-          "value": "America/Puerto_Rico"
-        },
-        {
-          "label": "America/Punta_Arenas",
-          "value": "America/Punta_Arenas"
-        },
-        {
-          "label": "America/Rankin_Inlet",
-          "value": "America/Rankin_Inlet"
-        },
-        {
-          "label": "America/Recife",
-          "value": "America/Recife"
-        },
-        {
-          "label": "America/Regina",
-          "value": "America/Regina"
-        },
-        {
-          "label": "America/Resolute",
-          "value": "America/Resolute"
-        },
-        {
-          "label": "America/Rio_Branco",
-          "value": "America/Rio_Branco"
-        },
-        {
-          "label": "America/Santarem",
-          "value": "America/Santarem"
-        },
-        {
-          "label": "America/Santiago",
-          "value": "America/Santiago"
-        },
-        {
-          "label": "America/Santo_Domingo",
-          "value": "America/Santo_Domingo"
-        },
-        {
-          "label": "America/Sao_Paulo",
-          "value": "America/Sao_Paulo"
-        },
-        {
-          "label": "America/Scoresbysund",
-          "value": "America/Scoresbysund"
-        },
-        {
-          "label": "America/Sitka",
-          "value": "America/Sitka"
-        },
-        {
-          "label": "America/St_Johns",
-          "value": "America/St_Johns"
-        },
-        {
-          "label": "America/Swift_Current",
-          "value": "America/Swift_Current"
-        },
-        {
-          "label": "America/Tegucigalpa",
-          "value": "America/Tegucigalpa"
-        },
-        {
-          "label": "America/Thule",
-          "value": "America/Thule"
-        },
-        {
-          "label": "America/Tijuana",
-          "value": "America/Tijuana"
-        },
-        {
-          "label": "America/Toronto",
-          "value": "America/Toronto"
-        },
-        {
-          "label": "America/Vancouver",
-          "value": "America/Vancouver"
-        },
-        {
-          "label": "America/Whitehorse",
-          "value": "America/Whitehorse"
-        },
-        {
-          "label": "America/Winnipeg",
-          "value": "America/Winnipeg"
-        },
-        {
-          "label": "America/Yakutat",
-          "value": "America/Yakutat"
-        },
-        {
-          "label": "Antarctica/Casey",
-          "value": "Antarctica/Casey"
-        },
-        {
-          "label": "Antarctica/Davis",
-          "value": "Antarctica/Davis"
-        },
-        {
-          "label": "Antarctica/Macquarie",
-          "value": "Antarctica/Macquarie"
-        },
-        {
-          "label": "Antarctica/Mawson",
-          "value": "Antarctica/Mawson"
-        },
-        {
-          "label": "Antarctica/Palmer",
-          "value": "Antarctica/Palmer"
-        },
-        {
-          "label": "Antarctica/Rothera",
-          "value": "Antarctica/Rothera"
-        },
-        {
-          "label": "Antarctica/Troll",
-          "value": "Antarctica/Troll"
-        },
-        {
-          "label": "Antarctica/Vostok",
-          "value": "Antarctica/Vostok"
-        },
-        {
-          "label": "Asia/Almaty",
-          "value": "Asia/Almaty"
-        },
-        {
-          "label": "Asia/Amman",
-          "value": "Asia/Amman"
-        },
-        {
-          "label": "Asia/Anadyr",
-          "value": "Asia/Anadyr"
-        },
-        {
-          "label": "Asia/Aqtau",
-          "value": "Asia/Aqtau"
-        },
-        {
-          "label": "Asia/Aqtobe",
-          "value": "Asia/Aqtobe"
-        },
-        {
-          "label": "Asia/Ashgabat",
-          "value": "Asia/Ashgabat"
-        },
-        {
-          "label": "Asia/Atyrau",
-          "value": "Asia/Atyrau"
-        },
-        {
-          "label": "Asia/Baghdad",
-          "value": "Asia/Baghdad"
-        },
-        {
-          "label": "Asia/Baku",
-          "value": "Asia/Baku"
-        },
-        {
-          "label": "Asia/Bangkok",
-          "value": "Asia/Bangkok"
-        },
-        {
-          "label": "Asia/Barnaul",
-          "value": "Asia/Barnaul"
-        },
-        {
-          "label": "Asia/Beirut",
-          "value": "Asia/Beirut"
-        },
-        {
-          "label": "Asia/Bishkek",
-          "value": "Asia/Bishkek"
-        },
-        {
-          "label": "Asia/Chita",
-          "value": "Asia/Chita"
-        },
-        {
-          "label": "Asia/Colombo",
-          "value": "Asia/Colombo"
-        },
-        {
-          "label": "Asia/Damascus",
-          "value": "Asia/Damascus"
-        },
-        {
-          "label": "Asia/Dhaka",
-          "value": "Asia/Dhaka"
-        },
-        {
-          "label": "Asia/Dili",
-          "value": "Asia/Dili"
-        },
-        {
-          "label": "Asia/Dubai",
-          "value": "Asia/Dubai"
-        },
-        {
-          "label": "Asia/Dushanbe",
-          "value": "Asia/Dushanbe"
-        },
-        {
-          "label": "Asia/Famagusta",
-          "value": "Asia/Famagusta"
-        },
-        {
-          "label": "Asia/Gaza",
-          "value": "Asia/Gaza"
-        },
-        {
-          "label": "Asia/Hebron",
-          "value": "Asia/Hebron"
-        },
-        {
-          "label": "Asia/Ho_Chi_Minh",
-          "value": "Asia/Ho_Chi_Minh"
-        },
-        {
-          "label": "Asia/Hong_Kong",
-          "value": "Asia/Hong_Kong"
-        },
-        {
-          "label": "Asia/Hovd",
-          "value": "Asia/Hovd"
-        },
-        {
-          "label": "Asia/Irkutsk",
-          "value": "Asia/Irkutsk"
-        },
-        {
-          "label": "Asia/Jakarta",
-          "value": "Asia/Jakarta"
-        },
-        {
-          "label": "Asia/Jayapura",
-          "value": "Asia/Jayapura"
-        },
-        {
-          "label": "Asia/Jerusalem",
-          "value": "Asia/Jerusalem"
-        },
-        {
-          "label": "Asia/Kabul",
-          "value": "Asia/Kabul"
-        },
-        {
-          "label": "Asia/Kamchatka",
-          "value": "Asia/Kamchatka"
-        },
-        {
-          "label": "Asia/Karachi",
-          "value": "Asia/Karachi"
-        },
-        {
-          "label": "Asia/Kathmandu",
-          "value": "Asia/Kathmandu"
-        },
-        {
-          "label": "Asia/Khandyga",
-          "value": "Asia/Khandyga"
-        },
-        {
-          "label": "Asia/Kolkata",
-          "value": "Asia/Kolkata"
-        },
-        {
-          "label": "Asia/Krasnoyarsk",
-          "value": "Asia/Krasnoyarsk"
-        },
-        {
-          "label": "Asia/Kuching",
-          "value": "Asia/Kuching"
-        },
-        {
-          "label": "Asia/Macau",
-          "value": "Asia/Macau"
-        },
-        {
-          "label": "Asia/Magadan",
-          "value": "Asia/Magadan"
-        },
-        {
-          "label": "Asia/Makassar",
-          "value": "Asia/Makassar"
-        },
-        {
-          "label": "Asia/Manila",
-          "value": "Asia/Manila"
-        },
-        {
-          "label": "Asia/Nicosia",
-          "value": "Asia/Nicosia"
-        },
-        {
-          "label": "Asia/Novokuznetsk",
-          "value": "Asia/Novokuznetsk"
-        },
-        {
-          "label": "Asia/Novosibirsk",
-          "value": "Asia/Novosibirsk"
-        },
-        {
-          "label": "Asia/Omsk",
-          "value": "Asia/Omsk"
-        },
-        {
-          "label": "Asia/Oral",
-          "value": "Asia/Oral"
-        },
-        {
-          "label": "Asia/Pontianak",
-          "value": "Asia/Pontianak"
-        },
-        {
-          "label": "Asia/Pyongyang",
-          "value": "Asia/Pyongyang"
-        },
-        {
-          "label": "Asia/Qatar",
-          "value": "Asia/Qatar"
-        },
-        {
-          "label": "Asia/Qostanay",
-          "value": "Asia/Qostanay"
-        },
-        {
-          "label": "Asia/Qyzylorda",
-          "value": "Asia/Qyzylorda"
-        },
-        {
-          "label": "Asia/Riyadh",
-          "value": "Asia/Riyadh"
-        },
-        {
-          "label": "Asia/Sakhalin",
-          "value": "Asia/Sakhalin"
-        },
-        {
-          "label": "Asia/Samarkand",
-          "value": "Asia/Samarkand"
-        },
-        {
-          "label": "Asia/Seoul",
-          "value": "Asia/Seoul"
-        },
-        {
-          "label": "Asia/Shanghai",
-          "value": "Asia/Shanghai"
-        },
-        {
-          "label": "Asia/Singapore",
-          "value": "Asia/Singapore"
-        },
-        {
-          "label": "Asia/Srednekolymsk",
-          "value": "Asia/Srednekolymsk"
-        },
-        {
-          "label": "Asia/Taipei",
-          "value": "Asia/Taipei"
-        },
-        {
-          "label": "Asia/Tashkent",
-          "value": "Asia/Tashkent"
-        },
-        {
-          "label": "Asia/Tbilisi",
-          "value": "Asia/Tbilisi"
-        },
-        {
-          "label": "Asia/Tehran",
-          "value": "Asia/Tehran"
-        },
-        {
-          "label": "Asia/Thimphu",
-          "value": "Asia/Thimphu"
-        },
-        {
-          "label": "Asia/Tokyo",
-          "value": "Asia/Tokyo"
-        },
-        {
-          "label": "Asia/Tomsk",
-          "value": "Asia/Tomsk"
-        },
-        {
-          "label": "Asia/Ulaanbaatar",
-          "value": "Asia/Ulaanbaatar"
-        },
-        {
-          "label": "Asia/Urumqi",
-          "value": "Asia/Urumqi"
-        },
-        {
-          "label": "Asia/Ust-Nera",
-          "value": "Asia/Ust-Nera"
-        },
-        {
-          "label": "Asia/Vladivostok",
-          "value": "Asia/Vladivostok"
-        },
-        {
-          "label": "Asia/Yakutsk",
-          "value": "Asia/Yakutsk"
-        },
-        {
-          "label": "Asia/Yangon",
-          "value": "Asia/Yangon"
-        },
-        {
-          "label": "Asia/Yekaterinburg",
-          "value": "Asia/Yekaterinburg"
-        },
-        {
-          "label": "Asia/Yerevan",
-          "value": "Asia/Yerevan"
-        },
-        {
-          "label": "Atlantic/Azores",
-          "value": "Atlantic/Azores"
-        },
-        {
-          "label": "Atlantic/Bermuda",
-          "value": "Atlantic/Bermuda"
-        },
-        {
-          "label": "Atlantic/Canary",
-          "value": "Atlantic/Canary"
-        },
-        {
-          "label": "Atlantic/Cape_Verde",
-          "value": "Atlantic/Cape_Verde"
-        },
-        {
-          "label": "Atlantic/Faroe",
-          "value": "Atlantic/Faroe"
-        },
-        {
-          "label": "Atlantic/Madeira",
-          "value": "Atlantic/Madeira"
-        },
-        {
-          "label": "Atlantic/South_Georgia",
-          "value": "Atlantic/South_Georgia"
-        },
-        {
-          "label": "Atlantic/Stanley",
-          "value": "Atlantic/Stanley"
-        },
-        {
-          "label": "Australia/Adelaide",
-          "value": "Australia/Adelaide"
-        },
-        {
-          "label": "Australia/Brisbane",
-          "value": "Australia/Brisbane"
-        },
-        {
-          "label": "Australia/Broken_Hill",
-          "value": "Australia/Broken_Hill"
-        },
-        {
-          "label": "Australia/Darwin",
-          "value": "Australia/Darwin"
-        },
-        {
-          "label": "Australia/Eucla",
-          "value": "Australia/Eucla"
-        },
-        {
-          "label": "Australia/Hobart",
-          "value": "Australia/Hobart"
-        },
-        {
-          "label": "Australia/Lindeman",
-          "value": "Australia/Lindeman"
-        },
-        {
-          "label": "Australia/Lord_Howe",
-          "value": "Australia/Lord_Howe"
-        },
-        {
-          "label": "Australia/Melbourne",
-          "value": "Australia/Melbourne"
-        },
-        {
-          "label": "Australia/Perth",
-          "value": "Australia/Perth"
-        },
-        {
-          "label": "Australia/Sydney",
-          "value": "Australia/Sydney"
-        },
-        {
-          "label": "Europe/Andorra",
-          "value": "Europe/Andorra"
-        },
-        {
-          "label": "Europe/Astrakhan",
-          "value": "Europe/Astrakhan"
-        },
-        {
-          "label": "Europe/Athens",
-          "value": "Europe/Athens"
-        },
-        {
-          "label": "Europe/Belgrade",
-          "value": "Europe/Belgrade"
-        },
-        {
-          "label": "Europe/Berlin",
-          "value": "Europe/Berlin"
-        },
-        {
-          "label": "Europe/Brussels",
-          "value": "Europe/Brussels"
-        },
-        {
-          "label": "Europe/Bucharest",
-          "value": "Europe/Bucharest"
-        },
-        {
-          "label": "Europe/Budapest",
-          "value": "Europe/Budapest"
-        },
-        {
-          "label": "Europe/Chisinau",
-          "value": "Europe/Chisinau"
-        },
-        {
-          "label": "Europe/Dublin",
-          "value": "Europe/Dublin"
-        },
-        {
-          "label": "Europe/Gibraltar",
-          "value": "Europe/Gibraltar"
-        },
-        {
-          "label": "Europe/Helsinki",
-          "value": "Europe/Helsinki"
-        },
-        {
-          "label": "Europe/Istanbul",
-          "value": "Europe/Istanbul"
-        },
-        {
-          "label": "Europe/Kaliningrad",
-          "value": "Europe/Kaliningrad"
-        },
-        {
-          "label": "Europe/Kirov",
-          "value": "Europe/Kirov"
-        },
-        {
-          "label": "Europe/Kyiv",
-          "value": "Europe/Kyiv"
-        },
-        {
-          "label": "Europe/Lisbon",
-          "value": "Europe/Lisbon"
-        },
-        {
-          "label": "Europe/London",
-          "value": "Europe/London"
-        },
-        {
-          "label": "Europe/Madrid",
-          "value": "Europe/Madrid"
-        },
-        {
-          "label": "Europe/Malta",
-          "value": "Europe/Malta"
-        },
-        {
-          "label": "Europe/Minsk",
-          "value": "Europe/Minsk"
-        },
-        {
-          "label": "Europe/Moscow",
-          "value": "Europe/Moscow"
-        },
-        {
-          "label": "Europe/Paris",
-          "value": "Europe/Paris"
-        },
-        {
-          "label": "Europe/Prague",
-          "value": "Europe/Prague"
-        },
-        {
-          "label": "Europe/Riga",
-          "value": "Europe/Riga"
-        },
-        {
-          "label": "Europe/Rome",
-          "value": "Europe/Rome"
-        },
-        {
-          "label": "Europe/Samara",
-          "value": "Europe/Samara"
-        },
-        {
-          "label": "Europe/Saratov",
-          "value": "Europe/Saratov"
-        },
-        {
-          "label": "Europe/Simferopol",
-          "value": "Europe/Simferopol"
-        },
-        {
-          "label": "Europe/Sofia",
-          "value": "Europe/Sofia"
-        },
-        {
-          "label": "Europe/Tallinn",
-          "value": "Europe/Tallinn"
-        },
-        {
-          "label": "Europe/Tirane",
-          "value": "Europe/Tirane"
-        },
-        {
-          "label": "Europe/Ulyanovsk",
-          "value": "Europe/Ulyanovsk"
-        },
-        {
-          "label": "Europe/Vienna",
-          "value": "Europe/Vienna"
-        },
-        {
-          "label": "Europe/Vilnius",
-          "value": "Europe/Vilnius"
-        },
-        {
-          "label": "Europe/Volgograd",
-          "value": "Europe/Volgograd"
-        },
-        {
-          "label": "Europe/Warsaw",
-          "value": "Europe/Warsaw"
-        },
-        {
-          "label": "Europe/Zurich",
-          "value": "Europe/Zurich"
-        },
-        {
-          "label": "Indian/Chagos",
-          "value": "Indian/Chagos"
-        },
-        {
-          "label": "Indian/Maldives",
-          "value": "Indian/Maldives"
-        },
-        {
-          "label": "Indian/Mauritius",
-          "value": "Indian/Mauritius"
-        },
-        {
-          "label": "Pacific/Apia",
-          "value": "Pacific/Apia"
-        },
-        {
-          "label": "Pacific/Auckland",
-          "value": "Pacific/Auckland"
-        },
-        {
-          "label": "Pacific/Bougainville",
-          "value": "Pacific/Bougainville"
-        },
-        {
-          "label": "Pacific/Chatham",
-          "value": "Pacific/Chatham"
-        },
-        {
-          "label": "Pacific/Easter",
-          "value": "Pacific/Easter"
-        },
-        {
-          "label": "Pacific/Efate",
-          "value": "Pacific/Efate"
-        },
-        {
-          "label": "Pacific/Fakaofo",
-          "value": "Pacific/Fakaofo"
-        },
-        {
-          "label": "Pacific/Fiji",
-          "value": "Pacific/Fiji"
-        },
-        {
-          "label": "Pacific/Galapagos",
-          "value": "Pacific/Galapagos"
-        },
-        {
-          "label": "Pacific/Gambier",
-          "value": "Pacific/Gambier"
-        },
-        {
-          "label": "Pacific/Guadalcanal",
-          "value": "Pacific/Guadalcanal"
-        },
-        {
-          "label": "Pacific/Guam",
-          "value": "Pacific/Guam"
-        },
-        {
-          "label": "Pacific/Honolulu",
-          "value": "Pacific/Honolulu"
-        },
-        {
-          "label": "Pacific/Kanton",
-          "value": "Pacific/Kanton"
-        },
-        {
-          "label": "Pacific/Kiritimati",
-          "value": "Pacific/Kiritimati"
-        },
-        {
-          "label": "Pacific/Kosrae",
-          "value": "Pacific/Kosrae"
-        },
-        {
-          "label": "Pacific/Kwajalein",
-          "value": "Pacific/Kwajalein"
-        },
-        {
-          "label": "Pacific/Marquesas",
-          "value": "Pacific/Marquesas"
-        },
-        {
-          "label": "Pacific/Nauru",
-          "value": "Pacific/Nauru"
-        },
-        {
-          "label": "Pacific/Niue",
-          "value": "Pacific/Niue"
-        },
-        {
-          "label": "Pacific/Norfolk",
-          "value": "Pacific/Norfolk"
-        },
-        {
-          "label": "Pacific/Noumea",
-          "value": "Pacific/Noumea"
-        },
-        {
-          "label": "Pacific/Pago_Pago",
-          "value": "Pacific/Pago_Pago"
-        },
-        {
-          "label": "Pacific/Palau",
-          "value": "Pacific/Palau"
-        },
-        {
-          "label": "Pacific/Pitcairn",
-          "value": "Pacific/Pitcairn"
-        },
-        {
-          "label": "Pacific/Port_Moresby",
-          "value": "Pacific/Port_Moresby"
-        },
-        {
-          "label": "Pacific/Rarotonga",
-          "value": "Pacific/Rarotonga"
-        },
-        {
-          "label": "Pacific/Tahiti",
-          "value": "Pacific/Tahiti"
-        },
-        {
-          "label": "Pacific/Tarawa",
-          "value": "Pacific/Tarawa"
-        },
-        {
-          "label": "Pacific/Tongatapu",
-          "value": "Pacific/Tongatapu"
-        }
-      ],
-      "help_text": "Timezone for scheduled checks. All IANA timezone names are supported."
+      "help_text": "Comma-separated cron expressions. Format: 'minute hour day month weekday' (weekday: 0=Sunday, 6=Saturday). Examples: '0 4 * * *' (daily at 4 AM), '0 3 * * 0' (Sundays at 3 AM), '0 2 */2 * *' (every 2 days at 2 AM). Leave blank to disable scheduling. \ud83d\udcbe After editing this field, click \"\ud83d\udcbe Save Schedule\" below to apply the new schedule."
     },
     {
       "id": "schedule_window_enabled",
-      "label": "🪟 Use Windowed Schedule (run only during a time window)",
+      "label": "\ud83e\ude9f Use Windowed Schedule (run only during a time window)",
       "type": "boolean",
       "default": false,
       "help_text": "When on, your Scheduled Times above mark the START of a run window. The check runs until the configured end-time / duration, then halts cleanly between streams. The next time the window opens it RESUMES from the same point (channels already checked are skipped). Group selection, alternative-stream and visible-only settings are read fresh at each window fire."
     },
     {
       "id": "schedule_end_mode",
-      "label": "🛑 Window End Mode",
+      "label": "\ud83d\uded1 Window End Mode",
       "type": "select",
       "default": "duration",
       "options": [
-        { "label": "Run for a fixed duration (hours)", "value": "duration" },
-        { "label": "Run until a specific time (HH:MM)", "value": "time" }
+        {
+          "label": "Run for a fixed duration (hours)",
+          "value": "duration"
+        },
+        {
+          "label": "Run until a specific time (HH:MM)",
+          "value": "time"
+        }
       ],
       "help_text": "Choose how the window ends. Duration counts forward from the cron-fire time. Time mode supports past-midnight wrap (e.g. start 22:00, end 02:00)."
     },
     {
       "id": "schedule_duration_hours",
-      "label": "⏳ Window Duration (hours)",
+      "label": "\u23f3 Window Duration (hours)",
       "type": "number",
       "default": 4,
       "help_text": "Used when Window End Mode = duration. Decimals allowed (e.g. 3.5). Default: 4 hours."
     },
     {
       "id": "schedule_end_time",
-      "label": "🕓 Window End Time (HH:MM, scheduler timezone)",
+      "label": "\ud83d\udd53 Window End Time (HH:MM, scheduler timezone)",
       "type": "string",
       "default": "04:00",
       "placeholder": "04:00",
-      "help_text": "Used when Window End Mode = time. 24-hour format in the Scheduler Timezone above. If earlier than the start time, the window is treated as wrapping past midnight."
+      "help_text": "Used when Window End Mode = time. 24-hour format in Dispatcharr's timezone. If earlier than the start time, the window is treated as wrapping past midnight."
+    },
+    {
+      "id": "_section_auto_run",
+      "type": "info",
+      "label": "\u2699\ufe0f Auto-run After Scheduled Checks",
+      "description": "Which post-check actions to apply automatically after each scheduled check completes. (Manual actions are always available on the Actions tab.)"
     },
     {
       "id": "scheduler_export_csv",
@@ -1489,11 +295,25 @@
       "help_text": "Automatically export results to CSV after scheduled checks complete."
     },
     {
+      "id": "scheduler_restore_channels",
+      "label": "\u267b\ufe0f Restore Recovered Channels After Scheduled Checks",
+      "type": "boolean",
+      "default": false,
+      "help_text": "After each scheduled check, channels that are Alive again but were previously marked by this plugin have their name tags ([DEAD]/[Slow]/[Blank]/quality) stripped and are moved back to their original group. Runs first, before re-marking. NOTE: a channel parked in a managed group (Graveyard / Slow / blank-screen) is only re-checked (and thus restorable) if your scan scope includes that group."
+    },
+    {
       "id": "scheduler_rename_dead_channels",
       "label": "\ud83d\udc80 Rename Dead Channels After Scheduled Checks",
       "type": "boolean",
       "default": false,
       "help_text": "Automatically rename dead channels after scheduled checks complete."
+    },
+    {
+      "id": "scheduler_rename_black_screen_channels",
+      "label": "\u2b1b Rename Blank-Screen Channels After Scheduled Checks",
+      "type": "boolean",
+      "default": false,
+      "help_text": "Automatically rename blank-screen channels after scheduled checks complete. Requires 'Detect Blank-Screen Streams' to be ON."
     },
     {
       "id": "scheduler_rename_low_framerate_channels",
@@ -1515,6 +335,13 @@
       "type": "boolean",
       "default": false,
       "help_text": "Automatically move dead channels to the configured group after scheduled checks complete."
+    },
+    {
+      "id": "scheduler_move_black_screen_channels",
+      "label": "\u2b1b Move Blank-Screen Channels After Scheduled Checks",
+      "type": "boolean",
+      "default": false,
+      "help_text": "Automatically move blank-screen channels to the configured group after scheduled checks complete."
     },
     {
       "id": "scheduler_move_low_framerate_channels",
@@ -1551,12 +378,43 @@
       "description": "Paths and low-level overrides. Change only if your environment differs from the Dispatcharr defaults."
     },
     {
+      "id": "ffprobe_flags",
+      "label": "\ud83d\udd0d FFprobe Analysis Flags",
+      "type": "string",
+      "default": "-show_streams,-show_packets,-loglevel error",
+      "placeholder": "-show_streams, -show_packets",
+      "help_text": "Comma-separated ffprobe flags for stream analysis. Options: -show_streams (basic validation), -show_packets (per-packet data; required for video bitrate calculation on live MPEG-TS streams), -loglevel error (errors only). Default: -show_streams,-show_packets,-loglevel error. Note: do not add -show_frames \u2014 when both -show_frames and -show_packets are passed, ffprobe returns a combined packets_and_frames array instead of separate packets[], which prevents the bitrate fallback from running."
+    },
+    {
+      "id": "ffprobe_analysis_duration",
+      "label": "\u23f1\ufe0f FFprobe Analysis Duration (seconds)",
+      "type": "number",
+      "default": 8,
+      "help_text": "Duration to analyze stream when using -show_frames or -show_packets. Longer duration = more accurate bitrate/GOP analysis but slower checks. Probes that capture fewer than 30 video packets leave video_bitrate unset, so 8s gives slow-start streams enough room to clear the threshold. Default: 8 seconds"
+    },
+    {
+      "id": "streamlink_hosts",
+      "label": "\u23fc Streamlink-Only Hosts (skip ffprobe)",
+      "type": "string",
+      "default": "youtube.com, youtu.be, twitch.tv, kick.com",
+      "placeholder": "youtube.com, twitch.tv",
+      "help_text": "Comma-separated host suffixes that ffprobe cannot validate (served via Streamlink). Streams on these hosts are marked 'Skipped' instead of 'Dead' so rename/move/delete actions leave them alone. Use full domains (e.g. 'youtube.com', not 'youtube'). Leave blank to use the defaults."
+    },
+    {
       "id": "ffprobe_path",
       "label": "\ud83d\udccd FFprobe Path",
       "type": "string",
       "default": "/usr/local/bin/ffprobe",
       "placeholder": "/usr/local/bin/ffprobe",
       "help_text": "Full path to the ffprobe executable. Default: /usr/local/bin/ffprobe (Dispatcharr's default location)"
+    },
+    {
+      "id": "ffmpeg_path",
+      "label": "\ud83d\udccd FFmpeg Path",
+      "type": "string",
+      "default": "/usr/local/bin/ffmpeg",
+      "placeholder": "/usr/local/bin/ffmpeg",
+      "help_text": "Full path to the ffmpeg executable, used for blank-screen detection. Default: /usr/local/bin/ffmpeg (Dispatcharr's default location)"
     }
   ],
   "actions": [
@@ -1656,6 +514,39 @@
       },
       "button_variant": "filled",
       "button_label": "\u26b0\ufe0f Move Dead"
+    },
+    {
+      "id": "rename_black_screen_channels",
+      "label": "\u2b1b Rename Blank-Screen Channels",
+      "description": "Rename all channels detected as a blank screen in the last check using the configured format.",
+      "button_color": "red",
+      "confirm": {
+        "message": "This will rename blank-screen channels. This action is irreversible. Continue?"
+      },
+      "button_variant": "filled",
+      "button_label": "\u2b1b Rename Blank"
+    },
+    {
+      "id": "move_black_screen_channels",
+      "label": "\u2b1b Move Blank-Screen Channels to Group",
+      "description": "Moves all channels detected as a blank screen in the last check to the specified group.",
+      "button_color": "red",
+      "confirm": {
+        "message": "This will move blank-screen channels to the configured group. This action is irreversible. Continue?"
+      },
+      "button_variant": "filled",
+      "button_label": "\u2b1b Move Blank"
+    },
+    {
+      "id": "restore_channels",
+      "label": "\u267b\ufe0f Restore Recovered Channels",
+      "description": "For channels that are Alive again but were previously marked: strip plugin name tags and move them back to their original group.",
+      "button_color": "green",
+      "confirm": {
+        "message": "This will strip plugin tags from recovered channel names and move them back to their original groups. Continue?"
+      },
+      "button_variant": "filled",
+      "button_label": "\u267b\ufe0f Restore Recovered"
     },
     {
       "id": "rename_low_framerate_channels",

--- a/plugins/iptv-checker/plugin.py
+++ b/plugins/iptv-checker/plugin.py
@@ -85,11 +85,12 @@ class PluginConfig:
     LOADED_CHANNELS_FILE = "/data/iptv_checker_loaded_channels.json"
     PROGRESS_FILE = "/data/iptv_checker_progress.json"
     PENDING_RESUME_FILE = "/data/iptv_checker_pending_resume.json"
+    CHANNEL_STATE_FILE = "/data/iptv_checker_channel_state.json"
     SCHEDULER_LOCK_FILE = "/data/iptv_checker_scheduler.pid"
     SCHEDULER_RELOAD_FLAG = "/data/iptv_checker_scheduler_reload.flag"
 
     # --- Scheduler ---
-    DEFAULT_TIMEZONE = "America/Chicago"
+    DEFAULT_TIMEZONE = "UTC"
     SCHEDULER_CHECK_INTERVAL = 30  # Check every 30 seconds
     SCHEDULER_TIME_WINDOW = 30  # ±30 second window to trigger
     SCHEDULER_ERROR_WAIT = 60  # Wait 60s if error occurs
@@ -282,7 +283,7 @@ class Plugin:
     
     # Explicitly set the plugin key
     key = "iptv_checker"
-    version = "1.26.1582047"
+    version = "1.26.1721834"
 
     # Fields and actions are defined in plugin.json (single source of truth)
     def __init__(self):
@@ -290,6 +291,7 @@ class Plugin:
         self.loaded_channels_file = PluginConfig.LOADED_CHANNELS_FILE
         self.progress_file = PluginConfig.PROGRESS_FILE
         self.pending_resume_file = PluginConfig.PENDING_RESUME_FILE
+        self.channel_state_file = PluginConfig.CHANNEL_STATE_FILE
         self.check_progress = self._load_progress()
         self.load_progress = {"current": 0, "total": 0, "status": "idle"}  # Track load groups progress
         self._thread = None
@@ -509,12 +511,38 @@ class Plugin:
             return False
         return datetime.now(self._active_window_tz) >= self._active_window_end
 
+    @staticmethod
+    def _coerce_timezone(value):
+        """Return a valid IANA timezone name, or PluginConfig.DEFAULT_TIMEZONE as a
+        safe fallback. Accepts None / blank / non-string / invalid -> default."""
+        if not isinstance(value, str) or not value.strip():
+            return PluginConfig.DEFAULT_TIMEZONE
+        candidate = value.strip()
+        try:
+            import pytz
+            pytz.timezone(candidate)
+        except Exception:
+            return PluginConfig.DEFAULT_TIMEZONE
+        return candidate
+
+    def _dispatcharr_timezone(self):
+        """Resolve the effective timezone from Dispatcharr's global setting
+        (General Settings -> Time Zone, core.models.CoreSettings). Falls back to
+        PluginConfig.DEFAULT_TIMEZONE ('UTC') when unreadable/invalid or when
+        running outside Dispatcharr. Lazy import so the module loads in tests."""
+        try:
+            from core.models import CoreSettings
+            return self._coerce_timezone(CoreSettings.get_system_time_zone())
+        except Exception as e:
+            LOGGER.debug(f"{LOG_PREFIX} Could not read Dispatcharr timezone, using {PluginConfig.DEFAULT_TIMEZONE}: {e}")
+            return PluginConfig.DEFAULT_TIMEZONE
+
     def _setup_window_state(self, settings):
         """Resolve TZ and compute end-of-window. Stores state on self. Returns False on bad config."""
         if not PYTZ_AVAILABLE:
             LOGGER.error("Windowed schedule requires pytz")
             return False
-        tz_str = settings.get('scheduler_timezone', PluginConfig.DEFAULT_TIMEZONE)
+        tz_str = self._dispatcharr_timezone()
         try:
             tz = pytz.timezone(tz_str)
         except Exception:
@@ -538,6 +566,7 @@ class Plugin:
             'group_names': settings.get('group_names', ''),
             'check_alternative_streams': bool(settings.get('check_alternative_streams', True)),
             'only_visible_channels': bool(settings.get('only_visible_channels', False)),
+            'group_names_exclude': settings.get('group_names_exclude', ''),
         }
 
     def _seed_pending_from_loaded_channels(self, settings):
@@ -580,7 +609,7 @@ class Plugin:
         if saved_end_iso:
             try:
                 saved_end = datetime.fromisoformat(saved_end_iso)
-                saved_tz = pytz.timezone(pending.get('tz') or PluginConfig.DEFAULT_TIMEZONE)
+                saved_tz = pytz.timezone(pending.get('tz') or self._dispatcharr_timezone())
                 if saved_end.tzinfo is None:
                     saved_end = saved_tz.localize(saved_end)
                 if datetime.now(saved_tz) >= saved_end:
@@ -673,7 +702,7 @@ class Plugin:
         if not pending or not pending.get("remaining_stream_ids"):
             return
         end_iso = pending.get("window_end_iso")
-        tz_str = pending.get("tz") or settings.get('scheduler_timezone', PluginConfig.DEFAULT_TIMEZONE)
+        tz_str = pending.get("tz") or self._dispatcharr_timezone()
         try:
             tz = pytz.timezone(tz_str)
             end = datetime.fromisoformat(end_iso) if end_iso else None
@@ -686,7 +715,6 @@ class Plugin:
             return
         now = datetime.now(tz)
         if now >= end:
-            LOGGER.info("⏰ WINDOW: pending state exists but its window already closed — discarding dead pending state")
             self._clear_pending_resume()
             return
         LOGGER.info(f"⏰ WINDOW: pending state detected (ends {end.isoformat()}); resuming check after restart")
@@ -913,7 +941,7 @@ class Plugin:
             return
         
         # Get timezone
-        tz_str = settings.get('scheduler_timezone', PluginConfig.DEFAULT_TIMEZONE)
+        tz_str = self._dispatcharr_timezone()
         try:
             local_tz = pytz.timezone(tz_str)
         except pytz.exceptions.UnknownTimeZoneError:
@@ -949,7 +977,7 @@ class Plugin:
                         fresh = self._fresh_settings(settings)
                         new_times_str = (fresh.get("scheduled_times") or "").strip()
                         new_times = self._parse_scheduled_times(new_times_str) if new_times_str else []
-                        new_tz_str = fresh.get("scheduler_timezone", PluginConfig.DEFAULT_TIMEZONE)
+                        new_tz_str = self._dispatcharr_timezone()
                         try:
                             new_tz = pytz.timezone(new_tz_str)
                         except pytz.exceptions.UnknownTimeZoneError:
@@ -1131,18 +1159,32 @@ class Plugin:
                 LOGGER.info("⏰ WINDOW: closed mid-list — post-actions deferred to next window")
                 return
             
+            # Step 3b: Restore recovered channels FIRST (heal before re-marking)
+            restored_count = 0
+            if settings.get('scheduler_restore_channels', False):
+                LOGGER.info("⏰ SCHEDULED: Restoring recovered channels...")
+                restore_result = self.restore_channels_action(settings, scheduled_logger)
+                restored_count = restore_result.get('restored', 0)
+                LOGGER.info(f"⏰ SCHEDULED: {restore_result.get('message')}")
+
             # Step 4: Rename dead channels if enabled
             if settings.get('scheduler_rename_dead_channels', False):
                 LOGGER.info("⏰ SCHEDULED: Renaming dead channels...")
                 rename_result = self.rename_channels_action(settings, scheduled_logger)
                 LOGGER.info(f"⏰ SCHEDULED: {rename_result.get('message')}")
-            
+
             # Step 5: Rename low framerate channels if enabled
             if settings.get('scheduler_rename_low_framerate_channels', False):
                 LOGGER.info("⏰ SCHEDULED: Renaming low framerate channels...")
                 rename_low_fps_result = self.rename_low_framerate_channels_action(settings, scheduled_logger)
                 LOGGER.info(f"⏰ SCHEDULED: {rename_low_fps_result.get('message')}")
-            
+
+            # Step 5b: Rename black-screen channels if enabled
+            if settings.get('scheduler_rename_black_screen_channels', False):
+                LOGGER.info("⏰ SCHEDULED: Renaming black-screen channels...")
+                rename_black_result = self.rename_black_screen_channels_action(settings, scheduled_logger)
+                LOGGER.info(f"⏰ SCHEDULED: {rename_black_result.get('message')}")
+
             # Step 6: Add video format suffix if enabled
             if settings.get('scheduler_add_video_format_suffix', False):
                 LOGGER.info("⏰ SCHEDULED: Adding video format suffixes...")
@@ -1161,6 +1203,12 @@ class Plugin:
                 move_low_fps_result = self.move_low_framerate_channels_action(settings, scheduled_logger)
                 LOGGER.info(f"⏰ SCHEDULED: {move_low_fps_result.get('message')}")
 
+            # Step 8b: Move black-screen channels if enabled
+            if settings.get('scheduler_move_black_screen_channels', False):
+                LOGGER.info("⏰ SCHEDULED: Moving black-screen channels to group...")
+                move_black_result = self.move_black_screen_channels_action(settings, scheduled_logger)
+                LOGGER.info(f"⏰ SCHEDULED: {move_black_result.get('message')}")
+
             # Step 9: Delete dead channels if enabled
             if settings.get('scheduler_delete_dead_channels', False):
                 LOGGER.info("⏰ SCHEDULED: Deleting dead channels...")
@@ -1173,7 +1221,7 @@ class Plugin:
             # Step 10: Fire webhook if enabled
             if settings.get('scheduler_fire_webhook', False):
                 LOGGER.info("⏰ SCHEDULED: Firing webhook...")
-                webhook_result = self._fire_webhook(settings, scheduled_logger)
+                webhook_result = self._fire_webhook(settings, scheduled_logger, restored=restored_count)
                 if webhook_result.get('status') == 'ok':
                     LOGGER.info(f"⏰ SCHEDULED: {webhook_result.get('message')}")
                 else:
@@ -1311,6 +1359,9 @@ class Plugin:
                 "cleanup_orphaned_tasks": self.cleanup_orphaned_tasks_action,
                 "check_scheduler_status": self.check_scheduler_status_action,
                 "delete_dead_channels": self.delete_dead_channels_action,
+                "rename_black_screen_channels": self.rename_black_screen_channels_action,
+                "move_black_screen_channels": self.move_black_screen_channels_action,
+                "restore_channels": self.restore_channels_action,
             }
 
             handler = action_map.get(action)
@@ -1398,6 +1449,20 @@ class Plugin:
                     has_errors = True
             else:
                 validation_results.append("ℹ️ No groups specified (will check all)")
+
+            # Validate the exclude filter (applied after the include filter)
+            exclude_str = settings.get("group_names_exclude", "").strip()
+            if exclude_str:
+                try:
+                    all_group_names = {g['name'] for g in self._get_all_groups(logger)}
+                    ex_matched = self._match_group_names(exclude_str, all_group_names)
+                    if ex_matched:
+                        validation_results.append(f"✅ Exclude filter matches {len(ex_matched)} group(s): {', '.join(sorted(ex_matched))}")
+                    else:
+                        validation_results.append("ℹ️ Exclude filter matches no current groups")
+                except Exception as e:
+                    validation_results.append(f"❌ Failed to validate exclude filter: {str(e)}")
+                    has_errors = True
         except Exception as e:
             validation_results.append(f"❌ DB error: {str(e)[:100]}")
             has_errors = True
@@ -1429,17 +1494,11 @@ class Plugin:
             else:
                 validation_results.append(f"✅ Cron schedule(s) valid: {', '.join(scheduled_times)}")
                 
-            # Validate timezone
-            scheduler_timezone = settings.get("scheduler_timezone", PluginConfig.DEFAULT_TIMEZONE)
+            # Timezone comes from Dispatcharr's global setting (General Settings -> Time Zone).
             if PYTZ_AVAILABLE:
-                try:
-                    pytz.timezone(scheduler_timezone)
-                    validation_results.append(f"✅ Timezone valid: {scheduler_timezone}")
-                except pytz.exceptions.UnknownTimeZoneError:
-                    validation_results.append(f"❌ Unknown timezone: {scheduler_timezone}")
-                    has_errors = True
+                validation_results.append(f"✅ Using Dispatcharr timezone: {self._dispatcharr_timezone()}")
             else:
-                validation_results.append("⚠️ pytz not available - scheduler timezone cannot be validated")
+                validation_results.append("⚠️ pytz not available - scheduler cannot run")
 
         # Validate auto-delete settings
         if settings.get('scheduler_delete_dead_channels', False):
@@ -1542,10 +1601,11 @@ class Plugin:
             if r.get('status') == 'Alive':
                 formats[r.get('format', 'Unknown')] += 1
 
+        black = sum(1 for r in results if self._is_black_screen(r))
         summary = [
             f"📊 Last Check Results ({len(results)} streams):",
             f"✅ Alive: {alive}",
-            f"❌ Dead: {dead}",
+            f"❌ Dead: {dead}" + (f"  (⬛ {black} black/blank)" if black else ""),
             f"⤼ Skipped: {skipped}\n",
             "📺 Alive Stream Formats:"
         ]
@@ -1569,7 +1629,7 @@ class Plugin:
             logger.warning(f"Could not trigger frontend refresh: {e}")
         return False
 
-    def _fire_webhook(self, settings, logger):
+    def _fire_webhook(self, settings, logger, restored=None):
         """Send check results summary to the configured webhook URL via HTTP POST."""
         webhook_url = settings.get('webhook_url', '').strip()
         if not webhook_url:
@@ -1598,9 +1658,13 @@ class Plugin:
                 f"**IPTV Checker — check complete**\n"
                 f"Total: {len(results)}  •  ✅ Alive: {alive}  •  ❌ Dead: {dead}  •  ⏭️ Skipped: {skipped}"
             )
+            # Discord: hide the line on 0/None (noise); generic JSON below keeps an
+            # explicit "restored": 0 key for stable machine consumers.
+            if restored:
+                content += f"  •  ♻️ Restored: {restored}"
             payload = json.dumps({"content": content}).encode('utf-8')
         else:
-            payload = json.dumps({
+            body = {
                 "plugin": self.key,
                 "event": "check_complete",
                 "total": len(results),
@@ -1608,7 +1672,10 @@ class Plugin:
                 "dead": dead,
                 "skipped": skipped,
                 "timestamp": datetime.utcnow().isoformat() + "Z",
-            }).encode('utf-8')
+            }
+            if restored is not None:
+                body["restored"] = restored
+            payload = json.dumps(body).encode('utf-8')
 
         # Always set an explicit User-Agent. Discord's Cloudflare edge 403s the
         # default "Python-urllib/3.x" UA, which silently dropped every webhook.
@@ -1712,6 +1779,21 @@ class Plugin:
             logger.info(f"Created new group '{name}' (ID: {group.id})")
         return group
 
+    @staticmethod
+    def _match_group_names(patterns_str, all_group_names):
+        """Return the set of group names matching any comma-separated pattern.
+        Wildcards (containing * ? [) use fnmatch.fnmatchcase (case-sensitive);
+        literals use case-sensitive exact membership — symmetric with the include path."""
+        matched = set()
+        for pattern in (p.strip() for p in (patterns_str or '').split(',')):
+            if not pattern:
+                continue
+            if any(c in pattern for c in '*?['):
+                matched |= {g for g in all_group_names if fnmatch.fnmatchcase(g, pattern)}
+            elif pattern in all_group_names:
+                matched.add(pattern)
+        return matched
+
     def load_groups_action(self, settings, logger):
         """Load channels and streams from specified Dispatcharr groups."""
         try:
@@ -1729,8 +1811,8 @@ class Plugin:
                 logger.warning(f"⚠️ Total groups found: {len(group_name_to_id)}")
                 logger.warning(f"⚠️ Groups: {', '.join(sorted(group_name_to_id.keys()))}")
 
-                target_group_names, target_group_ids = set(group_name_to_id.keys()), set(group_name_to_id.values())
-                if not target_group_ids: return {"status": "error", "message": "No groups found in Dispatcharr."}
+                target_group_names = set(group_name_to_id.keys())
+                if not target_group_names: return {"status": "error", "message": "No groups found in Dispatcharr."}
             else:
                 input_names = [name.strip() for name in group_names_str.split(',') if name.strip()]
                 all_group_names = set(group_name_to_id.keys())
@@ -1751,17 +1833,27 @@ class Plugin:
                     else:
                         unmatched_patterns.append(pattern)
 
-                target_group_ids = {group_name_to_id[name] for name in target_group_names}
-
                 # Log which groups are being loaded
                 if target_group_names:
                     logger.info(f"✓ Loading specified groups: {', '.join(sorted(target_group_names))}")
                 if unmatched_patterns:
                     logger.warning(f"⚠️ No groups matched: {', '.join(unmatched_patterns)}")
 
-                if not target_group_ids:
+                if not target_group_names:
                     return {"status": "error", "message": f"No groups matched: {', '.join(unmatched_patterns)}"}
 
+            # Exclude filter — remove any matching groups AFTER the include filter.
+            exclude_str = settings.get("group_names_exclude", "").strip()
+            if exclude_str:
+                excluded = self._match_group_names(exclude_str, set(group_name_to_id.keys()))
+                removed = target_group_names & excluded
+                if removed:
+                    logger.info(f"🚫 Excluding {len(removed)} group(s) from check: {', '.join(sorted(removed))}")
+                    target_group_names = target_group_names - excluded
+                if not target_group_names:
+                    return {"status": "error", "message": "All target groups were excluded by the 'Group(s) to Exclude' filter. Nothing to check."}
+
+            target_group_ids = {group_name_to_id[name] for name in target_group_names}
             channels_in_groups = self._get_all_channels(logger, group_ids=target_group_ids)
 
             only_visible = bool(settings.get("only_visible_channels", False))
@@ -1825,6 +1917,9 @@ class Plugin:
         """Build success message for load groups action"""
         total_streams = sum(len(c.get('streams', [])) for c in loaded_channels)
         group_msg = "all groups" if not group_names_str else f"group(s): {', '.join(target_group_names)}"
+        exclude_str = settings.get("group_names_exclude", "").strip()
+        if exclude_str:
+            group_msg += f" (excluding: {exclude_str})"
         if settings.get("only_visible_channels", False):
             group_msg += " (visible channels only)"
 
@@ -2226,6 +2321,127 @@ class Plugin:
             tracker.finish()
             self._trigger_frontend_refresh(settings, logger)
 
+    # --- Tag taxonomy (shared by black-flag handling and restore) -----------
+    # Standard labels this plugin can append to a channel name. Used as a
+    # defensive floor so a previously-applied standard tag is always strippable
+    # even after the user edits their rename formats (same approach as the
+    # issue-#18 suffix stripper).
+    STANDARD_STATUS_TAGS = ('DEAD', 'Slow', 'Blank')
+    STANDARD_QUALITY_TAGS = ('UHD', 'FHD', 'HD', 'SD', 'Unknown')
+
+    @staticmethod
+    def _is_dead_nonblack(result):
+        """Dead due to a probing failure, NOT a black/blank screen."""
+        return result.get('status') == 'Dead' and result.get('error_type') != 'Black Screen'
+
+    @staticmethod
+    def _is_black_screen(result):
+        """Marked Dead specifically because the stream is a black/blank screen."""
+        return result.get('status') == 'Dead' and result.get('error_type') == 'Black Screen'
+
+    @staticmethod
+    def _extract_format_tags(fmt):
+        """Pull bracketed labels out of a rename format (e.g. 'DEAD' from '{name} [DEAD]')."""
+        if not fmt:
+            return []
+        return re.findall(r'\[([^\[\]]+)\]', fmt)
+
+    @staticmethod
+    def _compile_trailing_tag_re(tags):
+        """Compile a case-insensitive regex matching one-or-more trailing ' [TAG]' groups."""
+        labels = sorted({t.strip() for t in tags if t and t.strip()}, key=len, reverse=True)
+        if not labels:
+            return None
+        pattern = r'(?:\s*\[(?:' + '|'.join(re.escape(t) for t in labels) + r')\])+\s*$'
+        return re.compile(pattern, re.IGNORECASE)
+
+    @classmethod
+    def _derive_status_tags(cls, settings):
+        """Compiled regex of PROBLEM tags only (DEAD/Slow/Blank + custom) — used for eligibility."""
+        tags = list(cls.STANDARD_STATUS_TAGS)
+        for key in ('dead_rename_format', 'low_framerate_rename_format', 'black_screen_rename_format'):
+            tags.extend(cls._extract_format_tags(settings.get(key, '')))
+        return cls._compile_trailing_tag_re(tags)
+
+    @classmethod
+    def _derive_strippable_tags(cls, settings):
+        """Compiled regex of ALL tags this plugin can append (status + quality)."""
+        tags = list(cls.STANDARD_STATUS_TAGS) + list(cls.STANDARD_QUALITY_TAGS)
+        for key in ('dead_rename_format', 'low_framerate_rename_format', 'black_screen_rename_format'):
+            tags.extend(cls._extract_format_tags(settings.get(key, '')))
+        tags.extend(s.strip() for s in (settings.get('video_format_suffixes', '') or '').split(','))
+        return cls._compile_trailing_tag_re(tags)
+
+    @staticmethod
+    def _compute_restore_plan(alive_names_by_id, state, strip_re, status_re, existing_group_ids):
+        """Pure planner for the restore action.
+
+        A channel is eligible iff it has stored original-group state OR its current
+        name carries a trailing status tag ([DEAD]/[Slow]/[Blank] or custom). Quality
+        tags alone never make a healthy channel eligible. Eligible channels have ALL
+        plugin tags stripped from the name and are moved back to their original group
+        when it still exists.
+        """
+        name_updates = []
+        group_updates = []
+        entries_to_clear = set()
+        missing_group_ids = {}
+
+        for cid, name in alive_names_by_id.items():
+            entry = state.get(str(cid))
+            has_state = entry is not None
+            has_status_tag = bool(status_re and name and status_re.search(name))
+            if not has_state and not has_status_tag:
+                continue
+
+            if strip_re and name:
+                base = strip_re.sub('', name).rstrip()
+                if base and base != name:
+                    name_updates.append({'id': cid, 'name': base})
+
+            if has_state:
+                orig = entry.get('original_group_id')
+                if orig is not None and orig in existing_group_ids:
+                    group_updates.append({'id': cid, 'channel_group_id': orig})
+                else:
+                    missing_group_ids[str(cid)] = orig
+                entries_to_clear.add(str(cid))
+
+        return {
+            'name_updates': name_updates,
+            'group_updates': group_updates,
+            'entries_to_clear': entries_to_clear,
+            'missing_group_ids': missing_group_ids,
+        }
+
+    @staticmethod
+    def _compute_capture_state(channel_ids, current_group_by_id, group_name_by_id,
+                               managed_group_names, existing_state, now_iso):
+        """Pure planner for original-state capture. Returns ONLY the new entries to add.
+
+        Skips channels already tracked, channels with no current group (nothing to
+        restore to), and channels currently sitting in a managed destination group (so
+        a second move never records a dead/slow/black group as the 'original').
+        """
+        managed = {n.strip().lower() for n in managed_group_names if n and n.strip()}
+        new_entries = {}
+        for cid in channel_ids:
+            key = str(cid)
+            if key in existing_state:
+                continue
+            gid = current_group_by_id.get(cid)
+            if gid is None:
+                continue  # no current group -> nothing to restore TO; name-strip eligibility still covers it
+            gname = group_name_by_id.get(gid, '')
+            if gname and gname.strip().lower() in managed:
+                continue
+            new_entries[key] = {
+                'original_group_id': gid,
+                'original_group_name': gname,
+                'moved_at': now_iso,
+            }
+        return new_entries
+
     def rename_channels_action(self, settings, logger):
         """Rename channels that were marked as dead in the last check."""
         rename_format = settings.get("dead_rename_format", "{name} [DEAD]").strip()
@@ -2239,7 +2455,7 @@ class Plugin:
         if results is None:
             return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first."}
 
-        dead_channels = {r['channel_id']: r['channel_name'] for r in results if r['status'] == 'Dead'}
+        dead_channels = {r['channel_id']: r['channel_name'] for r in results if self._is_dead_nonblack(r)}
         if not dead_channels: return {"status": "ok", "message": "No dead channels found in the last check."}
 
         payload = []
@@ -2267,10 +2483,11 @@ class Plugin:
         if results is None:
             return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first."}
         
-        dead_channel_ids = {r['channel_id'] for r in results if r['status'] == 'Dead'}
+        dead_channel_ids = {r['channel_id'] for r in results if self._is_dead_nonblack(r)}
         if not dead_channel_ids: return {"status": "ok", "message": "No dead channels were found in the last check."}
-        
+
         try:
+            self._capture_original_state(dead_channel_ids, settings, logger)
             dest_group = self._get_or_create_group(move_to_group_name, logger)
             new_group_id = dest_group.id
 
@@ -2326,6 +2543,17 @@ class Plugin:
             logger.warning(f"DELETED {deleted_count} dead channels permanently from the database.")
             if deleted_count != len(dead_channel_ids):
                 logger.warning(f"Expected to delete {len(dead_channel_ids)} channels but only {deleted_count} were found in the database.")
+
+            # Hygiene: drop original-state entries for channels we just deleted.
+            try:
+                state = self._load_json_file(self.channel_state_file) or {}
+                if state:
+                    for cid in dead_channel_ids:
+                        state.pop(str(cid), None)
+                    self._save_json_file(self.channel_state_file, state, indent=2)
+            except Exception as e:
+                logger.warning(f"Could not prune restore-state after delete: {e}")
+
             self._trigger_frontend_refresh(settings, logger)
             return {
                 "status": "ok",
@@ -2379,8 +2607,9 @@ class Plugin:
         
         low_fps_channel_ids = {r['channel_id'] for r in results if 0 < r.get('framerate_num', 0) < 30}
         if not low_fps_channel_ids: return {"status": "ok", "message": "No low framerate channels found to move."}
-        
+
         try:
+            self._capture_original_state(low_fps_channel_ids, settings, logger)
             dest_group = self._get_or_create_group(group_name, logger)
             new_group_id = dest_group.id
 
@@ -2494,6 +2723,138 @@ class Plugin:
 
         except Exception as e: return {"status": "error", "message": str(e)}
 
+    def _capture_original_state(self, channel_ids, settings, logger):
+        """Persist each channel's current group as its 'original' before a move so
+        restore can return it later. Never overwrites an existing entry and never
+        records a managed destination group. Best-effort: never aborts the move.
+
+        The state file is read-modify-written atomically (_save_json_file = tmp +
+        os.replace), but two processes mutating it concurrently are last-writer-wins.
+        That is acceptable: a lost capture only forfeits the exact-group restore for
+        that channel (its name is still restored). Same accepted RMW model as
+        pending_resume.json; moves are not actions users typically fire in parallel."""
+        try:
+            channel_ids = list(channel_ids)
+            if not channel_ids:
+                return
+            current_group_by_id = {c['id']: c.get('channel_group_id') for c in self._get_all_channels(logger)}
+            group_name_by_id = {g['id']: g['name'] for g in self._get_all_groups(logger)}
+            managed_group_names = [
+                settings.get('move_to_group_name', ''),
+                settings.get('move_low_framerate_group', ''),
+                settings.get('move_black_screen_group', ''),
+            ]
+            state = self._load_json_file(self.channel_state_file) or {}
+            now_iso = datetime.utcnow().isoformat() + 'Z'
+            new_entries = self._compute_capture_state(
+                channel_ids, current_group_by_id, group_name_by_id,
+                managed_group_names, state, now_iso,
+            )
+            if new_entries:
+                state.update(new_entries)
+                self._save_json_file(self.channel_state_file, state, indent=2)
+                logger.info(f"Captured original group for {len(new_entries)} channel(s) before move.")
+        except Exception as e:
+            logger.warning(f"Could not capture original channel state (continuing): {e}")
+
+    def rename_black_screen_channels_action(self, settings, logger):
+        """Rename channels marked Dead specifically because they are a black/blank screen."""
+        rename_format = settings.get("black_screen_rename_format", "{name} [Blank]").strip()
+        if not rename_format:
+            return {"status": "error", "message": "Please configure a Black-Screen Channel Rename Format."}
+        if "{name}" not in rename_format:
+            return {"status": "error", "message": "Black-Screen Channel Rename Format must contain {name} placeholder."}
+
+        results = self._load_json_file(self.results_file)
+        if results is None:
+            return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first."}
+
+        black_channels = {r['channel_id']: r['channel_name'] for r in results if self._is_black_screen(r)}
+        if not black_channels:
+            return {"status": "ok", "message": "No black-screen channels found in the last check."}
+
+        payload = []
+        for cid, name in black_channels.items():
+            new_name = rename_format.replace('{name}', name)
+            if new_name != name:
+                payload.append({'id': cid, 'name': new_name})
+
+        if not payload:
+            return {"status": "ok", "message": "No channels needed renaming."}
+        try:
+            count = self._bulk_update_channels(payload, ['name'], logger)
+            self._trigger_frontend_refresh(settings, logger)
+            return {"status": "ok", "message": f"Successfully renamed {count} black-screen channels. GUI refresh triggered."}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def move_black_screen_channels_action(self, settings, logger):
+        """Move black/blank-screen channels to a dedicated group (captures original group first)."""
+        group_name = settings.get("move_black_screen_group", "Black Screens").strip()
+        if not group_name:
+            return {"status": "error", "message": "Please enter a destination group name for black-screen channels."}
+
+        results = self._load_json_file(self.results_file)
+        if results is None:
+            return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first."}
+
+        black_channel_ids = {r['channel_id'] for r in results if self._is_black_screen(r)}
+        if not black_channel_ids:
+            return {"status": "ok", "message": "No black-screen channels found to move."}
+        try:
+            self._capture_original_state(black_channel_ids, settings, logger)
+            dest_group = self._get_or_create_group(group_name, logger)
+            payload = [{'id': cid, 'channel_group_id': dest_group.id} for cid in black_channel_ids]
+            moved_count = self._bulk_update_channels(payload, ['channel_group_id'], logger)
+            self._trigger_frontend_refresh(settings, logger)
+            return {"status": "ok", "message": f"Successfully moved {moved_count} black-screen channels to group '{group_name}'. GUI refresh triggered."}
+        except Exception as e:
+            return {"status": "error", "message": str(e)}
+
+    def restore_channels_action(self, settings, logger):
+        """Restore recovered channels: strip plugin name tags and move back to the
+        original group for channels that are Alive again but were previously marked."""
+        results = self._load_json_file(self.results_file)
+        if results is None:
+            return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first.", "restored": 0}
+
+        alive_ids = {r['channel_id'] for r in results if r.get('status') == 'Alive'}
+        if not alive_ids:
+            return {"status": "ok", "message": "No alive channels in the last check to restore.", "restored": 0}
+
+        state = self._load_json_file(self.channel_state_file) or {}
+        strip_re = self._derive_strippable_tags(settings)
+        status_re = self._derive_status_tags(settings)
+
+        alive_names_by_id = {c['id']: c['name'] for c in self._get_all_channels(logger) if c['id'] in alive_ids}
+        existing_group_ids = {g['id'] for g in self._get_all_groups(logger)}
+
+        plan = self._compute_restore_plan(alive_names_by_id, state, strip_re, status_re, existing_group_ids)
+
+        affected = {u['id'] for u in plan['name_updates']} | {u['id'] for u in plan['group_updates']}
+        if not affected and not plan['entries_to_clear']:
+            return {"status": "ok", "message": "No recovered channels needed restoring.", "restored": 0}
+
+        try:
+            renamed = self._bulk_update_channels(plan['name_updates'], ['name'], logger)
+            moved = self._bulk_update_channels(plan['group_updates'], ['channel_group_id'], logger)
+
+            if plan['missing_group_ids']:
+                logger.warning(
+                    f"Restore: original group no longer exists for {len(plan['missing_group_ids'])} channel(s); "
+                    f"name restored but left in current group: {sorted(plan['missing_group_ids'])}"
+                )
+
+            for key in plan['entries_to_clear']:
+                state.pop(key, None)
+            self._save_json_file(self.channel_state_file, state, indent=2)
+
+            self._trigger_frontend_refresh(settings, logger)
+            return {"status": "ok", "restored": len(affected),
+                    "message": f"Restored {len(affected)} recovered channel(s): {renamed} renamed, {moved} moved back to original group. GUI refresh triggered."}
+        except Exception as e:
+            return {"status": "error", "message": str(e), "restored": 0}
+
     def view_table_action(self, settings, logger):
         """Display results in table format"""
         results = self._load_json_file(self.results_file)
@@ -2541,18 +2902,21 @@ class Plugin:
         # Add plugin settings (excluding sensitive information)
         lines.append("# Plugin Settings:")
         lines.append(f"#   Group(s) Checked: {settings.get('group_names', 'All groups')}")
+        lines.append(f"#   Group(s) Excluded: {settings.get('group_names_exclude', '') or '(none)'}")
         lines.append(f"#   Only Visible Channels: {settings.get('only_visible_channels', False)}")
         if settings.get('schedule_window_enabled', False):
             end_mode = settings.get('schedule_end_mode', 'duration')
             if end_mode == 'duration':
-                lines.append(f"#   Schedule Mode: window (duration {settings.get('schedule_duration_hours', 4)}h, tz {settings.get('scheduler_timezone', PluginConfig.DEFAULT_TIMEZONE)})")
+                lines.append(f"#   Schedule Mode: window (duration {settings.get('schedule_duration_hours', 4)}h, tz {self._dispatcharr_timezone()})")
             else:
-                lines.append(f"#   Schedule Mode: window (until {settings.get('schedule_end_time', '04:00')}, tz {settings.get('scheduler_timezone', PluginConfig.DEFAULT_TIMEZONE)})")
+                lines.append(f"#   Schedule Mode: window (until {settings.get('schedule_end_time', '04:00')}, tz {self._dispatcharr_timezone()})")
         lines.append(f"#   Connection Timeout: {settings.get('timeout', 10)} seconds")
         lines.append(f"#   Probe Timeout: {settings.get('probe_timeout', 20)} seconds")
         lines.append(f"#   Dead Connection Retries: {settings.get('dead_connection_retries', 3)}")
         lines.append(f"#   Dead Rename Format: {settings.get('dead_rename_format', '{name} [DEAD]')}")
         lines.append(f"#   Move Dead to Group: {settings.get('move_to_group_name', 'Graveyard')}")
+        lines.append(f"#   Black-Screen Rename Format: {settings.get('black_screen_rename_format', '{name} [Blank]')}")
+        lines.append(f"#   Move Black-Screen to Group: {settings.get('move_black_screen_group', 'Black Screens')}")
         lines.append(f"#   Low Framerate Rename Format: {settings.get('low_framerate_rename_format', '{name} [Slow]')}")
         lines.append(f"#   Move Low Framerate to Group: {settings.get('move_low_framerate_group', 'Slow')}")
         lines.append(f"#   Video Format Suffixes: {settings.get('video_format_suffixes', 'UHD, FHD, HD, SD, Unknown')}")
@@ -2710,7 +3074,7 @@ class Plugin:
         """Update the scheduler configuration and restart the scheduler."""
         try:
             scheduled_times_str = settings.get("scheduled_times", "").strip()
-            scheduler_timezone = settings.get("scheduler_timezone", PluginConfig.DEFAULT_TIMEZONE)
+            scheduler_timezone = self._dispatcharr_timezone()
             
             # If scheduled times are empty, signal the elected scheduler to go idle
             # rather than tearing the loop down. Killing the thread leaves no
@@ -2732,16 +3096,8 @@ class Plugin:
                     "message": f"❌ Invalid cron expression format: '{scheduled_times_str}'\n\nPlease use cron format (e.g., '0 4 * * *' for daily at 4 AM).\nFormat: minute hour day month weekday"
                 }
             
-            # Validate timezone
-            if PYTZ_AVAILABLE:
-                try:
-                    pytz.timezone(scheduler_timezone)
-                except pytz.exceptions.UnknownTimeZoneError:
-                    return {
-                        "status": "error",
-                        "message": f"❌ Unknown timezone: {scheduler_timezone}\n\nPlease select a valid timezone from the dropdown."
-                    }
-            else:
+            # Timezone comes from Dispatcharr's global setting; only pytz is required.
+            if not PYTZ_AVAILABLE:
                 return {
                     "status": "error",
                     "message": "❌ Scheduler requires pytz library but it is not installed.\n\nPlease install pytz to use scheduling features."
@@ -2762,7 +3118,7 @@ class Plugin:
             
             message = f"✅ Schedule updated successfully!\n\n"
             message += f"Cron Schedules: {times_display}\n"
-            message += f"Timezone: {scheduler_timezone}\n"
+            message += f"Timezone (from Dispatcharr): {scheduler_timezone}\n"
             message += f"Status: Enabled ✓\n\n"
             message += f"The scheduler will run checks at the configured times."
             
@@ -2922,7 +3278,7 @@ class Plugin:
             else:
                 cron_lines.append("  • (none configured)")
 
-            tz_name = settings.get("scheduler_timezone", PluginConfig.DEFAULT_TIMEZONE)
+            tz_name = self._dispatcharr_timezone()
             now_str = "?"
             if PYTZ_AVAILABLE:
                 try:
@@ -3023,6 +3379,75 @@ class Plugin:
         host = host.lower()
         suffixes = self._streamlink_host_suffixes(settings)
         return any(host == s or host.endswith('.' + s) for s in suffixes)
+
+    @staticmethod
+    def _parse_blackdetect_output(stderr):
+        # Parse ffmpeg blackdetect stderr into a list of (start, end, duration)
+        # float tuples. Returns [] when no black segments are present.
+        segments = []
+        if not stderr:
+            return segments
+        pattern = re.compile(
+            r'black_start:(?P<start>[\d.]+)\s+'
+            r'black_end:(?P<end>[\d.]+)\s+'
+            r'black_duration:(?P<dur>[\d.]+)'
+        )
+        for m in pattern.finditer(stderr):
+            try:
+                segments.append((
+                    float(m.group('start')),
+                    float(m.group('end')),
+                    float(m.group('dur')),
+                ))
+            except (ValueError, TypeError):
+                continue
+        return segments
+
+    def _check_black_screen(self, url, timeout, settings, logger):
+        # Decode a few seconds of an Alive stream and detect a pure black
+        # picture. Returns True (black), False (has video), or None
+        # (undecidable -> caller leaves the stream Alive). Never raises.
+        s = settings or {}
+        ffmpeg_path = s.get('ffmpeg_path', '/usr/local/bin/ffmpeg')
+        sample_seconds = s.get('black_screen_sample_seconds', 6)
+        min_black = s.get('black_screen_min_black_seconds', 3)
+        ffmpeg_timeout = s.get('black_screen_ffmpeg_timeout', 20)
+
+        # Input options (-user_agent, -rw_timeout) MUST precede -i or ffmpeg
+        # silently ignores them. -loglevel info is required: blackdetect logs
+        # its results at info level, so -loglevel error would suppress them.
+        cmd = [
+            ffmpeg_path,
+            '-hide_banner', '-nostats', '-loglevel', 'info',
+            '-user_agent', 'VLC/3.0.21 LibVLC/3.0.21',
+            '-rw_timeout', str(int(timeout) * 1000000),
+            '-i', url,
+            '-t', str(sample_seconds),
+            '-an',
+            '-vf', f'blackdetect=d={min_black}:pic_th=0.98',
+            '-f', 'null', '-',
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=ffmpeg_timeout
+            )
+        except FileNotFoundError:
+            logger.warning(f"[Black Screen] ffmpeg not found at {ffmpeg_path}; leaving stream Alive")
+            return None
+        except subprocess.TimeoutExpired:
+            logger.warning(f"[Black Screen] ffmpeg timed out after {ffmpeg_timeout}s; leaving stream Alive")
+            return None
+        except Exception as e:
+            logger.warning(f"[Black Screen] ffmpeg error ({e}); leaving stream Alive")
+            return None
+
+        segments = self._parse_blackdetect_output(result.stderr or '')
+        if segments:
+            return True
+        if result.returncode == 0:
+            return False
+        return None
 
     def check_stream(self, stream_data, timeout, retries, logger, skip_retries=False, settings=None, retry_attempt=0):
         """Check individual stream status with optional retries."""
@@ -3279,6 +3704,23 @@ class Plugin:
                             video_bitrate = int(round(video_bitrate))
 
                         stream_format = self._get_stream_format(resolution)
+
+                        # Optional black-screen verification. An Alive-by-ffprobe
+                        # stream can still decode to a pure black picture; mark it
+                        # Dead so destructive actions clean it up. Fail-open: any
+                        # ffmpeg problem (None) leaves the stream Alive. Null
+                        # metadata mirrors every other Dead stream so the DB stats
+                        # get cleared (see _update_dispatcharr_metadata all_none).
+                        if (settings and settings.get('black_screen_detection')
+                                and not self._stop_event.is_set()):
+                            if self._check_black_screen(url, timeout, settings, logger) is True:
+                                logger.info(f"✗ '{channel_name}' DEAD - Black Screen ({resolution})")
+                                black_return = dict(default_return)
+                                black_return['dispatcharr_metadata'] = {k: None for k in default_return['dispatcharr_metadata']}
+                                black_return['error'] = 'Stream decodes to a black screen'
+                                black_return['error_type'] = 'Black Screen'
+                                return black_return
+
                         logger.info(f"✓ '{channel_name}' ALIVE - {stream_format} {resolution} {framerate_num:.1f}fps")
 
                         # Build complete metadata for Dispatcharr integration


### PR DESCRIPTION
Updates the **IPTV Checker** plugin from `1.26.1582047` to `1.26.1721834`.

### Highlights since the published version
- **Black/blank-screen detection (opt-in):** decodes a few seconds of each Alive stream with ffmpeg `blackdetect` and marks pure-black streams Dead.
- **Blank-screen is a first-class category:** own rename tag (`[Blank]`) and own destination group, kept separate from `[DEAD]` channels (still deletable).
- **Restore Recovered Channels:** when a previously-marked channel comes back Alive, the plugin strips its name tags and moves it back to its original group (manual action + scheduler toggle).
- **Scheduler timezone from Dispatcharr:** the scheduler now reads General Settings → Time Zone; the plugin's own timezone dropdown was removed.
- **Group exclude filter:** new `Group(s) to EXCLUDE` field (comma-separated, wildcards), applied after the include filter.
- **UX:** renamed “Black Screen” → “Blank Screen” throughout the settings UI and reorganized the settings layout by lifecycle.
- Scheduler reliability fixes and expanded test coverage (141 tests).

Source repo: https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin (release [v1.26.1721834](https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin/releases/tag/v1.26.1721834)).

Diff is exclusively `plugins/iptv-checker/` (plugin.py, plugin.json, README.md).