### PR TITLE
[reservoarr] Bump to v6.3.1

### DIFF
--- a/plugins/reservoarr/plugin.json
+++ b/plugins/reservoarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "reservoarr",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Delay-buffer stream profile that absorbs IPTV CDN gaps so Plex Live TV stops dying",
   "author": "brko7",
   "maintainers": ["brko7"],


### PR DESCRIPTION
Bumps reservoarr to v6.3.1.

**What's in this release** ([release notes](https://github.com/brko7/reservoarr/releases/tag/v6.3.1)):

- Hardening release from a full-repo review. **No pacing/controller behaviour changes**, no new features, no new dependencies. Still stdlib-only at runtime.
- All interval math (pacing, watchdogs, reconnect debounces) now uses `time.monotonic()` — a backward NTP step on the host could previously freeze output long enough to starve the player.
- Clean shutdown when SIGTERM lands mid-write: routine channel stops no longer emit a Python traceback + nonzero exit in the unlucky interleaving.
- Log rotation now runs continuously (checked every ~512 log lines), not only at process start — a 24/7 tune could previously grow `delaybuf.log` unboundedly.
- Plugin upgrade gate: a missing/unparseable `.installed_version` sentinel now triggers a reinstall instead of silently disabling auto-update forever.
- 3 new regression tests (log rotation); 58 unit + 7 e2e green.

**Artifact**: `reservoarr-6.3.1.zip` — sha256 `87639f84417d02b06649466f287fa6e9ad28a5255b7e34e4b721cc49bec5d73b`. Built reproducibly by `.github/workflows/release.yml` with `SOURCE_DATE_EPOCH` pinned to the tag commit. Zip contents: `LICENSE`, `README.md`, `logo.png`, `plugin.json`, `plugin.py`, `reservoarr.py` (6 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)