### PR TITLE
[tickarr]: bump to v0.3.01 — fix missing bundled files from v0.3.00

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.3.00",
+  "version": "0.3.01",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## ⚠️ Hotfix — please delete the v0.3.00 GitHub release

**Action required before or after merging:** Delete https://github.com/jstevenscl/tickarr/releases/tag/v0.3.00

The v0.3.00 ZIP shipped with only `plugin.py`, `plugin.json`, and `logo.png`. Three required files were missing:

- `channels.json` — satellite radio channel catalog; without it, channel matching is unavailable and Now Playing overlays never fire
- `channel_aliases.json` — channel name aliases for matching; without it, channels with alternate names fail to match
- `eas_tone.wav` — required audio file for EAS/JAS weather alert attention tone; without it, alerts fire silently

v0.3.01 corrects the ZIP. No code changes — same `plugin.py`, version bumped only to distinguish from the broken build.

---

### If you installed v0.3.00

Update to v0.3.01 via the Dispatcharr plugin manager UPDATE button. Settings and active tickers are preserved.

Release: https://github.com/jstevenscl/tickarr/releases/tag/v0.3.01