### PR TITLE
[vod2mlib] Bump to v1.16.0 + add discord_thread

### DIFF
--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -8,5 +8,6 @@
   "repo_url": "https://github.com/R3XCHRIS/VOD2MLIB",
   "help_url": "https://github.com/R3XCHRIS/VOD2MLIB#readme",
   "source_type": "external",
-  "source_url": "https://github.com/R3XCHRIS/VOD2MLIB/releases/download/v{version}/plugin-vod2mlib-v{version}.zip"
+  "source_url": "https://github.com/R3XCHRIS/VOD2MLIB/releases/download/v{version}/plugin-vod2mlib-v{version}.zip",
+  "discord_thread": "https://discord.com/channels/1340492560220684331/1503076618078261374"
 }

--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "VOD to Media Library",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Generate .strm files (with optional NFO metadata) from your Dispatcharr VOD catalogue so Jellyfin / Emby / Kodi / ChannelsDVR can index your movies and series. Adds a cron-driven auto-rescan that picks up newly-added episodes nightly. Optional category-nested folder layout for genre-organised libraries.",
   "author": "R3XCHRIS",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Version bump for the [vod2mlib](https://github.com/R3XCHRIS/VOD2MLIB) plugin: v1.15.2 → v1.16.0, plus a `discord_thread` metadata link (powers the "Discord Discussion" link in the plugin's More-info panel).

## What's new in v1.16.0
Three community-requested features, all opt-in, defaults unchanged:
- **Language-prefix stripping** now handles pipe (`EN|`), bare-space `EN`, and bullet-wrapped (`▪NL▪`) formats in addition to the existing dash form — guarding real titles like `IT Chapter Two` / `UP` / `AC-130`.
- **New `Category Filter (include only)`** — comma-separated category-name prefixes; only matching content generates. Query-level filter for large multi-language catalogues.
- **New `Don't pin .strm to a specific stream`** — omits `?stream_id=` so Dispatcharr can fail over across providers (pairs with upstream [#1398](https://github.com/Dispatcharr/Dispatcharr/pull/1398)).

Also adds `discord_thread` (metadata-only field).

181 unit tests pass. No backend code outside the plugin.

[Full release notes](https://github.com/R3XCHRIS/VOD2MLIB/releases/tag/v1.16.0) · SHA256 `b992b95d8d0c30249afe3d816118c5f360ce7c2d3ce0347953d2cabda60136e4`