### PR TITLE
[iptv-checker] Bump version to 1.26.1741204

### DIFF
--- a/plugins/iptv-checker/README.md
+++ b/plugins/iptv-checker/README.md
@@ -43,10 +43,12 @@ Before installing or using this plugin, it is **highly recommended** that you cr
 - **Enhanced Error Categorization:** Detailed error types (Timeout, 404, 403, Connection Refused, etc.)
 - **Webhook Notifications:** Send HTTP POST notifications after scheduled checks complete
 - **Auto-Delete Dead Channels:** Permanently remove dead channels with safety confirmation gate
-- **CSV Exports:** Export results with comprehensive statistics and URL masking. Scheduled sessions emit a CSV every time a run ends — including windowed runs that close mid-list — so each window has its own audit record (v1.26.1191257+; the hoist regressed via the subfolder/root sync drift and was re-applied in v1.26.1212238).
+- **CSV Exports:** Export results with comprehensive statistics and URL masking. Scheduled sessions emit a CSV every time a run ends — including windowed runs that close mid-list — so each window has its own audit record (v1.26.1191257+; the hoist regressed via the subfolder/root sync drift and was re-applied in v1.26.1212238). The header no longer duplicates the `ffprobe_monitoring_seconds` column, and the audit preamble's `FFprobe Flags:` line now reports the flags actually used (v1.26.1741204+).
 - **Video Bitrate Reporting:** Per-stream `video_bitrate` (kbps) captured via ffprobe per-packet data and stored in Dispatcharr's `stream_stats`, so the channel-menu UI can display it. Live MPEG-TS / HLS streams almost never expose container-level `bit_rate`, so the plugin computes the average from `packets[].size / packets[].duration_time` for the video stream. Rounded to the nearest whole kbps before write (v1.26.1220052+). Probes that capture fewer than 30 video packets (≈1s of 30fps video) leave `video_bitrate` unset rather than persist a noisy average — short samples were producing wildly inflated values (observed: 22924 kbps from 2 packets) that polluted the channel-menu display (v1.26.1221035+). The default `ffprobe_analysis_duration` was bumped from 5 s → 8 s in v1.26.1221101 to give slow-start streams enough room to clear the 30-packet trust gate; verified runs jumped from 97% to 100% bitrate coverage on alive streams with median packet count rising from 200–400 → 662 (default-only change, existing deployments keep their saved value). The default `ffprobe_flags` was changed to `-show_streams,-show_packets,-loglevel error` in v1.26.1211342 — passing both `-show_frames` and `-show_packets` makes ffprobe emit a combined `packets_and_frames` array instead of separate `packets[]`, which silently breaks the bitrate calc. If you've customized `ffprobe_flags`, do **not** include `-show_frames`.
 - **Window-Aware Retry Pass:** When a windowed run closes mid-list, the parallel/sequential retry passes now also bail on `_past_window_end()` so transient-error retries cannot overshoot the window boundary (v1.26.1212238+; previously observed up to 14 minutes of overrun).
 - **Adaptive Rate-Limit Guard:** Detects upstream HTTP 429 responses, classifies them as **Skipped (Rate Limited)** instead of Dead so destructive actions never act on a throttled stream, and applies an exponentially-doubling cooldown when 429s spike (v1.26.1181025+). The cooldown counter is shared across the whole container — Dispatcharr's multiple worker processes can no longer reset it independently (v1.26.1181126+).
