### PR TITLE
[stream-mapparr] Bump to 1.26.1820605 — zero-width char strip

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1791529",
+  "version": "1.26.1820605",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
External-mode version bump for **Stream-Mapparr**: `1.26.1791529` → `1.26.1820605`.

The Hub entry is `source_type: external`, so this PR bumps **only** `version` in `plugins/stream-mapparr/plugin.json`. Dispatcharr re-fetches the release zip from:
`https://github.com/PiratesIRC/Stream-Mapparr/releases/download/1.26.1820605/Stream-Mapparr.zip`

### What's in 1.26.1820605
- **Strip invisible zero-width characters before matching (bug-105 / #36).** Some providers pad stream names with invisible Unicode format characters (category `Cf`: ZERO WIDTH SPACE `U+200B`, ZWNJ/ZWJ, WORD JOINER `U+2060`, BOM `U+FEFF`, soft hyphen, bidi marks), often wrapped around a decorative block glyph (`UK ▎BBC 1 FHD`). They were matched by neither `\s` nor the visible-symbol strip, so they survived normalization and silently tanked a provider's whole match rate. `normalize_name` now removes them up front.
- **Bundled: OTA common-word callsign false-positive fix (bug-098)** — OTA channels whose callsign is also a common English word (KING/WHO/WOLF/…) no longer grab unrelated streams; a candidate must corroborate the station (parenthesized/suffixed callsign, FCC affiliation, or community city).

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.1820605
Release zip validated with `scripts/validate_zip.py` (forward-slash paths, bug-087-safe; LF line endings). Full test suite green (547 tests).