### PR TITLE
[event-channel-managarr]: bump to 1.26.2261346

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.2251616",
+  "version": "1.26.2261346",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Bumps the Event Channel Managarr listing to 1.26.2261346.

Event names that carry a bare slot number and no `PPV`, `LIVE` or `EVENT` keyword, such as `07 - 8/14 7pm Broncos at Falcons`, were not matched by the plugin's default title pattern, so Dispatcharr's dummy EPG renderer fell back to its static filler and the guide showed a repeating block titled with the whole channel name. The keyword is now optional, guarded so that an ordinary channel called `60 Minutes` is still left alone.

External listing; the release asset is published at https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/tag/v1.26.2261346 and returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)