### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.16.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Cross-sport interestingness curator. Pulls upcoming games per enabled sport, scores them on interestingness, matches to Dispatcharr channels via EPG, and renames+groups them into a Top Matchups channel profile so your guide shows only the games worth watching. Channels are numbered by kickoff time, so the list sorts soonest-first and the guide binds correctly in both the default M3U/EPG output and the Xtream Codes API with no special settings.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Four fixes.

- **European public broadcasters now match.** ORF/ARD/ZDF/SRF title a programme with the competition and put the fixture in the sub-title, in German. The matcher read only the title, so those broadcasts produced no candidates at all. It now reads sub-title and description, and matches team names in German as well as English and Spanish.
- **Previous nights' feeds no longer stack behind a game.** Stream matching had no time filter, and a three-game series has every night's feed naming the same two teams, so channels accumulated finished games as fallback streams. A stream whose name is dated before its game is now skipped; undated feeds are unaffected.
- **The main card, not the pre-show, is the primary feed for an event.** Pre-show / prelims / press-conference / multiview feeds now sort behind a plain feed instead of potentially becoming primary. They still attach as fallbacks.
- **An invalid channel-name template is now reported** instead of silently falling back to the default.

Verified against a live 6588-channel / 34640-programme / 16415-stream instance: replaying the slate gives identical verdicts before and after, so the wider matching costs no precision. 3581 tests pass.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.16.0
Changelog: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/blob/main/CHANGELOG.md