### PR TITLE
[tickarr]: bump to v0.4.0 — shared stream profile support ({channelId}, Dispatcharr #1252)

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.3.06",
+  "version": "0.4.0",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.4.0

Dispatcharr v0.29.0 added a `{channelId}` StreamProfile substitution token (closing #1252, which I filed). Tickarr now uses it so channels sharing the same overlay configuration share a single StreamProfile instead of Tickarr cloning one per channel (previously up to 424 clones for a full SiriusXM lineup). Applies to Now Playing, Custom Text, Sports Ticker, and EAS/JAS Weather Alerts. On Dispatcharr versions before v0.29.0, Tickarr detects the missing token and falls back to the previous per-channel-clone behavior automatically.

Also includes a new "Migrate to Shared Profiles" action for existing installs to consolidate old per-channel clones.

Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.4.0

## Checklist
- [x] Tested in my own Dispatcharr instance
- [x] Version bumped in `plugin.json` (0.3.06 → 0.4.0)
- [x] `source_url` release asset verified reachable at the new version tag