### PR TITLE
[iptv-checker] Bump to 1.26.2191412

### DIFF
--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.2191151",
+  "version": "1.26.2191412",
   "description": "Check IPTV stream status and quality with ffprobe, then rename, move, restore or delete channels based on the result. Judges a channel by all of its streams, so a working backup never marks it dead.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Updates the listing from 1.26.2191151 to 1.26.2191412. Manifest only; this plugin is listed in external mode, so the archive comes from the release the `source_url` resolves to.

Four releases since the listed version:

- **1.26.2191151, a scheduler fix.** Measured on a live install: the nightly cron fired twice, 1.34 seconds apart, and two concurrent five-hour scans each emailed a report. A plugin discovery pass re-imported the plugin module inside the process that already owned the scheduler election lock, so two scheduler loops ran holding two separate module objects. That defeats every in-memory guard at once, because each loop reads its own copy of the module globals and the election lock sees a single process id. The per-minute claim is now also written to disk with `os.open(O_CREAT|O_EXCL)`, which a re-import cannot defeat. It fails open: if the claim cannot be written the schedule still runs and logs a warning, because a duplicate run is recoverable and a scheduler that silently stops firing is not.
- **1.26.2191335, report styling.** The HTML report now follows the same visual language as the Dustarr listing: shared neutral palette, spacing and type scales, table treatment and footer.
- **1.26.2191411, a character-encoding fix.** The report page carried no doctype and no charset declaration, so the emoji in its section headings rendered as runs of wrong characters in browsers and mail clients. It now emits a real document head with `<meta charset="utf-8">`. The footer also credits Newsflasharr for emailed copies, matching the wording used by the lineuparr and channel-mapparr listings.
- **1.26.2191412, documentation.** README, user guide and contributor notes updated for the above.

Verified before submitting: the resolved `source_url` returns HTTP 200, the release asset exists, and the full test suite (463 tests) and linter pass at the tagged commit.
