### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.9.0 (favorites-only curation)

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps the **Ranked Matchups (Top Games)** listing from 1.8.0 → 1.9.0.

External plugin — source lives in [Jacob-Lasky/dispatcharr_ranked_matchups](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups). The `v1.9.0` release with `plugin.zip` is published and the resolved `source_url` returns 200.

### What's new in 1.9.0
- New **Favorites only** curation setting (off / favorites-only / favorites-only-with-postseason-shown): limits the guide to games involving your Favorites teams (e.g. USMNT-only World Cup instead of all 48 nations), with an option that still surfaces playoff/knockout games regardless of favorite.
- Corrected stale World Cup / EURO source help text.

Only `plugins/dispatcharr-ranked-matchups/plugin.json` `version` changed (metadata + external source pointer); release artifact verified byte-identical with a snake_case top-level folder.