### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.11.1

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Patch release. Fixes a matcher bug where a field-event title ending in a number (a UFC rematch card, `UFC 329: McGregor vs. Holloway 2`) reduced to the bare keyword `2` and matched thousands of unrelated streams. Not gated on any toggle; affected UFC independently.

- Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.11.1
- Metadata-only change here (`version` 1.11.0 → 1.11.1). Source stays external in the upstream repo; the resolved `source_url` (v1.11.1/plugin.zip) returns 200.