### PR TITLE
[twitcharr] Bump version to 1.3.2

### DIFF
--- a/plugins/twitcharr/plugin.json
+++ b/plugins/twitcharr/plugin.json
@@ -6,6 +6,6 @@
   "maintainers": ["eliasbruno124-dev"],
   "license": "MIT",
   "source_type": "external",
-  "source_url": "https://github.com/eliasbruno124-dev/Twitcharr/releases/download/{version}/twitcharr.zip",
+  "source_url": "https://github.com/eliasbruno124-dev/Twitcharr/releases/download/v{version}/twitcharr.zip",
   "repo_url": "https://github.com/eliasbruno124-dev/Twitcharr"
 }

--- a/plugins/twitcharr/plugin.json
+++ b/plugins/twitcharr/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "Twitcharr",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Twitch live-TV plugin for Dispatcharr with automatic channels, streams, XMLTV guide data and Streamlink playback.",
   "author": "eliasbruno124-dev",
   "maintainers": ["eliasbruno124-dev"],
   "license": "MIT",
   "source_type": "external",
-  "source_url": "https://github.com/eliasbruno124-dev/Twitcharr/releases/download/v{version}/twitcharr.zip",
+  "source_url": "https://github.com/eliasbruno124-dev/Twitcharr/releases/download/{version}/twitcharr.zip",
   "repo_url": "https://github.com/eliasbruno124-dev/Twitcharr"
 }


### PR DESCRIPTION
## About this submission

Updates the existing Twitcharr catalog entry from `1.3.1` to `1.3.2`.

The existing external source URL resolves to:

https://github.com/eliasbruno124-dev/Twitcharr/releases/download/v1.3.2/twitcharr.zip

## What's changed

- Configurable global channel-name prefix and suffix
- Per-channel name templates, including `TTV | {name}` and `{name} | TTV`
- Configurable XMLTV live indicators, description separators, and channel artwork
- Correct Dispatcharr `<live />` output so Emby imports live programmes as `IsLive: true`
- Emby-safe video-first MPEG-TS OutputProfile with H.264 video and AAC stereo audio
- Media-server M3U guidance and automatic update of Twitch-tagged Emby/Jellyfin tuners
- Cleaner uninstall, EPG cache invalidation, guide-refresh race handling, and complete anonymous Twitch batching

Resolves upstream feature requests [#3](https://github.com/eliasbruno124-dev/Twitcharr/issues/3), [#4](https://github.com/eliasbruno124-dev/Twitcharr/issues/4), [#5](https://github.com/eliasbruno124-dev/Twitcharr/issues/5), and [#6](https://github.com/eliasbruno124-dev/Twitcharr/issues/6).

## Validation

- Release artifact: HTTP 200
- SHA-256: `2e9211be932ed2e92936daa00463c822b5b052b10a257afc81f4ecb2f2da8b2c`
- 24 automated tests passed
- Tested against a running Dispatcharr instance with 11 managed Twitch channels and streams
- Validated in Emby: 11 channels, live guide flags, multiline descriptions, profile artwork, completed guide refresh, and live MPEG-TS playback with H.264 1080p plus AAC stereo

## Pre-submission checklist

- [x] `version` in `plugin.json` is incremented
- [x] I am listed in `author` and `maintainers`
- [x] The upstream release ZIP is publicly reachable
- [x] The plugin was tested against running Dispatcharr and Emby instances