+- **Audio-Only / Radio Streams Skipped:** Streams that ffprobe validates but that carry **no video track** (e.g. radio stations like BBC Radio 1) are classified **Skipped (`No Video Stream`)** instead of Dead, so rename/move/delete actions leave them alone (v1.26.1741204+). `Skipped` now has three triggers: Streamlink-only hosts, HTTP 429 rate-limiting, and audio-only streams.
+- **PAL-Safe Low-Framerate Threshold:** The low-framerate flag now triggers below **24 fps** (was 30 fps), so 25 fps PAL/European broadcasts and 24 fps film-rate feeds are no longer mis-tagged `[Slow]` — only genuinely choppy streams qualify (v1.26.1741204+).
 - **Single-Scheduler Election:** Dispatcharr runs ~9 separate Python processes; a file-based PID lock at `/data/iptv_checker_scheduler.pid` ensures exactly one of them hosts the cron scheduler. Prior versions could fire each cron N times in parallel (v1.26.1181126+). Module-reload duplicate-thread protection added in v1.26.1191257 (Django/uwsgi could re-import the plugin module within the elected process and spawn additional scheduler threads, defeating the PID lock). Cross-worker UI-restart protection added in v1.26.1220951: any UI button click landed in whichever uwsgi worker the load balancer picked, and `update_schedule_action` / `Plugin.run()` previously called `_start_background_scheduler` directly without checking the PID lock — so non-owner workers spawned rogue scheduler threads (observed: `'59 23 * * *'` fired twice 27 ms apart on 2026-05-02). Non-owners now write a `/data/iptv_checker_scheduler_reload.flag` file that the owner's scheduler loop polls every 30 s; the owner re-reads settings via `_fresh_settings` and swaps its cron expressions in place.
 
 ## Requirements
@@ -124,7 +126,7 @@ To update the plugin:
 | Move Dead Channels to Group | string | `Graveyard` | Group to move dead channels to (excludes black/blank) |
 | Blank-Screen Channel Rename Format | string | `{name} [Blank]` | Format for renaming channels detected as a blank screen |
 | Move Blank-Screen Channels to Group | string | `Black Screens` | Group to move blank-screen channels to |
-| Low Framerate Rename Format | string | `{name} [Slow]` | Format for renaming low FPS channels (<30fps) |
+| Low Framerate Rename Format | string | `{name} [Slow]` | Format for renaming low FPS channels (<24fps — 25fps PAL and 24fps film are not flagged) |
 | Move Low Framerate Group | string | `Slow` | Group to move low framerate channels to |
 | Video Format Suffixes | string | `UHD, FHD, HD, SD, Unknown` | Formats to add as suffixes |
 
@@ -257,7 +259,7 @@ Optional second pass that decodes a few seconds of each **alive** stream with `f
 - **Start Stream Check:** Begin checking all loaded streams in background thread
 - **View Check Progress:** View current progress and ETA of the running check
 - **Cancel Stream Check:** Stop the currently running stream check (confirmation dialog; queued and in-flight streams abort, already-probed results are kept)
-- **View Last Results:** View summary of the last completed stream check
+- **View Last Results:** View summary of the last completed stream check, including the date/time the check was produced
 
 ### Channel Management
 - **Rename Dead Channels:** Apply rename format to dead streams (excludes black/blank)
@@ -265,7 +267,7 @@ Optional second pass that decodes a few seconds of each **alive** stream with `f
 - **Delete Dead Channels:** Permanently remove dead channels (requires confirmation; includes black/blank)
 - **Rename Blank-Screen Channels:** Apply `[Blank]` format to channels detected as a blank screen
 - **Move Blank-Screen Channels to Group:** Relocate blank-screen channels to the `Black Screens` group
-- **Rename Low Framerate Channels:** Apply rename format to slow streams (<30fps)
+- **Rename Low Framerate Channels:** Apply rename format to slow streams (<24fps; PAL 25fps / film 24fps excluded)
 - **Move Low Framerate Channels:** Relocate slow channels
 - **Add Video Format Suffix:** Apply format tags ([UHD], [FHD], [HD], [SD])
 - **Restore Recovered Channels:** For channels Alive again but previously marked, strip all plugin tags from the name and move them back to their **exact original group** (captured when they were first moved). Original group remembered in `/data/iptv_checker_channel_state.json`. If the original group was deleted, the name is still restored.

