### PR TITLE
[channel-mapparr] Update to 1.26.2241315

### DIFF
--- a/plugins/channel-mapparr/plugin.json
+++ b/plugins/channel-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Channel Mapparr",
-  "version": "1.26.2241232",
+  "version": "1.26.2241315",
   "description": "Standardizes broadcast (OTA) and premium/cable channel names using network data and channel lists. Supports M3U stream import, category organization, and fuzzy matching across 42K+ channels in 11 countries.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
## Summary

Version bump only: `1.26.2241232` to `1.26.2241315`. The listing is `source_type: "external"`, so this changes one line.

## What is in the release

A defect present in **every previously published version of this plugin**, including the two published earlier today.

`normalize_name` replaced a quality tag with an empty string. Every pattern in the quality-tag list also consumes the whitespace flanking the tag, so deleting the match deleted that whitespace too. At the start or end of a name that is harmless. In the middle it joined two words that were never one:

| Input | Before | After |
|---|---|---|
| `SKY NEWS FHD rec` | `SKY NEWSrec` | `SKY NEWS rec` |
| `CNN [HD] USA` | `CNNUSA` | `CNN USA` |
| `CNBC HD Canadian Feed` | `CNBCCanadian Feed` | `CNBC Canadian Feed` |

A glued name matches nothing, and it was also unreachable by a user's own ignore tag, which is applied with a word boundary and finds none inside `NEWSrec`.

The shared matcher component has substituted a space since it was fixed there, but this plugin is a partial subclass that overrides `normalize_name` outright, so the shared version never ran and re-vendoring could not deliver it.

Measured on the plugin's own data: 128 of the 42,246 channel names in its shipped databases normalise differently, 0.30%. Two of the 284 frozen golden entries move.

Full notes: https://github.com/PiratesIRC/Dispatcharr-Channel-Maparr-Plugin/releases/tag/1.26.2241315

## Checks done before opening this

- The published release asset was downloaded and inspected: 35 entries, forward-slash paths, no CRLF, version `1.26.2241315`, and the corrected code present.
- The resolved `source_url` returns HTTP 200.
- Continuous integration green on the tagged commit; suite 1017 passing, 3 skipped.
