### PR TITLE
[epg-janitor] Update to 1.26.2241232

### DIFF
--- a/plugins/epg-janitor/plugin.json
+++ b/plugins/epg-janitor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPG Janitor",
-  "version": "1.26.2241113",
+  "version": "1.26.2241232",
   "description": "Scans for channels with EPG assignments but no program data. Auto-matches EPG to channels using intelligent fuzzy matching with aliases, removes EPG from hidden channels, and manages EPG assignments.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Version bump only. The listing is `external`, so the archive comes from the plugin's own GitHub release rather than this repository.

## What the release fixes

A quality tag in the **middle** of a channel name deleted the spaces around it, joining two words that were never one:

| Before | After |
|---|---|
| `SKY NEWS FHD rec` became `SKY NEWSrec` | now `SKY NEWS rec` |
| `CNN [HD] USA` became `CNNUSA` | now `CNN USA` |

A glued name matches nothing, and could not be reached by a user's custom ignore tag either, because that is applied with a word boundary and there is none inside `NEWSrec`. Tags at the start or end of a name were never affected.

Measured against the plugin's shipped channel databases: 134 of 43,469 names normalise differently, every one of them a name that had been glued.

**1.26.2241113, which this listing currently serves, claimed this fix in its changelog and did not contain it.** The change had been made in a component shared between the sibling plugins, but this plugin overrides the function in question, so the shared version never ran. That is stated plainly in the plugin's changelog rather than being quietly corrected.

## Checks run before opening this

- `source_url` resolves for this version: the bare-tag form returns HTTP 200, the `v`-prefixed form 404.
- The published release asset is byte-identical to an archive built from the git tag: 26 files hashed, 0 mismatches, sha256 `07b8e5bfa73cd150`.
- The archive contains no development files, notes or version-control data.
- Plugin test suite: 549 passed, 1 skipped. Lint clean.