### PR TITLE
[newsflasharr] Bump version to 1.26.2191208

### DIFF
--- a/plugins/newsflasharr/plugin.json
+++ b/plugins/newsflasharr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Newsflasharr",
-  "version": "1.26.2171427",
+  "version": "1.26.2191208",
   "description": "Central notification service: other plugins drop events, Newsflasharr routes them to Discord, a webhook, ntfy, Apprise, email, or an on-screen banner over live TV, with deduplication, storm throttling, quiet hours and per-channel retry.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Bumps Newsflasharr from `1.26.2142011` to `1.26.2191208`. Version field only; no other manifest field changed.

**What is in this release**

A user-reported bug fix. Every action writes its complete output to a file, because the plugin card's toast is clipped at roughly 280 characters. That file went to `/config/newsflasharr/`, which is only writable on an installation that mounts a host directory at `/config`. In the stock Dispatcharr image `/config` is owned by root, so the plugin could not create its directory there and every action reported `[readout file NOT written: PermissionError/EACCES]` with no file produced. Validate settings was the worst affected, since its output is far longer than a toast can hold.

The plugin now falls back to `/data/newsflasharr/readouts/<action>.txt`, on the volume it already uses for its queue, and the result names whichever path it used. Nothing to configure. Notification delivery was never affected.

Full notes: https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/releases/tag/1.26.2191208

**Checked before opening this**

- `source_url` with `{version}` substituted resolves: `https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/releases/download/1.26.2191208/Newsflasharr.zip` returns HTTP 200. The URL correctly carries no `v`, matching this project's bare tags.
- The archive is the one built by the project's allowlist-driven release script and validated: 21 entries, forward-slash separators only, no CRLF.
- The publish audit ran against the published tree and its whole history before the release, with no findings.
- `author` is `PiratesIRC`, the account opening this pull request.

Note on the previous bump, pull request #217: it merged and the registry published it, but the two `pages build and deployment` runs since 2026-08-05 both failed with the deploy step stuck in `deployment_queued`, so `manifest.json` on the Pages site still advertises `1.26.2142011`. The `releases` branch is correct. Mentioning it only because the version this pull request supersedes never reached clients.
