### PR TITLE
[epgeditarr] bump to v0.3.00 — Sport Templates live schedule matching

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "EPGeditARR",
-  "version": "0.2.10",
-  "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and provides a full SiriusXM toolkit: fill EPG from the community XMLTV (741 channels, sports smart blocks), sort into official lineup order, assign logos, and rename channels using the official SiriusXM API channel database.",
+  "version": "0.3.00",
+  "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and includes a Sports Editor: automatically renames Auto Channel Sync-created sports channels, assigns matchup logos, and generates real Pregame/Live/Postgame EPG data by matching against a live public schedule (NFL, NBA, MLB, NHL, NCAA Football, MLS).",
   "author": "jstevenscl",
   "license": "MIT",
   "repo_url": "https://github.com/jstevenscl/epgeditarr",


### PR DESCRIPTION
Bumps EPGeditARR to v0.3.00.

## What's new
Sports Editor gains a Sport Templates system: matches Auto Channel Sync-created sports channels against a live public schedule feed (NFL, NBA, MLB, NHL, NCAA Football, MLS), then automatically renames the channel, assigns a matchup logo, and generates real Pregame/Live/Postgame EPG data around the actual game time — fully UTC-anchored.

SiriusXM channel management has been removed (moved to a separate plugin); `description` updated to match.

## Links
- Release: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.3.00
- Full guide: https://github.com/jstevenscl/epgeditarr/blob/master/docs/SPORT_TEMPLATES.md

## Checksums (v0.3.00 zip)
- MD5: `cec4379c2db418360a27479f2b102703`
- SHA-256: `25cd38c8f0ada1ae5ca6d4961572c2b0678274cb9e6486ca27a8977b9d8d0b09`