### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.14.2

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Matcher precision fix. Two loose-match defects that attached a channel or stream carrying a **different fixture** than the game the virtual channel was for.

- A team abbreviation sitting in a provider's **feed label** could pair with an opponent named in the matchup body: `USA Soccer07: Australia vs Turkey` is the Australia-vs-*Turkey* feed, and it matched the Australia vs United States game because `USA` appeared in the network label. Tier-1 channel names now require both sides in one `:`/`|`-delimited segment.
- **Short team aliases** were matched as bare substrings, which made the 2-4 character forms near-wildcards: `NE` hit `Sportsnet` and `Tennessee`, `OM` hit `Roma`, `BOS` hit `Bosnia`, `PIT` hit `Jupiter`, `CLE` hit `Clearwater`, `Real` hit `Montreal`. They now match as whole tokens; longer keywords are unchanged.

Verified against a live 6588-channel / 16415-stream instance before release: a differential over the whole corpus across 33 fixtures dropped exactly two Tier-1 matches, both false positives, and gained none. 3488 tests pass.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.14.2
Changelog: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/blob/main/CHANGELOG.md