### PR TITLE
[tickarr]: bump to v0.2.00 — EAS/JAS Weather Alerts

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Tickarr",
-  "version": "0.1.02",
-  "description": "Dynamic text overlays for IPTV channels - SiriusXM Now Playing, Sports Ticker, Custom Text",
+  "version": "0.2.00",
+  "description": "Dynamic text overlays for IPTV channels \u2014 Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",
   "source_type": "external",


### PR DESCRIPTION
## Tickarr v0.2.00 — EAS/JAS Weather Alerts

### JAS — jesmannstl Alert System

> Dedicated to **jesmannstl**, a weather fanatic and beloved member of the Dispatcharr community.
> Every alert that fires is a reminder of him. Rest in peace.

---

This release brings real Emergency Alert System integration to Dispatcharr. Channels run in normal passthrough until a NOAA/NWS alert fires for configured zones — Tickarr then automatically switches to a broadcast-style EAS overlay profile with scrolling crawl, colored severity label, and optional attention tone. When the alert clears, channels silently restore to their original profiles with no user action required.

### What's new

**EAS/JAS Weather Alerts**
- Dynamic profile switching — zero CPU overhead until an alert actually fires
- Broadcast-style alert bar: full-width dark bar, colored severity label, scrolling crawl
- Periodic EAS attention tone (853+960 Hz dual tone) via FFmpeg `aevalsrc` — no external audio file needed, repeats at user-configured interval
- Configurable: NWS zone IDs, poll interval, overlay style, severity filter, siren interval, transcode quality
- Auto-restore: original profile silently restored the moment the alert clears

**Performance & reliability**
- Distributed worker locks + per-channel fetch dedup (CPU 184% → 5% under load)
- DB connection pool fix in background sweep loop

### Plugin manifest change

| Field | Old | New |
|---|---|---|
| version | 0.1.02 | 0.2.00 |
| description | ...SiriusXM Now Playing, Sports Ticker, Custom Text | ...Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts |

### Release assets

ZIP: https://github.com/jstevenscl/tickarr/releases/tag/v0.2.00

🤖 Generated with [Claude Code](https://claude.com/claude-code)