### PR TITLE
[stream-mapparr] Bump to 1.26.1992013

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1972151",
+  "version": "1.26.1992013",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Version-only bump for the external (source_url) plugin **stream-mapparr**: `1.26.1972151` -> `1.26.1992013`.

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.1992013

Two user-reported fixes:

- **Sort Streams ignored the "Prioritize Quality" setting.** With it enabled, Sort still ordered alternate streams by M3U source first and by quality only within each source. The setting was resolved on a code path Sort never took, so the comparator silently used its default ordering. Sort now resolves it directly and logs which ordering it applied.
- **New opt-in setting "Keep Same-Named Streams From One Source" (default off).** Some providers publish several genuinely different feeds under one identical name in a single M3U account, and duplicate detection (keyed on name plus source) discarded all but the first, so a channel got one stream instead of four. Enabling the setting adds the stream URL to the duplicate key. True duplicates and cross-source behavior are unchanged, and the default preserves existing behavior for everyone who does not opt in.

Only `version` changed in `plugins/stream-mapparr/plugin.json`; `source_url` already resolves the release asset via the `{version}` template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
