### PR TITLE
[lineuparr] Update to 1.26.2171315

### DIFF
--- a/plugins/lineuparr/plugin.json
+++ b/plugins/lineuparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Lineuparr",
-  "version": "1.26.2142327",
+  "version": "1.26.2171315",
   "description": "Mirror real-world provider channel lineups by creating channel groups, channels, and fuzzy-matching IPTV streams to them.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/plugins/lineuparr/plugin.py
+++ b/plugins/lineuparr/plugin.py
@@ -22,7 +22,7 @@ from .fuzzy_matcher import (FuzzyMatcher, has_upgrade_quality, detect_category_c
                             detect_name_country_prefix, country_codes_in_text)
 from .aliases import CHANNEL_ALIASES, COUNTRY_ALIASES
 from .progress_status import save_progress_atomic, load_progress, build_status_message
-from . import notify_bridge, reports
+from . import notify_bridge, report_count, reports
 
 from apps.channels.models import Channel, ChannelGroup, ChannelProfile, ChannelProfileMembership, ChannelStream, Stream
 from apps.m3u.models import M3UAccount
@@ -66,7 +66,7 @@ def _clean_json_text(s):
 
 
 class PluginConfig:
-    PLUGIN_VERSION = "1.26.2142327"
+    PLUGIN_VERSION = "1.26.2171315"
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True
@@ -1476,9 +1476,65 @@ class Plugin:
                 return None
             logger.info(f"{LOG_PREFIX} Report written: {result['html_path']}")
             self._emit_reports(result, settings, logger)
+            # Last, deliberately. This is the cosmetic step and delivery is the
+            # one the operator asked for, so nothing here can delay or precede
+            # it. Were this ever to raise, the enclosing except would swallow
+            # the return value and the caller would read a written report as a
+            # failed one.
+            self._publish_report_count(result, logger)
             return result["html_path"]
         except Exception as e:
             logger.warning(f"{LOG_PREFIX} HTML report failed: {e}")
+            return None
+
+    @staticmethod
+    def _publish_report_count(written, logger):
+        """Add one to the count Newsflasharr shows for this plugin.
+
+        Called from the one place a report build is known to have succeeded.
+        write_report degrades instead of raising, so a failed publish otherwise
+        looks exactly like a good one, and a counter that incremented anyway
+        would turn that failure into apparent success.
+
+        Two independent conditions are required, because they can disagree. The
+        result dict must carry no error, which is how write_report reports a
+        failure, and the named file must exist. write_report can return a path
+        AND an error together: the paths are assigned before the old-report
+        pruning step, so a failure inside pruning leaves both keys populated.
+        Checking only the path would count that as a clean build. Checking only
+        the error would count a build whose file was deleted underneath it.
+
+        The reverse case is a deliberate under-count. If the HTML file is
+        written and the CSV write then fails, write_report reports the whole
+        build as failed and this does not increment, even though a complete
+        HTML report is sitting on disk. That is the safe direction: the
+        alternative counts half-written builds as successes.
+
+        Counts builds, not deliveries: a report built while notifications are
+        off still counts, because it was still published to disk. The on-demand
+        Email Report Now action deliberately does not call this, since it sends
+        a report that already exists rather than building one.
+
+        Never raises and never fails the run. A cosmetic number is not worth a
+        report for.
+        """
+        try:
+            written = written or {}
+            path = written.get("html_path")
+            if written.get("error") or not path or not os.path.isfile(path):
+                return None
+            value = report_count.increment(report_count.counter_path())
+            if value is None:
+                # Logged at warning, not debug. The usual cause is the counter
+                # directory having been created root-owned by something run as
+                # root inside the container, which the plugin can then never
+                # rewrite. Nothing else about the plugin looks unhealthy when
+                # that happens, so a debug line would hide it permanently.
+                logger.warning(f"{LOG_PREFIX} Report counter not updated. Check that "
+                               f"{report_count.counter_dir()} is owned by dispatch.")
+            return value
+        except Exception as e:
+            logger.warning(f"{LOG_PREFIX} Report counter not updated: {e}")
             return None
 
     @staticmethod

