### PR TITLE
[lineuparr]: Bump to 1.26.2271740

### DIFF
--- a/plugins/lineuparr/aliases.py
+++ b/plugins/lineuparr/aliases.py
@@ -456,6 +456,39 @@ CHANNEL_ALIASES = {
 # These overrides are merged on top of CHANNEL_ALIASES by _build_alias_map()
 # only for the lineup's own country, so they never leak across markets.
 COUNTRY_ALIASES = {
+    "AU": {
+        # Australian providers and guide sources spell a national channel with a
+        # suffix the lineup does not carry: the word National, a city, or a feed
+        # number. Every right-hand name below was read off a live install on
+        # 2026-08-15, not guessed.
+        #
+        # These are AU-scoped rather than global for two reasons. "ESPN"
+        # reaching "ESPN 1" is correct in Australia, where the carried feed is
+        # numbered, and wrong in the United States and the United Kingdom, where
+        # ESPN is not. And stripping a trailing "National" in normalize_name
+        # instead would damage "YES National" and "Sportsnet New York National"
+        # in the US lineups, which are genuinely different channels from "YES"
+        # and "Sportsnet New York".
+        #
+        # DELIBERATELY ABSENT: "CNN International" -> "CNN". It won the guide
+        # entry, and it also reached the United States stream "GO: CNN", which
+        # then attached as a backup feed carrying different programming. The
+        # alias table applies to streams and guide entries alike with no way to
+        # scope an entry to one of them, so the guide is not worth the wrong
+        # stream. Operator decision, 2026-08-15.
+        "ABC News": ["ABC News Australia"],
+        "Racing.com": ["Racing.com National"],
+        "SBS Food": ["SBS Food National"],
+        "SBS World Movies": ["SBS World Movies National"],
+        # Foxtel lists the channel as ESPN; the Australian feed is carried as
+        # ESPN 1. Without this the channel took a United States ESPN feed,
+        # because the Australian one never scored against the bare name.
+        "ESPN": ["ESPN 1"],
+        # NITV is one national channel. The guide source publishes a separate
+        # entry per capital city (Sydney, Melbourne, Brisbane, Perth, Adelaide,
+        # Hobart) carrying the same schedule, so one of them is picked.
+        "NITV": ["NITV Sydney"],
+    },
     "FR": {
         # TLC France airs on the former Discovery Science feed; some French
         # IPTV sources still label the stream "Discovery Science".

--- a/plugins/lineuparr/fuzzy_matcher.py
+++ b/plugins/lineuparr/fuzzy_matcher.py
@@ -698,7 +698,8 @@ class FuzzyMatcher(FuzzyMatcherCore):
         return None, 0, None
 
     def match_all_streams(self, lineup_name, candidate_names, alias_map, channel_number=None,
-                          user_ignored_tags=None, lineup_country=None, quality_aware=False):
+                          user_ignored_tags=None, lineup_country=None, quality_aware=False,
+                          candidate_countries=None):
         """
         Full matching pipeline for Lineuparr: alias → exact → substring → fuzzy, with number boost.
         Returns ALL matching streams sorted by score.
@@ -712,6 +713,11 @@ class FuzzyMatcher(FuzzyMatcherCore):
             quality_aware: When True, upgrade streams (4K/8K/UHD/HDR) are excluded
                 from standard channels. Streams listed in alias_map for this channel bypass
                 the filter (e.g. "France 2": ["FRANCE 2 4K HDR"] allows that specific stream).
+            candidate_countries: Optional {stream name: ISO-2 country} taken from the
+                provider group each stream came from. Used ONLY for streams whose own
+                name carries no country marker, which is the common case for providers
+                that prefix by platform ("GO:", "RK:", "PRIME:") rather than by country.
+                Omit it and matching behaves exactly as it did before.
 
         Returns:
             List of (stream_name, score, match_type) tuples sorted by score desc.
@@ -893,6 +899,35 @@ class FuzzyMatcher(FuzzyMatcherCore):
                         continue
                     self.country_filter_drops += 1
                 all_matches = kept
+
+                # Second pass, on the provider GROUP rather than the name. A
+                # provider that prefixes streams by platform ("GO:", "RK:",
+                # "PRIME:") leaves every name untagged, so the pass above keeps
+                # all of them and a United States feed reaches an Australian
+                # lineup. The group the stream came from is named for its
+                # country, so use it wherever the name said nothing.
+                #
+                # Skipped entirely when it would remove every remaining
+                # candidate, which is the same escape the regionless branch of
+                # the region filter uses below. A provider whose groups are
+                # mislabelled therefore loses no matches, it just gains nothing.
+                if candidate_countries:
+                    group_kept = {}
+                    for name, val in all_matches.items():
+                        if detect_stream_country(name) is not None:
+                            group_kept[name] = val  # already judged on its name
+                            continue
+                        gc = candidate_countries.get(name)
+                        if gc is None or gc == lc:
+                            group_kept[name] = val
+                            continue
+                        shared = _CROSS_BORDER_SHARED.get(frozenset({lc, gc}))
+                        if shared and nq_fold in shared:
+                            group_kept[name] = val
+                            continue
+                    if group_kept:
+                        self.country_filter_drops += len(all_matches) - len(group_kept)
+                        all_matches = group_kept
 
         # Filter out wrong-region matches (East vs West vs Pacific).
         # Detect the lineup channel's region from the ORIGINAL un-normalized

--- a/plugins/lineuparr/plugin.json
+++ b/plugins/lineuparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Lineuparr",
-  "version": "1.26.2241618",
+  "version": "1.26.2271740",
   "description": "Mirror real-world provider channel lineups by creating channel groups, channels, and fuzzy-matching IPTV streams to them.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/plugins/lineuparr/plugin.py
+++ b/plugins/lineuparr/plugin.py
@@ -99,7 +99,7 @@ def _clean_json_text(s):
 
 
 class PluginConfig:
-    PLUGIN_VERSION = "1.26.2241618"
+    PLUGIN_VERSION = "1.26.2271740"
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True
@@ -1005,7 +1005,9 @@ class Plugin:
         """Get all streams, optionally filtered by M3U sources."""
         valid_ids, priority_map, _ = self._resolve_m3u_sources(settings, logger)
 
-        qs = Stream.objects.all().values('id', 'name', 'm3u_account', 'stream_stats')
+        qs = Stream.objects.all().values(
+            'id', 'name', 'm3u_account', 'stream_stats', 'channel_group__name'
+        )
         if valid_ids is not None:
             qs = qs.filter(m3u_account__in=valid_ids)
 
@@ -1013,9 +1015,77 @@ class Plugin:
         for s in streams:
             s['_m3u_priority'] = priority_map.get(s.get('m3u_account'), 999)
             s['_stream_stats'] = s.pop('stream_stats', None) or {}
+            # The provider group this stream came from. Its name usually carries
+            # a country ("AU| AUSTRALIA VIP"), which is the only country signal
+            # available for a provider that prefixes stream names by platform
+            # ("GO:", "RK:") rather than by country.
+            s['_group_name'] = s.pop('channel_group__name', None)
 
         logger.info(f"{LOG_PREFIX} Loaded {len(streams)} streams" + (f" from {len(valid_ids)} M3U sources" if valid_ids else ""))
         return streams
+
+    @staticmethod
+    def _disabled_selected_sources(sources, tokens, select_all):
+        """Names of EPG sources this run will match against that are switched off.
+
+        EPG matching reads every EPGData row without checking whether its source
+        is enabled, so a disabled source still supplies candidates. Dispatcharr
+        will never refresh those rows, so a channel matched to one gets a guide
+        that quietly stops being true, and nothing else about the plugin looks
+        wrong when it happens.
+
+        Args:
+            sources: rows of {"name", "is_active", "entry_count"}
+            tokens: the source-filter tokens, which may carry shell wildcards
+            select_all: True when the filter selects every source
+
+        Returns the names in alphabetical order, so the reported list is stable.
+        """
+        hits = []
+        for src in sources or []:
+            if src.get("is_active"):
+                continue
+            name = src.get("name") or ""
+            if select_all:
+                # Every source is in the candidate pool, so only a source that
+                # actually holds entries can mislead anyone.
+                if src.get("entry_count"):
+                    hits.append(name)
+                continue
+            for token in tokens or []:
+                if fnmatch.fnmatch(name.upper(), str(token).upper()):
+                    hits.append(name)
+                    break
+        return sorted(hits)
+
+    @staticmethod
+    def _stream_countries_by_name(streams):
+        """Map each stream NAME to the country of the provider group it came from.
+
+        Only the stream name reaches the matcher, and a provider that prefixes
+        names by platform ("GO: ESPN", "RK: VEVO POP") leaves the matcher with no
+        country to work from, so a United States feed passes the country filter
+        into an Australian lineup. The provider group name carries the country
+        that the stream name does not.
+
+        A name that appears under groups of two different countries is left OUT
+        of the map rather than resolved by whichever row was read first: an
+        ambiguous answer here silently drops the wrong stream, and absence just
+        falls back to the previous behaviour.
+        """
+        seen = {}
+        for s in streams:
+            name = s.get('name')
+            if not name:
+                continue
+            cc = detect_category_country(s.get('_group_name'))
+            if cc is None:
+                continue
+            if name in seen and seen[name] != cc:
+                seen[name] = None  # ambiguous, and stays that way
+            elif name not in seen:
+                seen[name] = cc
+        return {k: v for k, v in seen.items() if v is not None}
 
     def _alias_map_provider(self, settings, logger):
         """Return a callable mapping a country code to that country's alias map.
@@ -1853,6 +1923,30 @@ class Plugin:
                     results.append({"Setting": "EPG Sources Filter", "Value": epg_sources_str, "Status": f"OK ({len(filtered)} entries after filtering)"})
                 else:
                     results.append({"Setting": "EPG Sources Filter", "Value": "All sources", "Status": "OK"})
+
+                # A disabled EPG source is still matched against, because EPG
+                # matching does not filter on EPGSource.is_active. Dispatcharr
+                # never refreshes a disabled source, so any channel matched to
+                # one gets a guide that stops being true and nothing looks wrong.
+                epg_tokens, epg_select_all = self._parse_source_filter(epg_sources_str)
+                source_rows = []
+                for src in EPGSource.objects.all().values('id', 'name', 'is_active'):
+                    source_rows.append({
+                        "name": src['name'],
+                        "is_active": src['is_active'],
+                        "entry_count": EPGData.objects.filter(epg_source_id=src['id']).count(),
+                    })
+                disabled = self._disabled_selected_sources(source_rows, epg_tokens, epg_select_all)
+                if disabled:
+                    results.append({
+                        "Setting": "EPG Sources: disabled",
+                        "Value": ", ".join(disabled),
+                        "Status": ("WARNING: these EPG sources are switched off in Dispatcharr but "
+                                   "are still matched against. Dispatcharr does not refresh a "
+                                   "disabled source, so channels matched to one keep a guide that "
+                                   "stops being updated. Enable them, or exclude them from the "
+                                   "EPG Sources for Matching filter."),
+                    })
             except Exception as e:
                 results.append({"Setting": "EPG Data", "Value": str(e), "Status": "ERROR"})
                 errors += 1
@@ -2081,6 +2175,7 @@ class Plugin:
 
             # Deduplicate stream names for matching (performance: avoid redundant fuzzy comparisons)
             unique_stream_names = list(set(s['name'] for s in streams))
+            stream_countries = self._stream_countries_by_name(streams)
             logger.info(f"{LOG_PREFIX} Matching against {len(unique_stream_names)} unique stream names (from {len(streams)} total)")
 
             # Pre-normalize stream names for performance
@@ -2115,6 +2210,7 @@ class Plugin:
                         channel_number=boost_number,
                         lineup_country=entry_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
+                        candidate_countries=stream_countries,
                     )
 
                     if matches:
@@ -2762,6 +2858,7 @@ class Plugin:
 
             # Deduplicate stream names for matching performance
             unique_stream_names = list(stream_by_name.keys())
+            stream_countries = self._stream_countries_by_name(all_streams)
             logger.info(f"{LOG_PREFIX} Matching against {len(unique_stream_names)} unique stream names (from {len(all_streams)} total)")
 
             # Pre-normalize stream names for performance
@@ -2819,6 +2916,7 @@ class Plugin:
                         channel_number=ch_number,
                         lineup_country=entry_cc,
                         quality_aware=(ch_name in upgrade_twin_set),
+                        candidate_countries=stream_countries,
                     )
 
                     if matches:
