### PR TITLE
[reservoarr] Bump to v6.3.0

### DIFF
--- a/plugins/reservoarr/plugin.json
+++ b/plugins/reservoarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reservoarr",
-  "version": "6.2.3",
+  "version": "6.3.0",
   "description": "Delay-buffer stream profile that absorbs IPTV CDN gaps so Plex Live TV stops dying",
   "author": "brko7",
   "maintainers": ["brko7"],


### PR DESCRIPTION
Bumps reservoarr to v6.3.0.

**What's in this release** ([release notes](https://github.com/brko7/reservoarr/releases/tag/v6.3.0)):

- New ingest-side observer: `pcr_back=N` telemetry counter + per-event `pcr backward jump: -X.Xs (last=A.A cur=B.B)` log line. Triggers on backward PCR jumps > 0.5s — the signature of a CDN serving overlapping content twice. **Log-only**; pacing behaviour is unchanged.
- 3 new unit tests covering real-magnitude rewinds, sub-threshold jitter, and 26.5h PCR wrap (distinguished from real rewinds via signed-delta check).
- `docs/TELEMETRY.md` documents the new field.
- No new features, no behaviour changes, no new dependencies. Still stdlib-only at runtime.

**Why now**: 2026-06-22 morning observation — same CDN edge served 13–27 seconds of duplicate cartoon content three times in 8 minutes, visible to the viewer as mid-stream "rewinds". None of the existing TS counters named the failure directly; this counter does, and is the "log marker + gather evidence" step `docs/INVARIANTS.md` already required before any future dedup work.

**Artifact**: `reservoarr-6.3.0.zip` — sha256 `60b4717af9a90370bccee1fac96e825048bb53a8f0bbb3b0b7b632dc082cf716`. Built reproducibly by `.github/workflows/release.yml` with `SOURCE_DATE_EPOCH` pinned to the tag commit. Zip contents: `LICENSE`, `README.md`, `logo.png`, `plugin.json`, `plugin.py`, `reservoarr.py` (6 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)