### PR TITLE
[tickarr]: bump to v0.3.02 — Weather Canada EAS, NAAD tone, separate CA targeting

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.3.01",
+  "version": "0.3.02",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bumps Tickarr to v0.3.02
- Adds Weather Canada (Environment Canada) alert monitoring with NAAD attention tone
- Separate channel targeting for NWS (USA) and EC (Canada) — both can run simultaneously
- EAS settings reorganized into three clear blocks: USA → Canada → Shared
- Severity filter labels updated with USA/Canada equivalents (Watch/Yellow, Warning/Orange, Emergency/Red)
- Fixes `_clean_orphans()` to protect active EAS profile IDs in addition to Now Playing profiles
- Bundles `eas_tone_ca.wav` (NAAD attention signal) and `ca_city_names.json` (844-city static lookup)

Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.3.02