### PR TITLE
[dispatcharr-ranked-matchups] v1.11.0: add boxing source

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps **dispatcharr-ranked-matchups** to **v1.11.0**.

### What's new
- **Boxing source** — professional boxing cards as field events (Boxing Data API / RapidAPI). ESPN has no boxing feed, so it uses a keyed source; free tier, ~7-day lookahead. New `Boxing` toggle + API-key setting.
- World Cup knockout importance premium.
- Fix: archive-channel null number could truncate the Xtream Codes feed.

### Packaging
- External plugin; source lives in [Jacob-Lasky/dispatcharr_ranked_matchups](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups).
- Release `v1.11.0` published; resolved `source_url` returns HTTP 200 (verified). Zip top folder is snake_case `dispatcharr_ranked_matchups/` so intra-plugin imports resolve on install.
- Only `version` changed in the manifest. `author` (Jacob-Lasky) and `MIT` license unchanged.