### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.12.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Metadata-only bump of the external listing for **dispatcharr-ranked-matchups** to **1.12.0** (`version` field only; `source_type: external`).

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.12.0
Resolved artifact: `https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/download/v1.12.0/plugin.zip` (verified HTTP 200, snake_case top folder, byte-identical to local build).

### What's in 1.12.0
- **Added:** trophy grounding for knockout previews (World Cup / Euros / Champions League) so descriptions stop inventing title history; for a final the line spells out the outcome ("a win would be their 4th").
- **Changed:** a final's subtitle/headline no longer appends the closeness descriptor (`Final · close spread` → `Final`); finals only.

Pre-flighted locally against `.github/scripts/validate/validate.sh`: folder kebab, required fields, semver, version bump (1.11.1 → 1.12.0), external source_url resolves 200, repo_url present, author matches PR login, MIT is OSI-approved. Only the `version` field changed.