### PR TITLE
[stream-mapparr] Bump version to 1.26.1931038

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1820605",
+  "version": "1.26.1931038",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Version-only bump for Stream-Mapparr (external / `source_url` plugin, so this changes `version` only).

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.1931038

**Fixed:** a web UI hang after running Match and Assign. Long matching jobs could run inline in the HTTP request; because Dispatcharr runs uWSGI with gevent, the CPU-bound matcher never yields and froze the whole worker, so the UI stopped responding and nginx returned a 504 while live streams kept playing. Matching now runs in the background unless the job is trivially small.

**Added** (built earlier, first published here): opt-in auto-match after an M3U refresh, via the `m3u_refresh` event. Inert on Dispatcharr below v0.27, so `min_dispatcharr_version` is unchanged.

Also normalizes the repo to LF, so the release zip no longer ships CRLF files.