--- a/plugins/lineuparr/report_count.py
+++ b/plugins/lineuparr/report_count.py
@@ -1,0 +1,210 @@
+"""Publishes the count of reports this plugin has built, for Newsflasharr to show.
+
+THE CONTRACT, which is Newsflasharr's to read and ours to write:
+
+    /data/lineuparr/report_count.json   ->   {"reports_built": 42}
+
+One key, one non-negative JSON integer. That is the whole interface. The reader
+is newsflasharr/report_count.py in the Newsflasharr repository, it degrades to
+showing nothing on every unexpected condition, and it reports no error when it
+does. So every rule below is load bearing even though breaking one looks like
+nothing at all:
+
+  - the value must be a JSON integer, not a float, because int(2.9) is 2 and a
+    silent under-report looks deliberate;
+  - it must not be a JSON boolean, because bool subclasses int in Python and
+    true would display as "1 built";
+  - it must be zero or greater, and zero is legal;
+  - the top level must be a JSON object;
+  - the whole file must stay under 4096 bytes, which the reader checks before
+    it reads, because it runs on an operator click inside a uWSGI worker where
+    a blocking read freezes every greenlet in that process;
+  - the file must be a regular file readable by user dispatch.
+
+An absent file is not an error. It means no count is shown, which is the right
+display for a plugin that publishes no counter.
+
+WHAT THE NUMBER COUNTS. Reports whose files were confirmed written to disk, one
+per successful build, whether an operator pressed the button or a scheduled job
+ran it. A build that failed to write must not increment it. That distinction is
+the point: write_report degrades instead of raising, so a failed publish looks
+identical to a good one from the outside, and a counter that incremented anyway
+would turn that failure into apparent success.
+
+NO LOCKING, DELIBERATELY. The read, add one, write sequence here is unlocked
+across several uWSGI and Celery workers, so two reports finishing in the same
+instant can lose an increment, and an unlucky interleaving can even publish a
+value one lower than the one already on disk: a worker that read N while two
+others advanced the file to N+2 goes on to write N+1. The next increment heals
+it. That is accepted. The number is a floor, not an audit, and a file lock on a
+request path is a worse trade for a cosmetic number. Do not "fix" this by
+adding one.
+
+NO FSYNC, ALSO DELIBERATELY. Measured on this installation inside the
+container: the write sequence below costs 0.26 ms without an fsync and 5.16 ms
+with one, rising to a 29.5 ms ninetieth percentile and a 39 ms maximum while
+another process is writing to the same filesystem. An fsync pays for a journal
+commit, not for the twenty bytes, and /data carries the PostgreSQL data
+directory on the same ext4 filesystem, so it waits behind whatever else is in
+the current transaction. uWSGI here runs gevent with 400 async cores across two
+workers, so that wait freezes an entire worker and every stream it is proxying,
+on the path of an operator button click. The report this counts is not fsynced
+either. Losing a cosmetic increment to a host crash is the cheaper failure.
+
+NOTHING HERE EVER RAISES INTO THE REPORT PATH. Failing to publish the counter
+must not fail the report that was just written.
+"""
+import json
+import os
+import posixpath
+import threading
+
+# The directory is named for the `source` string this plugin passes to
+# notify_client.notify(), because that is what the reader joins onto its data
+# root. It is imported rather than repeated so the two cannot drift apart: the
+# plugin's installed directory name and its own runtime directory are neither
+# of them guaranteed to be this string.
+try:
+    from .notify_bridge import SOURCE
+except ImportError:  # standalone import, as the rest of this package allows
+    from notify_bridge import SOURCE
+
+DATA_ROOT = "/data"
+
+# The single key of the single-key file.
+KEY = "reports_built"
+
+FILENAME = "report_count.json"
+
+# The reader refuses anything larger before it parses. The documented file is
+# around twenty bytes, so this only ever trips on a corrupt or hostile file,
+# which is exactly when we want to refuse to build on top of it.
+MAX_BYTES = 4096
+
+# Writer and reader are the same user, so the file needs no wider access than
+# this. Newsflasharr shipped a defect where an action output file was widened
+# to 0644 and exposed derived provider hostnames to every other user on the
+# host; its own tests, its linter and its publish audit all passed on that code.
+FILE_MODE = 0o600
+
+# The directory mode applies only on the run that creates it, and this
+# directory is new: reports themselves live in /data/lineuparr_reports, so
+# nothing has created /data/lineuparr before. Whichever process gets there
+# first owns it. If that is anything run as root inside the container, and the
+# documented way of probing a plugin is exactly that, the dispatch workers can
+# never write here again and the count silently stops moving. The deploy
+# runbook in this repository's CLAUDE.md chowns this path for that reason, and
+# _publish_report_count logs a failed write at warning level rather than debug
+# so the condition is visible rather than merely present.
+DIR_MODE = 0o700
+
+
+def counter_dir(data_root=DATA_ROOT):
+    """The directory the reader looks in for this plugin's counter.
+
+    Joined with posixpath rather than os.path because this names a location
+    inside the Linux container, always, whatever machine the code is being
+    read or tested on. os.path.join on a Windows checkout returns a backslash
+    form that is not the path the reader opens.
+    """
+    return posixpath.join(data_root, SOURCE)
+
+
+def counter_path(data_root=DATA_ROOT):
+    """The full path of the counter file."""
+    return posixpath.join(counter_dir(data_root), FILENAME)
+
+
+def read(path):
+    """The stored count, or None when there is no usable one.
+
+    Applies the same rules the reader applies, so a value this function returns
+    is a value Newsflasharr would display. None means the file is absent,
+    unreadable, oversized, malformed, or holds something that is not a
+    non-negative integer. Never raises.
+    """
+    try:
+        if not os.path.isfile(path) or os.stat(path).st_size > MAX_BYTES:
+            return None
+        with open(path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, ValueError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get(KEY)
+    # bool first: it subclasses int, so True passes an isinstance int check.
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def write(path, value):
+    """Write the counter atomically. Returns True on success, False otherwise.
+
+    The temporary file is created in the destination directory, so os.replace
+    is a rename within one filesystem and a reader only ever opens a complete
+    file. It is created BY os.open with the final mode rather than chmodded
+    afterwards, so there is no moment at which it is more readable than
+    intended, and os.replace carries that mode to the destination, narrowing an
+    existing file that somehow had a wider one.
+
+    The temporary name carries this process's id AND this thread's id rather
+    than random characters. A worker killed between the create and the rename
+    would otherwise leave a uniquely named file that nothing ever cleans up; a
+    per-thread name is reused by that thread's next write instead.
+
+    The thread id is not decoration. Dispatcharr's dvr Celery worker runs a
+    thread pool, so two of its threads share one process id, and a name built
+    from the process id alone would have them truncating each other's temporary
+    file. The later close would then flush at its own offset and the rename
+    could publish padding bytes followed by valid JSON.
+
+    Never raises. A caller that cannot publish a cosmetic number must carry on.
+    """
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return False
+    directory = os.path.dirname(path) or "."
+    tmp = os.path.join(
+        directory, f"{FILENAME}.tmp-{os.getpid()}-{threading.get_ident()}")
+    handle = None
+    try:
+        # exist_ok means the mode is applied only when this call is the one
+        # that creates the directory. On an existing directory makedirs does
+        # nothing at all, including nothing about its permissions.
+        os.makedirs(directory, mode=DIR_MODE, exist_ok=True)
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, FILE_MODE)
+        handle = os.fdopen(fd, "w", encoding="utf-8")
+        json.dump({KEY: value}, handle)
+        handle.write("\n")
+        handle.close()
+        handle = None
+        os.replace(tmp, path)
+        return True
+    except Exception:
+        if handle is not None:
+            try:
+                handle.close()
+            except OSError:
+                pass
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False
+
+
+def increment(path):
+    """Add one to the published count. Returns the new value, or None.
+
+    An absent, unreadable or malformed file starts the count again from one
+    rather than refusing forever: the number is a floor, and a counter that
+    stayed permanently silent because of one bad write would be worse than one
+    that under-reports. Never raises.
+    """
+    try:
+        current = read(path)
+        new_value = (current if isinstance(current, int) and current >= 0 else 0) + 1
+        return new_value if write(path, new_value) else None
+    except Exception:
+        return None

