### PR TITLE
[stream-mapparr] Bump version to 1.26.1972151

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1960020",
+  "version": "1.26.1972151",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
External-mode version bump for Stream-Mapparr: 1.26.1960020 → 1.26.1972151.

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.1972151 (asset `Stream-Mapparr.zip`, forward-slash paths, LF)

This release bundles two versions since the last Hub bump:

- **1.26.1971200 — crash fix.** Scheduler state now survives Dispatcharr's plugin module re-imports; fixes accumulating orphaned scheduler threads (one per channel zap on affected installs) that degraded the web UI to nginx 504 when a schedule was configured.
- **1.26.1972151 — new feature (issue #36).** Stream Name Regex Rules: user-defined `[find, replace]` regex pairs applied to stream names before matching (matching only — never modifies stream names in Dispatcharr), plus a Test Regex Rules action that previews per-rule effects with invisible characters escaped. Unsafe (exponentially-backtracking) patterns are rejected at validation; runtime caps make bad rules degrade gracefully.

617 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S3V1E42MHh4xrjWFVmcMC5