### PR TITLE
[epgeditarr]: Bump to v0.2.08 — SXM absolute numbering, Series-mode EPG tags, EPG auto-refresh fix

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.07",
+  "version": "0.2.08",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.2.08

- Fixed the SiriusXM EPG source never auto-refreshing (`refresh_interval` was left disabled on creation)
- Added Force Category (Series Mode) and Synthesize Episode Numbers From Air Date to EPG Transform, so Plex can treat same-titled programs as distinct recordable episodes instead of one movie (closes #17)
- Added Absolute channel numbering mode to Sort — channel number = start + real SXM station number, with a required Numbering Block Size to keep it from overlapping neighboring channel groups
- Added a station-number name prefix option (zero-padded or plain)
- Fixed two bugs found during testing: prefixed channel names failing to re-match on subsequent Sort/Rename Channels/Assign Logos runs, and two channels matching the same station silently colliding on the same channel number
- Automated SXM lineup-change follow-up work (auto-alias high-confidence renames, targeted orphaned-logo cleanup) that was previously piling up unactioned in weekly issues

Full release notes: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.2.08

## Test plan
- [x] Verified live against a real 431-channel SiriusXM provider group on a local Dispatcharr test instance (not just synthetic data)
- [x] Verified the Force Category/episode-num transform end-to-end against real EPG data
- [x] Confirmed the release ZIP's `source_url` resolves with HTTP 200
- [x] Confirmed `plugin.json` version bump only — no other marketplace metadata changed