### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.14.1

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.12.0",
+  "version": "1.14.1",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Version-only bump, `1.12.0` → `1.14.1`. External plugin, so this entry is just the pointer; the release artifact is live and reachable at the resolved `source_url`.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.14.1

## What's in it

**1.14.1 — matching precision.** Two composing defects attached a different sport's feeds to a game channel: an MLB `New York Yankees at Chicago White Sox` channel came back carrying dedicated NFL Giants and Jets feeds.

- Team keywords included the bare city (`New York`), and the EPG title pre-filter admits a candidate on any one keyword, so every same-city franchise entered the pool. Keywords are now split into strong (identify the team alone) and weak (bare place names); single-keyword admissions use strong only, while the both-teams gates keep using everything, so a city-only feed name like `Cincinnati vs. San Jose` still matches correctly.
- A matched channel donated every stream it carried with no name check, multiplying one bad match into every feed bundled onto that channel. Streams are now gated per channel, with generic broadcaster channels (naming no team on any stream) unaffected.

**1.14.0 — security and correctness pass.** Notably, API keys no longer reach the logs: the Odds API key arrived inside `requests` exception text via a query param, and the TheSportsDB key via a URL path segment. Also fixes a lock that could be released by a different holder, an unguarded `int()` on a user setting, and a rename cleanup that matched a user's ChannelGroup by loose substring instead of provenance.

**1.13.0 — club pre-season friendlies** source, plus knockout/scheduling fixes.

Full history: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/blob/main/CHANGELOG.md

## Note

1.13.0 and 1.14.0 were never published here, so this bump carries three releases' worth of changes. Publishing the current version rather than backfilling tags nobody would install from.

## Pre-flight

Checked locally against `.github/scripts/validate/validate.sh` before opening: folder name matches the kebab regex, strict semver with no `v` prefix, required fields present, version greater than the published `1.12.0`, `license` is an OSI SPDX id (`MIT`), `source_url` is HTTPS and contains the `{version}` placeholder, the resolved URL returns HTTP 200, and `author` matches the PR author's login.

The published release asset was downloaded and confirmed byte-identical (sha256 `7ef6e0f6…`) to the locally built zip, unzipping with the required snake_case top-level folder `dispatcharr_ranked_matchups/` so intra-plugin imports resolve on install.