--- a/plugins/lineuparr/reports.py
+++ b/plugins/lineuparr/reports.py
@@ -20,6 +20,7 @@ the account name list is None, which is how a caller reports that the lookup
 failed. An empty list is a different thing and is allowed: an installation can
 legitimately have no active M3U accounts.
 """
+import base64
 import csv
 import datetime
 import html
@@ -185,39 +186,185 @@ def truncation_notice(model):
 
 # Styling is inlined because the page is read from a file path or inside an email
 # client, where an external stylesheet would not resolve.
+#
+# THE TOKEN LAYER, adopted from the Dustarr plugin's report. Four rules govern
+# it, and each one was a real defect in that plugin before it was fixed:
+#
+#   Spacing is a scale. Every margin, padding and gap picks --s1 to --s5. The
+#   steps are about a third apart, because a linear ramp makes small steps look
+#   identical and large ones look arbitrary.
+#
+#   No opacity for text hierarchy. Use --ink, --ink-muted, --ink-dim. An
+#   opacity value paints a different colour on every surface it lands on, so
+#   the contrast ratio moves silently whenever a background changes, and the
+#   fade applies to everything nested inside. The ramp is 5.24:1 at its weakest
+#   against the light surface, over the 4.5:1 floor. Opacity remains fine for a
+#   decorative fill that carries no text.
+#
+#   Light and dark differ only in token values. Needing !important means the
+#   tokens are wrong.
+#
+#   No literal colour inside a rule. Light and dark cannot both be right about
+#   one. Literals appear only in the two :root blocks.
+#
+# The category colours and the two surface colours were validated all pairs for
+# colourblind safety against those exact surfaces, with a validator that is not
+# in this repository. THE NUMBERS ARE NOT RE-DERIVABLE HERE. Reuse the semantic
+# slots for new categories rather than inventing a hex value.
 _CSS = """
