### PR TITLE
[newsflasharr] add the Discord discussion thread

### DIFF
--- a/plugins/newsflasharr/plugin.json
+++ b/plugins/newsflasharr/plugin.json
@@ -7,6 +7,7 @@
   "source_type": "external",
   "repo_url": "https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin",
   "help_url": "https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/issues",
+  "discord_thread": "https://discord.com/channels/1340492560220684331/1533575430400114730",
   "min_dispatcharr_version": "v0.20.0",
   "source_url": "https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/releases/download/{version}/Newsflasharr.zip"
 }


### PR DESCRIPTION
## About this submission

Metadata-only update to the existing `newsflasharr` entry: adds `discord_thread`, linking it to the plugin's discussion thread on the Dispatcharr Discord where it was announced.

No version bump, since `discord_thread` is on the metadata-only list in the Versioning section of CONTRIBUTING.

## Pre-submission checklist

**If this is a new plugin:**
- [ ] Plugin folder is named `lowercase-kebab-case`
- [ ] `plugin.json` contains all required fields (`name`, `version`, `description`, `author` or `maintainers`, `license`)
- [ ] My GitHub username is in `author` or `maintainers`
- [ ] `license` is a valid [OSI-approved SPDX identifier](https://spdx.org/licenses/) (e.g. `MIT`, `Apache-2.0`)
- [ ] I have tested the plugin against a running Dispatcharr instance

**If this is an update to an existing plugin:**
- [x] `version` in `plugin.json` is incremented (unless this is a metadata-only change - see [Versioning](https://github.com/Dispatcharr/Plugins/blob/main/CONTRIBUTING.md#versioning))
- [x] I am listed in `author` or `maintainers` of the existing plugin