### PR TITLE
[stream-mapparr] Bump version to 1.26.2141957

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2072208",
+  "version": "1.26.2141957",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Bumps Stream-Mapparr to `1.26.2141957`.

This plugin uses `source_type: external`, so this pull request changes the `version` field and nothing else. The release asset is published on the plugin's own repository and is already available at the `source_url` this entry points to:

https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.2141957

The asset was downloaded back from the release and re-validated before this pull request was opened: 27 entries, forward-slash paths, package root intact, no CRLF in any text file, and the `plugin.json` inside the package reports `1.26.2141957`.

### What is in this release

- **Placeholder streams that claim HD but carry almost no video are now ranked last.** Providers serve looping slates and static cards that report 1080p while carrying roughly 190 kbps. The existing throughput check cannot catch these, because it measures how fast bytes arrive and a tiny payload arrives quickly. Two new settings control it, defaulting to on with a deliberately generous 300 kbps floor that only applies at 720p and above. Streams are reordered, never removed.
- **`GB` is accepted for the United Kingdom and `DR` for the Dominican Republic**, in addition to `UK` and `DO`. Providers disagree about which code they use. Both fold onto the code the shipped channel databases already use, so no database needs duplicating.
- **Custom Aliases now work whichever way the channel name is capitalised.** An entry filed under a differently-cased name was previously ignored with no error.
- **The bundled notification client is updated to 1.2.0**, which removes the host and stream id from a provider URL during redaction rather than only the username and password.
- Documentation reorganised, with a disclaimer, contributing guide and pull request template added.

Full notes: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.2141957
