### PR TITLE
[stream-mapparr] Bump to 1.26.1791529 — shared matcher core

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1761110",
+  "version": "1.26.1791529",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
External-mode version bump for **Stream-Mapparr**: `1.26.1761110` → `1.26.1791529`.

The Hub entry is `source_type: external`, so this PR bumps **only** `version` in `plugins/stream-mapparr/plugin.json`. Dispatcharr re-fetches the release zip from:
`https://github.com/PiratesIRC/Stream-Mapparr/releases/download/1.26.1791529/Stream-Mapparr.zip`

### What's in 1.26.1791529
- **Shared matcher core migration** — the per-plugin `fuzzy_matcher.py` now subclasses a byte-identically-vendored `FuzzyMatcherCore` (`matching_core.py`), sha256-pinned and enforced by parity + golden gates in CI. `matching_core.py` ships inside the release zip (the plugin won't import without it).
- Non-ASCII normalization + Unicode box-bar delimiter handling (ported from Lineuparr PR #13).

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.1791529
Release zip validated with `scripts/validate_zip.py` (forward-slash paths, bug-087-safe).
