### PR TITLE
[tickarr]: Bump to v0.3.05 — fix Absolute mode unmatched-channel placement order

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.3.04",
+  "version": "0.3.05",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.3.05

Fixed a real bug in the Absolute numbering mode added in v0.3.04: unmatched and duplicate-match-loser channels were filling free slots starting from the bottom of the reserved block instead of after the highest real matched station. Since SXM's own numbering starts at station 2, those low slots are never claimed by a real station — this bug backfilled them with unrelated content instead of placing it at the end where it belongs.

Found via a real user report (a duplicate-named channel landed at the very first slot instead of right after its real match) and confirmed fixed by reproducing the exact scenario before shipping.

Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.3.05

## Test plan
- [x] Reproduced the exact reported scenario on a local Dispatcharr test instance and confirmed the fix
- [x] Confirmed the release ZIP's `source_url` resolves with HTTP 200
- [x] Confirmed `plugin.json` version bump only — no other marketplace metadata changed