### PR TITLE
[event-channel-managarr]: release v1.26.2251616

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.2242049",
+  "version": "1.26.2251616",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Bumps the external listing to v1.26.2251616.

Release: https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/tag/v1.26.2251616

What is in it:

- The GitHub update checker is removed. The settings page no longer shows a version status line and the plugin no longer makes any outbound request.
- Every settings label, help text and action description was rewritten for clarity. Three labels now state the input format, for example "Channel Profile Names (Required, comma-separated)".

No setting was added, removed or renamed, and the scan behaviour is unchanged.
