### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.17.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Never miss a good game. Scores every upcoming game across 37 leagues, tours and competitions (20 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps `dispatcharr-ranked-matchups` from 1.16.0 to 1.17.0.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.17.0

Two user-reported fixes from the Discord thread:

- **Curated channels now land in your Channel Profiles.** Dispatcharr creates profile memberships in its API view layer, so channels a plugin creates through the ORM never got one and were filtered out of every named profile, showing up only under `All`. Apply now sets that membership, defaulting to all profiles (matching a hand-created channel), with a new setting to narrow it to named ones.
- **A dry-run apply no longer looks like a silent success.** `Dry run on Apply` defaults on, and on a fresh install apply returned from its dry-run branch without logging anything while the async dispatch discarded its message, so the user saw `status=ok` and no channels. The message now reaches the log, both dry-run exits state the remedy, and "Show current state" reports when dry run is on.

Includes 1.16.1, which was never published separately.
