### PR TITLE
[embyfin-stream-cleanup] deprecate and unlist

### DIFF
--- a/plugins/embyfin-stream-cleanup/plugin.json
+++ b/plugins/embyfin-stream-cleanup/plugin.json
@@ -7,5 +7,8 @@
   "author": "sethwv",
   "min_dispatcharr_version": "v0.22.0",
   "help_url": "https://github.com/swvn-dispatch/embyfin-stream-cleanup",
-  "repo_url": "https://github.com/swvn-dispatch/embyfin-stream-cleanup"
+  "repo_url": "https://github.com/swvn-dispatch/embyfin-stream-cleanup",
+
+  "deprecated": true,
+  "unlisted": true
 }


### PR DESCRIPTION
Mark the plugin as deprecated and unlisted.

Will potentially resume development in the future, but for now I don't think people should be using this plugin.