--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.1721834",
+  "version": "1.26.1741204",
   "description": "A Dispatcharr Plugin that goes through a playlist to check IPTV channels",
   "author": "PiratesIRC",
   "logo": "logo.png",

--- a/plugins/iptv-checker/plugin.py
+++ b/plugins/iptv-checker/plugin.py
@@ -105,6 +105,21 @@ class PluginConfig:
     # a fresh shot. 30 ≈ 1s of 30fps video; healthy probes return 200-400.
     MIN_PACKETS_FOR_BITRATE_CALC = 30
 
+    # --- Low framerate detection ---
+    # A stream is flagged "low framerate" (eligible for [Slow]/Slow group) when
+    # 0 < fps < this threshold. Kept below 25 so PAL/European broadcasts (25fps)
+    # and film-rate feeds (24fps; NTSC 23.976 rounds to 24.0) are NOT flagged —
+    # only genuinely choppy streams are. See _is_low_framerate.
+    LOW_FRAMERATE_THRESHOLD = 24
+
+    # --- FFprobe defaults ---
+    # Single source of truth for the default ffprobe flags. -show_packets is
+    # required for the packet-based video_bitrate fallback; -loglevel error keeps
+    # stderr usable for error classification. Both check_stream and the CSV audit
+    # preamble fall back to this so the recorded flags match the flags actually
+    # used (the preamble previously fell back to just '-show_streams').
+    DEFAULT_FFPROBE_FLAGS = '-show_streams,-show_packets,-loglevel error'
+
     # --- ETA Estimation ---
     # Fallback only; _estimate_check_seconds models a realistic mix.
     ESTIMATED_SECONDS_PER_STREAM = 10
@@ -283,7 +298,7 @@ class Plugin:
     
     # Explicitly set the plugin key
     key = "iptv_checker"
-    version = "1.26.1721834"
+    version = "1.26.1741204"
 
     # Fields and actions are defined in plugin.json (single source of truth)
     def __init__(self):
@@ -1580,6 +1595,28 @@ class Plugin:
 
         return {"status": "ok", "message": f"✅ Stream check cancelled.\n\nProcessed {current}/{total} streams before cancellation.\n\nPartial results have been saved and can be viewed with '📋 View Last Results'."}
 
+    def _results_timestamp_str(self):
+        """Best-effort 'when were these results produced' string, or None.
+
+        Prefers the check's recorded end_time; falls back to the results file mtime
+        (e.g. results restored from disk after a restart, where progress was reset).
+        """
+        ts = None
+        progress = self.check_progress if isinstance(self.check_progress, dict) else {}
+        if progress.get('end_time'):
+            ts = progress['end_time']
+        else:
+            try:
+                ts = os.path.getmtime(self.results_file)
+            except OSError:
+                ts = None
+        if not ts:
+            return None
+        try:
+            return datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
+        except (OverflowError, OSError, ValueError):
+            return None
+
     def view_results_action(self, settings, logger):
         """View summary of the last completed stream check."""
         # Reload progress from file to get latest state
@@ -1602,8 +1639,13 @@ class Plugin:
                 formats[r.get('format', 'Unknown')] += 1
 
         black = sum(1 for r in results if self._is_black_screen(r))
