### PR TITLE
[epgeditarr]: Bump to v0.2.10 — add 56 verified channel aliases, fix wrong Pro Wrestling alias

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.08",
+  "version": "0.2.10",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.2.10

Added 56 channel-name aliases for real SXM lineup renames — each confirmed still current against the live dataset before adding, not added speculatively from a stale issue:
- 37 `X Play-by-Play NNN` → `X NNN` suffix strips (ACC, Big 12, Big Ten, SEC, Sports)
- 2 trademark-symbol drops (`MLB/NHL Network Radio™`)
- A few dataset typos/abbreviations
- `The Weather Channel` → `FOX Weather` (a real rebrand)

Also fixed an existing hardcoded alias (`pro wrestling nation24/7`) that pointed the wrong direction — the dataset dropped the space, the alias still assumed the spaced form was official.

Deliberately did not alias three "Limited Edition N" renames flagged in an earlier issue — those are SXM's rotating guest-content slots, not stable identities, and two of the three targets have already rotated away again.

Full release notes: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.2.10

## Test plan
- [x] Verified every alias value resolves to a real, current dataset key (zero missing) before adding any of them
- [x] Confirmed clean plugin load on a local Dispatcharr test instance
- [x] Confirmed the release ZIP's `source_url` resolves with HTTP 200
- [x] Confirmed `plugin.json` version bump only — no other marketplace metadata changed