-:root { color-scheme: light dark; --accent: #2a78d6; }
-body { font: 15px/1.5 system-ui, -apple-system, Segoe UI, sans-serif;
-       margin: 0; padding: 24px; background: #fbfbfd; color: #16181d; }
-@media (prefers-color-scheme: dark) {
-  :root { --accent: #3987e5; }
-  body { background: #14161a; color: #e8eaed; }
-  th { background: #1e2127 !important; }
-  tr:nth-child(even) td { background: #191c21; }
-  .card { background: #1a1d22 !important; border-color: #2a2e35 !important; }
-  .notice { background: #2a2410 !important; border-color: #5a4a18 !important; }
+:root {
+  color-scheme: light dark;
+  --never: #2a78d6; --watched: #1baf7a; --tuned: #e34948; --toonew: #898781;
+  --track: #e1e0d9; --ok: #0ca30c; --bad: #d03b3b;
+
+  --s1: 4px; --s2: 8px; --s3: 12px; --s4: 16px; --s5: 24px;
+
+  --bg: #fbfbfd; --raised: #ffffff; --zebra: #f7f8fa; --head: #f2f3f6;
+  --ink: #16181d; --ink-muted: #5c616b; --ink-dim: #656a76;
+  --line: #e3e5ea; --line-soft: #e6e8ec;
+  --warn-bg: #fff4e5; --warn-line: #ffb84d; --warn-ink: #7a4b00;
+  --lift: 0 1px 2px rgba(16, 18, 29, .05), 0 4px 12px rgba(16, 18, 29, .04);
 }
-h1 { font-size: 22px; margin: 0 0 4px; }
-.sub { opacity: .7; font-size: 15px; margin-bottom: 20px; }
-.card { background: #fff; border: 1px solid #e3e5ea; border-radius: 10px;
-        padding: 14px 16px; margin-bottom: 18px; }
-.notice { background: #fff8e1; border: 1px solid #e8d9a0; border-radius: 8px;
-          padding: 10px 14px; margin-bottom: 18px; font-size: 14px; }
+@media (prefers-color-scheme: dark) {
+  :root {
+    --never: #3987e5; --watched: #199e70; --tuned: #e66767; --toonew: #898781;
+    --track: #2c2c2a; --ok: #0ca30c; --bad: #d03b3b;
+
+    --bg: #14161a; --raised: #1a1d22; --zebra: #191c21; --head: #1e2127;
+    --ink: #e8eaed; --ink-muted: #a7adb8; --ink-dim: #9aa0ab;
+    --line: #2a2e35; --line-soft: #262a31;
+    --warn-bg: #2e2312; --warn-line: #8a6320; --warn-ink: #f2c98a;
+    --lift: 0 1px 2px rgba(0, 0, 0, .35), 0 4px 12px rgba(0, 0, 0, .25);
+  }
+}
+body { font: 15px/1.5 system-ui, -apple-system, Segoe UI, sans-serif;
+       margin: 0; padding: var(--s5); background: var(--bg); color: var(--ink); }
+/* The logo sits beside the title rather than above it, so the masthead costs
+   one line of vertical space instead of three. */
+.masthead { display: flex; align-items: center; gap: var(--s3);
+            margin-bottom: var(--s5); }
+.mark { flex: none; width: 48px; height: 48px; display: block; }
+/* The type scale is 15 / 17 / 22, hand picked and deliberately sparse. A step
+   7 percent from the body size reads as an accident rather than a decision,
+   and this page is sized for reading at television distance, so nothing here
+   shrinks. Supporting text is separated by colour instead. */
+h1 { font-size: 22px; line-height: 1.2; letter-spacing: -.01em;
+     margin: 0 0 var(--s1); }
+.masthead .sub { margin-bottom: 0; }
+.sub { color: var(--ink-muted); font-size: 15px; margin-bottom: var(--s4); }
+.card { background: var(--raised); border: 1px solid var(--line);
+        border-radius: 10px; box-shadow: var(--lift);
+        padding: var(--s3) var(--s4); margin-bottom: var(--s4); }
+.notice { background: var(--warn-bg); border: 1px solid var(--warn-line);
+          border-radius: 10px; box-shadow: var(--lift);
+          padding: var(--s3) var(--s4); margin-bottom: var(--s4);
+          color: var(--warn-ink); font-size: 15px; }
 table { border-collapse: collapse; width: 100%; font-size: 15px; }
 .scroll { overflow-x: auto; }
-th, td { text-align: left; padding: 6px 10px; border-bottom: 1px solid #e6e8ec;
-         vertical-align: top; }
-th { background: #f2f3f6; }
+th, td { text-align: left; padding: var(--s2) var(--s3);
+         border-bottom: 1px solid var(--line-soft); vertical-align: top; }
+th { background: var(--head); }
+/* Zebra striping is defined once, in tokens, so both themes render the same
+   table. Dustarr had it in dark mode only for months. */
+tr:nth-child(even) td { background: var(--zebra); }
 th.sortable { cursor: pointer; user-select: none; white-space: nowrap; }
-th.sortable::after { content: " \\2195"; opacity: .35; font-size: 12px; }
-th.sortable[aria-sort="ascending"]::after { content: " \\2191"; opacity: 1; }
-th.sortable[aria-sort="descending"]::after { content: " \\2193"; opacity: 1; }
-.empty { opacity: .7; font-style: italic; }
-.note { font-size: 14px; opacity: .7; margin-top: 20px; }
-dl.meta { margin: 0; display: grid; grid-template-columns: auto 1fr; gap: 2px 14px; }
-dl.meta dt { opacity: .7; }
+th.sortable::after { content: " \\2195"; color: var(--ink-dim); font-size: 15px; }
+th.sortable[aria-sort="ascending"]::after { content: " \\2191"; color: var(--ink); }
+th.sortable[aria-sort="descending"]::after { content: " \\2193"; color: var(--ink); }
+.empty { color: var(--ink-muted); font-style: italic; }
+dl.meta { margin: 0; display: grid; grid-template-columns: auto 1fr;
+          gap: var(--s1) var(--s4); }
+dl.meta dt { color: var(--ink-muted); }
 dl.meta dd { margin: 0; }
+details { border-top: 1px solid var(--track); padding: var(--s1) 0 var(--s2); }
+/* Never add outline: none here. The focus ring is how this page is driven by a
+   television remote control's directional pad. */
+summary { font-size: 17px; font-weight: 600; cursor: pointer;
+          padding: var(--s2) var(--s1); list-style: none; }
+summary::-webkit-details-marker { display: none; }
+summary::before { content: '\\25B8'; display: inline-block; width: 1em;
+                  color: var(--ink-dim); transition: transform .12s; }
+details[open] > summary::before { transform: rotate(90deg); }
+.dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%;
+       margin-right: var(--s2); vertical-align: baseline; }
+.dot-watched { background: var(--watched); }
+.dot-toonew { background: var(--toonew); }
+.dot-tuned { background: var(--tuned); }
+.dot-never { background: var(--never); }
+.dot-neutral { background: var(--track); }
+/* The heading is 600 and the count stays at 400, which is what makes the
+   number read as data rather than as part of the label. */
+.count { font-weight: 400; color: var(--ink-dim);
+         font-variant-numeric: tabular-nums; }
+/* Emoji ignore colour, so this cannot carry meaning even by accident. It is
+   spacing only. */
+.glyph { margin-right: var(--s2); }
+.hint { font-size: 15px; color: var(--ink-dim); margin: 0 0 var(--s2); }
+.colophon { margin-top: var(--s5); padding-top: var(--s4);
+            border-top: 1px solid var(--track); color: var(--ink-dim); }
+.colophon p { margin: 0 0 var(--s1); }
+.colophon a { color: var(--never); }
 """
+
+# The project's own pages, shown in the report footer.
+REPO_URL = "https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin"
+ISSUES_URL = "https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin/issues"
+
+# The plugin that delivers an emailed copy of this report.
+#
+# Newsflasharr already writes its own credit line into the EMAIL BODY, in
+# email_render.footer_text, reading "Lineuparr report courtesy of
+# Newsflasharr". The line below is the same credit carried inside the report
+# page, so it survives the page being saved, forwarded or opened from disk
+# without the mail around it.
+#
+# The wording is deliberately about emailed copies rather than about this copy.
+# A report read straight from the report directory was never delivered by
+# anything, and a page that thanked a deliverer that had not run would be
+# saying something untrue in its own footer.
+NEWSFLASHARR_URL = "https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin"
+
+LOGO_FILE = "logo.png"
+
+# A logo larger than this is not embedded. The page is mailed as an attachment
+# and every byte of the image is carried in every report, so an oversized file
+# is a cost paid repeatedly by the person receiving the mail. The current
+# logo.png is 440 by 440 and about 181 KB, which encodes to roughly 247 KB of
+# base64; a 256 by 256 version would be about a quarter of that.
+MAX_LOGO_BYTES = 262144
+
+# One slot: empty means not yet resolved, one entry means resolved. The failure
+# is cached too, so a missing file is not re-read on every render.
+_logo_cache = []
+
+
+def logo_data_uri():
+    """The logo as a data URI, or an empty string when it cannot be used.
+
+    Embedded, never linked. This page is opened from a file path and is also
+    mailed as an attachment, so a relative path resolves against nothing and a
+    remote address is blocked by default in most mail clients. This repository
+    was private for much of its life, so a raw link to it would not have
+    resolved either.
+
+    Returns an empty string rather than raising on any failure, and the caller
+    then renders no image element at all rather than a broken image icon.
+    render_html has no safety net of its own: write_report catches the failure
+    one level up, so a logo problem must cost the header image and nothing more.
+    """
+    if not _logo_cache:
+        try:
+            path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                LOGO_FILE)
+            if os.path.getsize(path) > MAX_LOGO_BYTES:
+                _logo_cache.append("")
+            else:
+                with open(path, "rb") as handle:
+                    encoded = base64.b64encode(handle.read()).decode("ascii")
+                _logo_cache.append(f"data:image/png;base64,{encoded}")
+        except Exception:
+            _logo_cache.append("")
+    return _logo_cache[0]
 
 
 def _esc(value):
@@ -292,27 +439,196 @@ _SORT_SCRIPT = """
 """
 
 
+# The glyph is keyed on the section's COLOUR CLASS rather than on its title, so
+# a heading can never end up with a glyph that disagrees with its colour. Each
+# one says what the section MEANS rather than decorating it. dot-neutral is
+# shared by more than one kind of section and no single honest glyph fits them
+# all, so it gets none.
+_SECTION_GLYPH = {
+    "dot-watched": "\N{GLOWING STAR}",          # keep these, they are right
+    "dot-toonew": "\N{HOURGLASS WITH FLOWING SAND}",   # judge these yourself
+    "dot-tuned": "\N{WARNING SIGN}",            # these need attention
+    "dot-neutral": "",
+}
+
+# The score bands. A band is a range of the match score a row carries, and the
+# boundaries are stated in the section descriptions so a reader never has to
+# guess what "strong" meant. Ordered high to low, and the last entry must have
+# a floor of 0 so every row lands somewhere.
+_SCORE_BANDS = (
+    (90, "Strong matches", "dot-watched",
+     "Scored 90 or above. These are the matches least likely to need a second "
+     "look, and they are listed so you can confirm rather than search."),
+    (60, "Worth checking", "dot-toonew",
+     "Scored 60 to 89. Good enough to propose and not good enough to trust "
+     "without reading. This is the section to spend your time in."),
+    (0, "Weak or no match", "dot-tuned",
+     "Scored below 60, or nothing was found at all. Either the lineup names "
+     "this channel differently from your provider, or the channel is absent. "
+     "An alias is usually the fix."),
+)
+
+# Every section is collapsed, so this line appears in each one.
+_FIND_HINT = ("<p class=\"hint\">Expand this section before searching it. "
+              "Find in page does not reach inside a collapsed section on some "
+              "browsers.</p>")
+
+
+def _section(title, count, body, dot_class, open_by_default=False):
+    """One report section as a collapsible details element.
+
+    Every section starts collapsed. The page is an index of what the run found,
+    not a wall of tables, and a reader opens the part they care about.
+
+    `count` must equal the number of rows in the table directly beneath it, in
+    every section without exception. A reader looking at a collapsed page
+    cannot see any distinction that would justify one section omitting it, and
+    a section with no number reads as one that forgot.
+
+    A details element needs no JavaScript, and a client that does not implement
+    it renders the content expanded. The failure mode is everything visible,
+    never content lost.
+    """
+    open_attr = " open" if open_by_default else ""
+    number = "" if count is None else f' <span class="count">{int(count)}</span>'
+    # Decoration on top of the coloured dot and the words, never the only thing
+    # carrying the meaning, which is why it is hidden from assistive software.
+    # A client with no emoji font shows a box or nothing and the heading still
+    # reads correctly.
+    glyph = _SECTION_GLYPH.get(dot_class, "")
+    badge = f'<span class="glyph" aria-hidden="true">{glyph}</span>' if glyph else ""
+    return (f'<details{open_attr}><summary>'
+            f'<span class="dot {_esc(dot_class)}" aria-hidden="true"></span>'
+            f'{badge}{_esc(title)}{number}</summary>{body}</details>')
+
+
+def _column_index(headers, wanted):
+    """The index of the first header whose text contains `wanted`, or None.
+
+    Matched on the DISPLAYED header rather than the row key, because the four
+    callers use four different keys for the same idea: Score, Best Score and
+    confidence_score all display as a score.
+    """
+    for index, header in enumerate(headers or []):
+        if wanted in str(header).strip().lower():
+            return index
+    return None
+
+
+def _as_score(value):
+    """A row's score as a float, or None when the cell holds no number.
+
+    Total over its input on purpose. Every cell reaching here has already been
+    stringified by build_model, and a provider supplied name can be anything at
+    all, so this must not raise on text, on an empty cell or on None.
+    """
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def group_entries(model):
+    """Split the rendered rows into sections. Returns a list of section dicts.
+
+    -> [{"title", "dot", "description", "entries"}], in display order.
+
+    Three shapes, in order of preference:
+
+    A score column gives score bands, which is the split that matches how the
+    report is actually read: the reader wants the doubtful matches, not the
+    confident ones. A row whose score cell holds no number is treated as no
+    match, which is what an empty score cell means here.
+
+    Failing that, a status column gives one section per distinct status value,
+    in first-seen order so the grouping does not reorder the run's own output.
+
+    Failing both, one section holding every row. The page still gains the
+    collapse behaviour and the count, and nothing is invented.
+
+    Every row lands in exactly one section, so the counts sum to the number of
+    rows rendered. No row is dropped and no row appears twice.
+    """
+    headers = model.get("headers") or []
+    entries = model.get("entries") or []
+
+    score_at = _column_index(headers, "score")
+    if score_at is not None:
+        buckets = {floor: [] for floor, _, _, _ in _SCORE_BANDS}
+        for entry in entries:
+            cell = entry[score_at] if score_at < len(entry) else None
+            score = _as_score(cell)
+            for floor, _, _, _ in _SCORE_BANDS:
+                if score is not None and score >= floor:
+                    buckets[floor].append(entry)
+                    break
+            else:
+                # No number in the cell, so no match was recorded for this row.
+                buckets[_SCORE_BANDS[-1][0]].append(entry)
+        return [{"title": title, "dot": dot, "description": description,
+                 "entries": buckets[floor]}
+                for floor, title, dot, description in _SCORE_BANDS]
+
+    status_at = _column_index(headers, "status")
+    if status_at is not None:
+        order = []
+        buckets = {}
+        for entry in entries:
+            cell = entry[status_at] if status_at < len(entry) else ""
+            key = str(cell).strip() or "No status recorded"
+            if key not in buckets:
+                buckets[key] = []
+                order.append(key)
+            buckets[key].append(entry)
+        return [{"title": key, "dot": "dot-neutral",
+                 "description": f"Every row this run reported as {key.lower()}.",
+                 "entries": buckets[key]}
+                for key in order]
+
+    return [{"title": "Every row in this run", "dot": "dot-neutral",
+             "description": "This run reported no score and no status, so the "
+                            "rows are listed exactly as it produced them.",
+             "entries": list(entries)}]
+
+
+def _table(headers, entries):
+    """One sortable table, or a line saying the section is empty."""
+    if not entries:
+        return "<p class=\"empty\">No rows in this section.</p>"
+    head = "".join(
+        "<th class=\"sortable\" aria-sort=\"none\" tabindex=\"0\" role=\"columnheader\" "
+        f"title=\"Sort by {_esc(h)}\">{_esc(h)}</th>"
+        for h in headers or [])
+    body = "".join(
+        "<tr>" + "".join(f"<td data-v=\"{_esc(cell)}\">{_esc(cell)}</td>"
+                         for cell in entry) + "</tr>"
+        for entry in entries)
+    return ("<div class=\"scroll\"><table>"
+            "<thead><tr>" + head + "</tr></thead>"
+            "<tbody>" + body + "</tbody>"
+            "</table></div>")
+
+
 def render_html(model):
     """Render the model to one self contained HTML page.
 
-    The table is sortable by clicking or keyboard-activating a column header.
+    Rows are grouped into collapsible sections, all closed, so the page opens
+    as an index of what the run found rather than as one long table. Each
+    section states what it holds and what to do about it, because a collapsed
+    heading is all a reader has to decide whether to open it.
+
+    Every table is sortable by clicking or keyboard activating a column header.
     See _SORT_SCRIPT for what that does and what it deliberately does not do.
     """
-    rows = []
-    for entry in model.get("entries") or []:
-        cells = "".join(f"<td data-v=\"{_esc(cell)}\">{_esc(cell)}</td>" for cell in entry)
-        rows.append(f"<tr>{cells}</tr>")
-    headers = "".join(
-        "<th class=\"sortable\" aria-sort=\"none\" tabindex=\"0\" role=\"columnheader\" "
-        f"title=\"Sort by {_esc(h)}\">{_esc(h)}</th>"
-        for h in model.get("headers") or [])
-    if rows:
-        table = ("<div class=\"scroll\"><table>"
-                 "<thead><tr>" + headers + "</tr></thead>"
-                 "<tbody>" + "".join(rows) + "</tbody>"
-                 "</table></div>")
-    else:
-        table = "<p class=\"empty\">This run produced no rows.</p>"
+    headers = model.get("headers") or []
+    sections = "".join(
+        _section(
+            group["title"], len(group["entries"]),
+            f"<p class=\"sub\">{_esc(group['description'])}</p>"
+            + _FIND_HINT
+            + "<div class=\"card\">" + _table(headers, group["entries"]) + "</div>",
+            group["dot"])
+        for group in group_entries(model))
 
     meta = "".join(f"<dt>{_esc(k)}</dt><dd>{_esc(v)}</dd>"
                    for k, v in model.get("summary") or [])
@@ -320,24 +636,41 @@ def render_html(model):
     notice = truncation_notice(model)
     notice_html = f"<div class=\"notice\">{_esc(notice)}</div>\n" if notice else ""
 
+    # An empty data URI renders no image element at all, rather than the broken
+    # image icon a missing file would otherwise produce.
+    logo = logo_data_uri()
+    mark = (f'<img class="mark" src="{logo}" alt="" width="48" height="48">'
+            if logo else "")
+
+    title = _esc(model.get("title"))
     return (
         "<!doctype html>\n<html lang=\"en\">\n<head>\n"
         "<meta charset=\"utf-8\">\n"
         "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
-        f"<title>Lineuparr: {_esc(model.get('title'))}</title>\n"
+        f"<title>Lineuparr: {title}</title>\n"
         f"<style>{_CSS}</style>\n</head>\n<body>\n"
-        f"<h1>Lineuparr: {_esc(model.get('title'))}</h1>\n"
-        f"<div class=\"sub\">{_esc(model.get('shown_rows', 0))} row(s) shown</div>\n"
+        f"<header class=\"masthead\">\n{mark}\n<div>\n"
+        f"<h1>Lineuparr: {title}</h1>\n"
+        f"<div class=\"sub\">{_esc(model.get('shown_rows', 0))} row(s) shown. "
+        "Every section below is collapsed. Open the one you want.</div>\n"
+        "</div>\n</header>\n"
         + notice_html +
         f"<div class=\"card\"><dl class=\"meta\">{meta}</dl></div>\n"
-        f"<div class=\"card\">{table}</div>\n"
-        "<p class=\"note\">Click a column heading to sort by it, or focus it and "
-        "press Enter. Sorting needs the page open in a browser; a mail client "
-        "previewing this file shows every row but cannot reorder them.</p>\n"
-        "<p class=\"note\">Stream names here are shown without their M3U source "
-        "label, and the plugin settings that name your M3U sources are not "
-        f"included. The complete export, which does include them, stays in "
-        f"{EXPORTS_LOCATION} inside the container.</p>\n"
+        f"{sections}\n"
+        "<footer class=\"colophon\">\n"
+        "<p>Built by Lineuparr, a lineup matcher for Dispatcharr.</p>\n"
+        "<p>Click a column heading to sort by it, or focus it and press Enter. "
+        "Sorting needs the page open in a browser. A mail client previewing "
+        "this file shows every row but cannot reorder them.</p>\n"
+        "<p>Stream names here are shown without their M3U source label, and the "
+        "plugin settings that name your M3U sources are not included. The "
+        f"complete export, which does include them, stays in {EXPORTS_LOCATION} "
+        "inside the container and is not emailed.</p>\n"
+        "<p>Emailed copies of this report are delivered courtesy of "
+        f"<a href=\"{NEWSFLASHARR_URL}\">Newsflasharr</a>.</p>\n"
+        f"<p><a href=\"{REPO_URL}\">Source and documentation</a> · "
+        f"<a href=\"{ISSUES_URL}\">Report a problem</a></p>\n"
+        "</footer>\n"
         f"<script>{_SORT_SCRIPT}</script>\n"
         "</body>\n</html>\n"
     )


### PR DESCRIPTION
## What changed

Updates Lineuparr from `1.26.2142327` to `1.26.2171315`.

### A report count for the Newsflasharr plugin

Lineuparr now writes `/data/lineuparr/report_count.json`, holding the number of reports it has built. The Newsflasharr plugin's status action reads that file and shows the count next to Lineuparr in its list of report sources.

It counts reports whose files reached the disk, so a run that failed to write one does not increase it. Failing to write the counter never fails the report.

New file: `report_count.py`.

### A redesigned HTML report

The report was one long table. It is now an index of what the run found:

- **Collapsed sections.** Rows are grouped and every section starts closed. A report with a score column splits into strong matches (90 and above), worth checking (60 to 89), and weak or no match. A report with only a status column groups by status instead.
- **The row count is in every heading**, equal to the rows in the table directly beneath it.
- **Each section says what it holds and what to do about it**, since a collapsed heading is all the reader has to decide whether to open it.
- **One colour system for light and dark**, from a token layer, with no hardcoded colours in any rule.
- **The logo is embedded** rather than linked, so it renders when the page is opened from disk or read as a mail attachment.
- **A footer** linking to the project and its issue tracker.

The page remains a single self-contained file with no external images, fonts or scripts.

### Documentation

The plugin's user guide gained a Reports section covering the report files, the sections, and how to switch on emailing through Newsflasharr.

## Notes for reviewers

- Four files changed: `plugin.json` (version only), `plugin.py`, `reports.py`, and the new `report_count.py`.
- The plugin's own test suite passes: 704 tests.
- The author of this pull request, PiratesIRC, is the `author` in the manifest.