+        checked_at = self._results_timestamp_str()
         summary = [
             f"📊 Last Check Results ({len(results)} streams):",
+        ]
+        if checked_at:
+            summary.append(f"🕐 Checked: {checked_at}")
+        summary += [
             f"✅ Alive: {alive}",
             f"❌ Dead: {dead}" + (f"  (⬛ {black} black/blank)" if black else ""),
             f"⤼ Skipped: {skipped}\n",
@@ -2563,6 +2605,15 @@ class Plugin:
         except Exception as e:
             return {"status": "error", "message": f"Error deleting channels: {str(e)}"}
 
+    @staticmethod
+    def _is_low_framerate(fps):
+        """True when fps is a known, sub-threshold framerate (PAL 25 / film 24 are safe)."""
+        try:
+            fps = float(fps)
+        except (TypeError, ValueError):
+            return False
+        return 0 < fps < PluginConfig.LOW_FRAMERATE_THRESHOLD
+
     def rename_low_framerate_channels_action(self, settings, logger):
         """Rename channels with low framerate streams."""
         rename_format = settings.get("low_framerate_rename_format", "{name} [Slow]").strip()
@@ -2577,7 +2628,7 @@ class Plugin:
         if results is None:
             return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first."}
 
-        low_fps_channels = {r['channel_id']: r['channel_name'] for r in results if 0 < r.get('framerate_num', 0) < 30}
+        low_fps_channels = {r['channel_id']: r['channel_name'] for r in results if self._is_low_framerate(r.get('framerate_num', 0))}
         if not low_fps_channels: return {"status": "ok", "message": "No low framerate channels found."}
 
         payload = []
@@ -2605,7 +2656,7 @@ class Plugin:
         if results is None:
             return {"status": "error", "message": "No check results found (or data corrupted). Please run 'Check Streams' first."}
         
-        low_fps_channel_ids = {r['channel_id'] for r in results if 0 < r.get('framerate_num', 0) < 30}
+        low_fps_channel_ids = {r['channel_id'] for r in results if self._is_low_framerate(r.get('framerate_num', 0))}
         if not low_fps_channel_ids: return {"status": "ok", "message": "No low framerate channels found to move."}
 
         try:
@@ -2922,7 +2973,7 @@ class Plugin:
         lines.append(f"#   Video Format Suffixes: {settings.get('video_format_suffixes', 'UHD, FHD, HD, SD, Unknown')}")
         lines.append(f"#   Parallel Checking Enabled: {settings.get('enable_parallel_checking', False)}")
         lines.append(f"#   Parallel Workers: {settings.get('parallel_workers', 2)}")
-        lines.append(f"#   FFprobe Flags: {settings.get('ffprobe_flags', '-show_streams')}")
+        lines.append(f"#   FFprobe Flags: {settings.get('ffprobe_flags', PluginConfig.DEFAULT_FFPROBE_FLAGS)}")
         lines.append(f"#   FFprobe Analysis Duration: {settings.get('ffprobe_analysis_duration', 5)} seconds")
         lines.append("#")
 
@@ -2970,9 +3021,9 @@ class Plugin:
             lines.append(f"#   Average Framerate (Alive): {avg_framerate:.1f} fps")
 
         # Low framerate streams
-        low_fps_count = sum(1 for r in results if r.get('status') == 'Alive' and 0 < r.get('framerate_num', 0) < 30)
+        low_fps_count = sum(1 for r in results if r.get('status') == 'Alive' and self._is_low_framerate(r.get('framerate_num', 0)))
         if low_fps_count > 0:
-            lines.append(f"#   Low Framerate Streams (<30fps): {low_fps_count}")
+            lines.append(f"#   Low Framerate Streams (<{PluginConfig.LOW_FRAMERATE_THRESHOLD}fps): {low_fps_count}")
 
         if error_counts:
             lines.append("#")
@@ -2986,6 +3037,22 @@ class Plugin:
         lines.append("#")
 
         return lines
+
+    @staticmethod
+    def _compute_csv_fieldnames(results):
+        """Ordered CSV columns: fixed base columns + any dynamic ffprobe_* keys.
+
+        ffprobe_monitoring_seconds lives in base_fieldnames AND is emitted on each
+        result under its ffprobe_-prefixed key, so it must be excluded from the
+        auto-collected set or it lands in the header twice (bug-csv-dup-monitoring-col).
+        """
+        base_fieldnames = ['channel_id', 'channel_name', 'stream_id', 'status', 'format', 'framerate_num', 'error_type', 'error', 'retry_count', 'connection_timeout_seconds', 'probe_timeout_seconds', 'ffprobe_monitoring_seconds']
+        ffprobe_fieldnames = set()
+        for result in results:
+            for key in result.keys():
+                if key.startswith('ffprobe_') and key not in base_fieldnames:
+                    ffprobe_fieldnames.add(key)
+        return base_fieldnames + sorted(ffprobe_fieldnames)
 
     def export_results_action(self, settings, logger):
         """Export results to CSV"""
@@ -3004,15 +3071,7 @@ class Plugin:
                     result[f'ffprobe_{key}'] = value
 
         # Determine all possible fieldnames including dynamic ffprobe fields
-        base_fieldnames = ['channel_id', 'channel_name', 'stream_id', 'status', 'format', 'framerate_num', 'error_type', 'error', 'retry_count', 'connection_timeout_seconds', 'probe_timeout_seconds', 'ffprobe_monitoring_seconds']
-        ffprobe_fieldnames = set()
-        for result in results:
-            for key in result.keys():
-                if key.startswith('ffprobe_'):
-                    ffprobe_fieldnames.add(key)
-
-        # Create complete fieldnames list
-        fieldnames = base_fieldnames + sorted(list(ffprobe_fieldnames))
+        fieldnames = self._compute_csv_fieldnames(results)
 
         filepath = f"/data/exports/iptv_checker_results_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv"
         os.makedirs(PluginConfig.EXPORTS_DIR, exist_ok=True)
@@ -3531,7 +3590,7 @@ class Plugin:
         max_attempts = 1 if skip_retries else (retries + 1)
 
         # Parse ffprobe flags from settings
-        ffprobe_flags_str = settings.get('ffprobe_flags', '-show_streams,-show_packets,-loglevel error') if settings else '-show_streams,-show_packets,-loglevel error'
+        ffprobe_flags_str = settings.get('ffprobe_flags', PluginConfig.DEFAULT_FFPROBE_FLAGS) if settings else PluginConfig.DEFAULT_FFPROBE_FLAGS
         ffprobe_flags = [flag.strip() for flag in ffprobe_flags_str.split(',') if flag.strip()]
 
         # Get ffprobe path from settings
@@ -3813,6 +3872,17 @@ class Plugin:
             default_return['status'] = 'Skipped'
             default_return['error'] = masked_error
             default_return['error_type'] = 'Rate Limited'
+            return default_return
+
+        # Audio-only streams (e.g. radio stations) return "No video stream found"
+        # with a clean ffprobe exit — they are working streams that simply carry no
+        # video track, not dead channels. Classify as Skipped so destructive actions
+        # (rename/move/delete) leave them alone.
+        if last_error_type == 'No Video Stream':
+            logger.info(f"⤼ '{channel_name}' SKIPPED - No Video Stream (audio-only)")
+            default_return['status'] = 'Skipped'
+            default_return['error'] = masked_error
+            default_return['error_type'] = 'No Video Stream'
             return default_return
 
         # Log final result once if stream is dead after all attempts


### PR DESCRIPTION
Updates the `iptv-checker` listing to **v1.26.1741204** (was 1.26.1582047).

Built, tested, and released in the source repo:
https://github.com/PiratesIRC/Dispatcharr-IPTV-Checker-Plugin/releases/tag/v1.26.1741204

Latest changes:
- Audio-only streams (e.g. radio) are now classified **Skipped** (`No Video Stream`) instead of Dead, so rename/move/delete actions leave them alone.
- Low-framerate flag threshold lowered 30 → 24 fps so PAL (25 fps) / film (24 fps) broadcasts aren't mis-tagged `[Slow]`.
- CSV export header no longer duplicates a column; the audit preamble reports the ffprobe flags actually used.
- "View Last Results" now shows the check date.

Also rolls up accumulated fixes since 1.26.1582047 (restore-recovered-channels, group-exclude filter, blank-screen vocabulary, Dispatcharr-sourced timezone, scheduler hardening). Single-plugin change; CI green on the source repo.