### PR TITLE
[epgeditarr]: Bump to v0.2.09 — fix Absolute mode unmatched-channel placement order, wrong channel alias

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.08",
+  "version": "0.2.09",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.2.09

Two real bugs fixed after v0.2.08 shipped:

- **Absolute mode placing unmatched channels ahead of real matches** — unmatched and duplicate-match-loser channels were filling free slots from the bottom of the reserved block instead of after the highest real match. Since SXM's own numbering starts at station 2, those low slots are never claimed by a real station — this bug backfilled them with unrelated content instead of the end where it belongs.
- **Wrong hardcoded channel alias** — removed `"smokey's holidaysoultown" -> "smokey's soul town"`. A real user confirmed via their own provider these are genuinely distinct channels; the forced alias caused a real duplicate-collision once the user corrected their channel's name to be distinct.

Also adds official logos for two previously-missing channels (Little Miss Twain Radio, The Beach Boys Channel).

Full release notes: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.2.09

## Test plan
- [x] Reproduced the exact reported scenario on a local Dispatcharr test instance and confirmed the fix
- [x] Confirmed the release ZIP's `source_url` resolves with HTTP 200
- [x] Confirmed `plugin.json` version bump only — no other marketplace metadata changed