### PR TITLE
[tickarr]: bump to v0.3.06 — fix Siren Tone Interval not disabling at 0

### DIFF
--- a/plugins/tickarr/README.md
+++ b/plugins/tickarr/README.md
@@ -2,9 +2,12 @@
 
 Dynamic text overlays for IPTV channels managed by Dispatcharr.
 
+📖 **[Read the full User Guide](https://github.com/jstevenscl/tickarr/blob/master/docs/USERGUIDE.md)** — setup steps, settings reference, and troubleshooting for every feature below.
+
 ## Features
 
 - **SiriusXM Now Playing** — auto-maps Dispatcharr channels to SiriusXM stations and displays the current artist and track in a centered overlay box
+- **EAS/JAS Weather Alerts (USA + Canada)** — NWS and Environment Canada alert overlays with broadcast-style ticker and attention tone
 - **Custom Text** — user-defined static or scrolling text, with always-on or timed display schedules
 - **Sports Ticker** — live scores from the ESPN API across 23 leagues and NASCAR, with single-color and multi-color rendering modes
 

--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.3.05",
+  "version": "0.3.06",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Fixes `eas_tone_interval` always flooring to 30s even when explicitly set to `0` — the settings field's minimum and the code's `max(30, ...)` clamp both ignored the documented "0 = disable the tone" behavior, so the tone could never actually be turned off. Now `0` is respected end-to-end.
- README: moved the User Guide link up top (was buried under Requirements) and added the missing EAS/Weather Canada Alerts line to the feature list.

Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.3.06

## Test plan
- [x] `plugin.py` compiles clean and loads without error in a local Dispatcharr test instance after restart
- [x] Directly exercised `_clone_and_inject_eas(..., tone_interval=0)` and confirmed the generated FFmpeg params contain no tone-audio filter, only the visual overlay
- [x] `plugin.json` version matches the `v0.3.06` GitHub Release tag and its attached `tickarr-0.3.06.zip` (checksums included in release notes)