### PR TITLE
[tickarr]: Bump to v0.3.04 — SXM absolute numbering, EPG auto-refresh fix, prefix/duplicate-match bug fixes

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.3.03",
+  "version": "0.3.04",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.3.04

- Fixed the SiriusXM EPG source never auto-refreshing (`refresh_interval` was left disabled on creation)
- Added Absolute channel numbering mode to Sort Channels — channel number = start + real SXM station number, with a required Numbering Block Size to keep it from overlapping neighboring channel groups
- Added a station-number name prefix option (zero-padded or plain)
- Fixed two bugs found during testing: prefixed channel names failing to re-match on subsequent Sort/Assign Logos/Fill EPG runs, and two channels matching the same station silently colliding on the same channel number

Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.3.04

## Test plan
- [x] Verified live against a real 431-channel SiriusXM provider group on a local Dispatcharr test instance (not just synthetic data)
- [x] Confirmed the release ZIP's `source_url` resolves with HTTP 200
- [x] Confirmed `plugin.json` version bump only — no other marketplace metadata changed