### PR TITLE
[newsflasharr] update listing to 1.26.2241159

### DIFF
--- a/plugins/newsflasharr/plugin.json
+++ b/plugins/newsflasharr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Newsflasharr",
-  "version": "1.26.2191208",
+  "version": "1.26.2241159",
   "description": "Central notification service: other plugins drop events, Newsflasharr routes them to Discord, a webhook, ntfy, Apprise, email, or an on-screen banner over live TV, with deduplication, storm throttling, quiet hours and per-channel retry.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Updates the Newsflasharr listing from `1.26.2191208` to `1.26.2241159`.

Version field only. No other manifest field changed.

The release covers three things since the listed version:

- The on-screen ticker overlay was re-encoding every channel at a fixed bitrate with no quality target, which degraded the picture it draws on. The encoder now targets picture quality with a ceiling, and a new setting chooses the trade.
- Validate settings now reports which setting contributed each subscribed Dispatcharr event, rather than only the combined total.
- Documentation corrections: the user guide's reference Output Profile parameters were out of date and are now pinned to what the plugin renders by a test.

The plugin is external mode, so the asset is the release archive on the plugin's own repository:

- https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/releases/download/1.26.2241159/Newsflasharr.zip

Verified to return HTTP 200 with the tag format the manifest produces (bare version, no `v` prefix).
