### PR TITLE
[stream-mapparr] Bump version to 1.26.2072208

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.1992013",
+  "version": "1.26.2072208",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Version-only bump for the external (source_url) Stream-Mapparr plugin.

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.2072208

Highlights:
- Fixes Restrict Matching To Same Country, which silently did nothing when a channel's country could not be detected. Country markers are now recognized in the forms providers actually use (bare codes, pipe delimiters, multi-token prefixes), the channel database is the primary country signal, and streams with no marker are kept as lower-priority alternates rather than dropped.
- Restores the Preview Changes button, which was declared in plugin.json but missing from the action list in plugin.py, so an enabled plugin never served it.
- Adds a Quick Start block and a Report a Bug block to the settings page.
- Refreshes the US, UK, CA, AU and ES channel databases to 2026-05-17.

806 tests. Zip validated for forward-slash paths and LF endings after download from the release.