@@ -3085,7 +3183,19 @@ class Plugin:
             logger.info(f"{LOG_PREFIX} Pre-filtered to {len(epg_data_with_programs)} EPG entries with program data (from {len(epg_data)} total)")
 
             if not epg_data_with_programs:
-                return {"status": "ok", "message": "No EPG entries have program data in the next 12 hours. Skipping EPG matching."}
+                # Do NOT stop here. Dispatcharr downloads programme data only for
+                # EPG entries that are already mapped to a channel, and mapping
+                # them is what this action does, so a source that has never been
+                # matched always has zero programmes. Stopping would make such a
+                # source permanently unmatchable. The second match pass below
+                # searches every entry regardless of programme data, so let the
+                # run continue and fall through to it.
+                logger.warning(
+                    f"{LOG_PREFIX} No EPG entry has programme data in the next 12 hours. "
+                    f"Matching against all {len(epg_data)} entries instead. This is normal "
+                    f"for an EPG source that has never been matched to a channel: Dispatcharr "
+                    f"fetches programmes only for mapped entries."
+                )
 
             # Build source ID -> name lookup for CSV
             epg_source_names = {}


### PR DESCRIPTION
Bumps the lineuparr listing to 1.26.2271740, matching the release at https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin/releases/tag/v1.26.2271740

