### PR TITLE
[channel-mapparr] Update to 1.26.2241232

### DIFF
--- a/plugins/channel-mapparr/plugin.json
+++ b/plugins/channel-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Channel Mapparr",
-  "version": "1.26.2241126",
+  "version": "1.26.2241232",
   "description": "Standardizes broadcast (OTA) and premium/cable channel names using network data and channel lists. Supports M3U stream import, category organization, and fuzzy matching across 42K+ channels in 11 countries.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
## Summary

Version bump only: `1.26.2241126` to `1.26.2241232`. The listing is already `source_type: "external"`, so this changes one line.

## What is in the release

`Create Channels From Streams` gains a setting, **Networks to Skip When Creating Channels**, taking a comma-separated list. A station whose own network is on that list is reported in the CSV preview under `skip, network excluded` and not created, rather than silently missing.

It reads what a station **is**, not what it carries. Most large stations run a second network on a subchannel, so reading every network in the FCC affiliation field excludes the station itself: an earlier version of this filter removed 21 stations of which 6 were ABC, CBS or FOX affiliates that merely carry the skipped network on a subchannel. Six real affiliation strings from the shipped station table are pinned as test cases.

Full notes: https://github.com/PiratesIRC/Dispatcharr-Channel-Maparr-Plugin/releases/tag/1.26.2241232

## Checks done before opening this

- The release asset was downloaded and inspected: 35 entries, forward-slash paths, no CRLF, `plugin.json` version `1.26.2241232`.
- The resolved `source_url` returns HTTP 200.
- Continuous integration is green on the tagged commit; the plugin's suite is 1001 passing, 3 skipped.
