### PR TITLE
[event-channel-managarr] Declare maintainers

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -3,6 +3,9 @@
   "version": "1.26.2242049",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
+  "maintainers": [
+    "PiratesIRC"
+  ],
   "license": "MIT",
   "source_type": "external",
   "source_url": "https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/download/v{version}/Event-Channel-Managarr.zip",


### PR DESCRIPTION
Adds the `maintainers` field to the Event Channel Managarr listing. It was missing here while the `epg-janitor` listing already carries it, and it is the field the permission check reads — stating it explicitly rather than relying on `author` alone matches the sibling listing and makes the basis for that check obvious.

**No version bump.** `maintainers` is on the Hub's `METADATA_ONLY_FIELDS` list, so this does not require one. The version stays at `1.26.2242049`.

### A second purpose, stated plainly

[#235](https://github.com/Dispatcharr/Plugins/pull/235) merged successfully, but the `Publish Plugins` run that followed it failed:

```
curl: (22) The requested URL returned error: 503
```

That is GitHub's release-download endpoint erroring while fetching our archive, three retries about 15 seconds apart. It was transient rather than a bad URL — the `codeql-analyze` job in the same pull request downloaded the identical URL successfully two minutes earlier, `clamav-scan` fetched it too, and the release-artifact validation check passed.

The result is that the listing is merged but the published manifest still serves `1.26.2241846`. That workflow does not retry and only triggers on a push to `main` touching `plugins/**`, so merging this change re-runs it.

The download has been verified healthy since: HTTP 200 on five consecutive attempts. This change is worth making on its own merits; the re-trigger is a side effect I would rather disclose than leave implied.
