### PR TITLE
[epg-janitor]: Bump to 1.26.2281111

### DIFF
--- a/plugins/epg-janitor/plugin.json
+++ b/plugins/epg-janitor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPG Janitor",
-  "version": "1.26.2241232",
+  "version": "1.26.2281111",
   "description": "Scans for channels with EPG assignments but no program data. Auto-matches EPG to channels using intelligent fuzzy matching with aliases, removes EPG from hidden channels, and manages EPG assignments.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Bumps the EPG Janitor listing to 1.26.2281111.

External listing, so this is a version bump only; the Hub downloads the release archive.

What changed in this release:

- Channel names with a bracketed group in the middle now match correctly. Removing a group such as (Southern California) removed the spaces around it too, joining the words on either side, so "Big Ten Network (Southern California) Alternate" normalised to "Big 10 NetworkAlternate" and matched nothing. This is the same defect fixed for quality tags in 1.26.2241232, in a second place that was missed. Measured on 25,231 real channel and guide names: 101 normalise differently, all of them previously joined, and none loses or gains any text.
- Failures now appear in the plugin card as a persistent message rather than a notice that closes itself after four seconds.
- Corrected help text for five settings.

Release asset: https://github.com/PiratesIRC/Dispatcharr-EPG-Janitor-Plugin/releases/download/1.26.2281111/EPG-Janitor.zip (verified HTTP 200, and byte-identical to the archive built from the tag).