### PR TITLE
[iptv-checker] Bump to 1.26.2201040

### DIFF
--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.2191412",
+  "version": "1.26.2201040",
   "description": "Check IPTV stream status and quality with ffprobe, then rename, move, restore or delete channels based on the result. Judges a channel by all of its streams, so a working backup never marks it dead.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Updates the listing from 1.26.2191412 to 1.26.2201040. Manifest only; this plugin is listed in external mode, so the archive comes from the release the `source_url` resolves to.

**Clearing a stuck progress file no longer clears a check that is actually running.** Measured on a live install on 2026-08-08: two plugin discovery passes, at 04:24:58 and 04:29:31, each clamped a running check to idle, at 418 of 2691 streams and then 488 of 2691.

The routine exists for a real problem: a container kill bypasses the code that marks a check finished, so the file is left saying "running" forever and every later scheduled fire defers to a check that is not there. Its assumption was the flaw. It ran from the plugin constructor and assumed nothing could be running at that moment, which holds inside one process and does not hold across the several worker processes Dispatcharr runs, because a discovery pass constructs a plugin instance in whichever worker serves it.

It now stamps the container boot token into the progress file on every write and uses it to tell the two situations apart. A file from a previous container cannot belong to a running check. Within one container life the file's modification time decides instead, since a live check rewrites it continuously, with a threshold far above the write cadence: clearing a live run is worse than leaving a dead file for a few more minutes.

Verified before submitting: the resolved `source_url` returns HTTP 200, and the full test suite (473 tests, 10 of them new and covering both situations) and the linter pass at the tagged commit.
