### PR TITLE
[stream-mapparr] Bump version to 1.26.1761110

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1751210",
+  "version": "1.26.1761110",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Bumps Stream-Mapparr to 1.26.1761110.

This is a re-release of the 1.26.1751210 code with a correctly-packaged release zip. The 1.26.1751210 asset had backslash path separators (built on Windows via Compress-Archive / .NET Framework ZipFile), which violate the ZIP spec and broke install on Linux with "missing plugin.py or package __init__.py". Since this plugin is external-mode, the registry re-hosted the broken zip; a version bump is required for the registry to re-fetch the corrected one.

No functional code change — version-only. The 1.26.1761110 release asset is published and validated (forward-slash paths, package root intact).