### PR TITLE
[dispatcharr-ranked-matchups] Say "leagues, tours and competitions"

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ranked Matchups (Top Games)",
   "version": "1.16.0",
-  "description": "Never miss a good game. Scores every upcoming game across 37 leagues and competitions (20 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
+  "description": "Never miss a good game. Scores every upcoming game across 37 leagues, tours and competitions (20 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
   "author": "Jacob-Lasky",
   "license": "MIT",
   "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",


### PR DESCRIPTION
Follow-up to #205, which auto-merged before this correction reached the branch.

#205 shipped "across 37 **leagues and competitions**". That overclaims: PGA/ATP/WTA are tours, F1/NASCAR are series, and UFC and boxing are promotions and cards, so roughly 9 of the 37 are neither leagues nor competitions. This changes the phrase to "leagues, tours and competitions".

It also restores the invariant #205's description claimed: the listing description is once again byte-identical to the one in the plugin's own `plugin.json`, so there is one wording to maintain rather than two that can drift. Verified identical against https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/pull/168.

Sole change, `description` only, which is on `METADATA_ONLY_FIELDS`, so no version bump. Branched from current `upstream/main`.

| Check | Result |
|---|---|
| Changed fields | `description` |
| `METADATA_ONLY_FIELDS` gate | Pass, metadata-only |
| Other files in plugin dir | None |
| `version` | `1.16.0`, unchanged |
| Identical to upstream repo manifest | Yes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)