### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.15.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.14.2",
+  "version": "1.15.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Fixes intermittent login failures around plugin activity on some instances.

Standalone `apply` was the last plugin action doing heavy DB work inside the gevent web worker. When it stalled a worker, nginx kept round-robining into it, so login — a multi-request flow — failed for roughly a quarter of attempts, and the `3/minute` throttle then locked out the retries. It presented as "I can't log in", not as a slow plugin, and it survived two earlier fixes aimed at the same symptom (shrinking the apply transaction to sub-second, and closing a leaked scheduler DB connection).

`apply` now runs in the same subprocess `refresh` and `auto_pipeline` already use, so no plugin action does bulk DB work in the web worker. It stays synchronous and still returns the real summary; the only visible difference is one to two extra seconds of child startup.

Verified live on a 6588-channel instance: apply confirmed executing in the child, 1.6-2.2s end to end, login answering in ~0.4s while an apply was in flight (versus a 20s timeout recorded on the old code), and an unchanged database result afterwards.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.15.0
Changelog: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/blob/main/CHANGELOG.md