### PR TITLE
[stream-mapparr] Bump version to 1.26.1960020

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1931038",
+  "version": "1.26.1960020",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Version-only bump for the external/source_url plugin **Stream-Mapparr** (1.26.1931038 → 1.26.1960020). Only `plugins/stream-mapparr/plugin.json` `version` changes; `source_url` is templated with `{version}` and points at the plugin's own GitHub release.

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.1960020 (asset `Stream-Mapparr.zip`, LF, verified HTTP 200)

**Fixes in this version**
- Mid-name quality tag no longer glues neighbouring words (Custom Ignore Tags now work on mid-name tags).
- Web UI no longer 504s when zapping channels with a schedule configured (idempotent scheduler arming).
- East/West zone routing now covers lone unmarked channels and treats Pacific as West.

🤖 Generated with [Claude Code](https://claude.com/claude-code)