Four changes, all measured against a live Dispatcharr install rather than assumed.

**A brand new EPG source is no longer unmatchable.** Dispatcharr downloads programme data only for guide entries already attached to a channel, and attaching them is what the plugin's EPG matching does, so a source that has just been added always reports zero entries with programme data. The plugin used to stop there and return a successful looking result, which made every newly added source permanently unmatchable with nothing reporting it. Matching now continues against every entry in that case and logs a warning naming the reason. On the install where this was found, a freshly enabled source went from 0 channels matched to 23.

**A stream's country can now be read from the provider group it came from.** Only the stream name reached the matcher, so a provider that labels streams by platform rather than by country left the country filter with nothing to work from and those streams could attach to a lineup from any country. The provider group is normally named for its country, and that is now used where the stream name says nothing. The group is consulted only when the name carries no country marker, and it is ignored when acting on it would leave a channel with no candidate streams, so no existing match is lost.

**Validate Settings warns when an EPG source it will match against is switched off.** A disabled source is still matched against and Dispatcharr never refreshes one, so a channel matched to it keeps a guide that stops being updated while nothing else looks wrong.

**Six alias bridges scoped to Australian lineups**, for channels whose feeds are spelled with a National suffix, a city name, or a feed number. They cannot affect any other country.

Only the four files that changed are touched: `aliases.py`, `fuzzy_matcher.py`, `plugin.py` and the listing manifest's version field. The listing's file set was compared against the released package first and matches exactly at 30 files, so nothing is missing. Files were copied with LF endings and the committed blobs carry no CRLF.
