### PR TITLE
[stream-mapparr] Bump version to 1.26.2241602

### DIFF
--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2141957",
+  "version": "1.26.2241602",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
External-mode version bump. This changes the `version` field in `plugins/stream-mapparr/plugin.json` and nothing else.

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.2241602

The download URL the registry will substitute resolves, checked by hand rather than assumed:
`https://github.com/PiratesIRC/Stream-Mapparr/releases/download/1.26.2241602/Stream-Mapparr.zip` returns the asset, 608158 bytes, sha256 `06c8ccf427d144ee55be1b47213ea60512903e3ffd1d9956aea9351f3585ba0f`. That checksum was taken by downloading the published asset back and comparing it against the local build, so it is the published bytes rather than the ones that were uploaded.

The archive was built with `git archive` from the git index, so it carries forward-slash paths and LF line endings and contains no untracked or ignored file. It passes the repository's archive validator, and a separate check confirms no entry contains CRLF.

What is in this version, briefly: guide-aware matching for placeholder-named streams; a fix so a name broken into words differently matches, which recovered eleven channels that previously matched nothing out of 25,323 stream names; a country prefix override setting; and two reliability fixes, one so a run stops monopolising a web worker under gevent and one so the scheduler takes its schedule from the database rather than from a settings file that could silently disagree with it. Full detail is in the release notes.