### PR TITLE
[tickarr]: bump to v0.3.03 — fix on-demand restart race and timing, add Always On mode

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.3.02",
+  "version": "0.3.03",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps Tickarr to v0.3.03 — two bug fixes to the Now Playing on-demand overlay flow, plus a new Always On trigger mode.

### 🔒 Fixed a multi-worker race in Now Playing's viewer detection
Every Dispatcharr worker process ran Tickarr's background poller independently with no cross-process coordination — a single viewer connecting could trigger 2+ simultaneous profile clones and restarts for the same channel. Now uses a Redis-based leader-election lock so only one worker runs the poller, sports sweep, EAS sweep, and now-playing sweep loops; every other worker defers.

### ⏱️ Fixed on-demand restart timing
The overlay restart used to fire the instant a channel reached "active" state — exactly the moment a player transitions from buffering to playing, guaranteeing an interruption. Now waits up to 20 seconds for the channel to go active, then gives it a 5-second grace period of real playback before restarting for the profile swap. Significantly reduces playback interruptions on players sensitive to mid-stream restarts (Plex, some web/VLC setups).

### 🆕 Always On trigger mode for Now Playing
Previously on-demand only; now supports the same Trigger Mode choice already available on Custom Text and Sports Ticker. Always On assigns the overlay profile permanently at enable time, before any viewer connects — eliminating the restart-on-connect entirely. Steady-state cost is unchanged: FFmpeg only runs while a channel is actively connected, regardless of trigger mode.

### 📖 Documentation
Clarified that Now Playing requires a genuinely audio-only base profile — no `-c:v`/`-vcodec` flag, not even `-c:v copy` — since Tickarr generates its own video canvas for the overlay and misclassifies profiles carrying a leftover video flag. Added an example audio-only profile and a Trigger Mode reference entry to the User Guide.

## Testing
All changes tested live against real SiriusXM channels on two separate Dispatcharr instances (production + dev) before this release: confirmed the multi-worker race no longer fires duplicate restarts, confirmed on-demand restarts now land after stable playback instead of mid-buffer, and confirmed Always On assigns the overlay before connect with zero restart.

## Links
- Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.3.03
- Release ZIP: https://github.com/jstevenscl/tickarr/releases/download/v0.3.03/tickarr-0.3.03.zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)
