### PR TITLE
[newsflasharr] Bump version to 1.26.2171427

### DIFF
--- a/plugins/newsflasharr/plugin.json
+++ b/plugins/newsflasharr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Newsflasharr",
-  "version": "1.26.2142011",
+  "version": "1.26.2171427",
   "description": "Central notification service: other plugins drop events, Newsflasharr routes them to Discord, a webhook, ntfy, Apprise, email, or an on-screen banner over live TV, with deduplication, storm throttling, quiet hours and per-channel retry.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Bumps Newsflasharr from `1.26.2142011` to `1.26.2171427`. Version field only; no other manifest field changed.

**What is in this release**

Show status gains a `report sources:` line naming every plugin that has delivered a report through Newsflasharr, with how long ago its most recent one arrived. Where a calling plugin publishes a count of the reports it has written, that count is shown beside it. The line is informational and never turns the plugin card red; deciding that a report is overdue stays with the existing report absence check, judged against the cadence the operator configured.

Full notes: https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/releases/tag/1.26.2171427

**Checked before opening this**

- `source_url` with `{version}` substituted resolves: `https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/releases/download/1.26.2171427/Newsflasharr.zip` returns HTTP 200. The `v`-prefixed form returns 404, so the URL correctly has no `v`, matching this project's bare tags.
- The archive is the one built by the project's allowlist-driven release script and validated: 21 entries, forward-slash separators only, no CRLF.
- The plugin's own publish audit ran against the published tree before the release, with no findings.
- `author` is `PiratesIRC`, which is the account opening this pull request.
