### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.10.0: preserve DVR recordings across channel reaps

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Version bump **1.9.0 → 1.10.0** for [dispatcharr_ranked_matchups](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups). External entry only (`plugin.json` version); source stays in the upstream repo.

### What's new in 1.10.0
DVR recording preservation: when the plugin reaps a past game's virtual channel, it no longer CASCADE-deletes any DVR recording made on it. Completed recordings are re-homed onto a persistent (configurable) archive group before the channel is reaped, channels mid-recording aren't reaped, and the archive group exists only while it holds recordings.

### Release
- Tag: [`v1.10.0`](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.10.0)
- Artifact resolves: `.../releases/download/v1.10.0/plugin.zip` → HTTP 200 (verified), snake-case top folder, 45 entries.

Diff is version-only; `author` (`Jacob-Lasky`) matches the PR author.