### PR TITLE
[repo] Fix octal-parsing crash in validate.sh version comparison

### DIFF
--- a/.github/scripts/validate/validate.sh
+++ b/.github/scripts/validate/validate.sh
@@ -63,11 +63,11 @@ version_greater_than() {
   local old_version=$2
   IFS='.' read -r NEW_MAJOR NEW_MINOR NEW_PATCH <<< "$new_version"
   IFS='.' read -r OLD_MAJOR OLD_MINOR OLD_PATCH <<< "$old_version"
-  if (( NEW_MAJOR > OLD_MAJOR )); then return 0; fi
-  if (( NEW_MAJOR < OLD_MAJOR )); then return 1; fi
-  if (( NEW_MINOR > OLD_MINOR )); then return 0; fi
-  if (( NEW_MINOR < OLD_MINOR )); then return 1; fi
-  if (( NEW_PATCH > OLD_PATCH )); then return 0; fi
+  if (( 10#$NEW_MAJOR > 10#$OLD_MAJOR )); then return 0; fi
+  if (( 10#$NEW_MAJOR < 10#$OLD_MAJOR )); then return 1; fi
+  if (( 10#$NEW_MINOR > 10#$OLD_MINOR )); then return 0; fi
+  if (( 10#$NEW_MINOR < 10#$OLD_MINOR )); then return 1; fi
+  if (( 10#$NEW_PATCH > 10#$OLD_PATCH )); then return 0; fi
   return 1
 }
 


### PR DESCRIPTION
## What's wrong

Plugin PR #192 (epgeditarr bump to v0.2.08) failed validate-plugin CI with:

    .github/scripts/validate/validate.sh: line 70: ((: 08: value too great for base (error token is "08")

version_greater_than() splits a semver string on "." and compares the segments
with bash ((...)) arithmetic. Bash treats any numeric string with a leading 0
as octal, and 08/09 aren't valid octal digits, so the script aborts (the file
has set -e). Any plugin version with a zero-padded segment ending in 8 or 9,
such as 0.2.08 or 1.09.0, trips this. It isn't specific to epgeditarr.

## Fix

Force base-10 interpretation with the 10# prefix on every arithmetic comparison
in version_greater_than(). No other changes needed. validate_semver and
validate_dispatcharr_version only do regex matching, not arithmetic.