### PR TITLE
[epgeditarr] bump to v0.3.01 — Sport Templates expanded to 93 leagues

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "EPGeditARR",
-  "version": "0.3.00",
-  "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and includes a Sports Editor: automatically renames Auto Channel Sync-created sports channels, assigns matchup logos, and generates real Pregame/Live/Postgame EPG data by matching against a live public schedule (NFL, NBA, MLB, NHL, NCAA Football, MLS).",
+  "version": "0.3.01",
+  "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and includes a Sports Editor: automatically renames Auto Channel Sync-created sports channels, assigns matchup logos, and generates real Pregame/Live/Postgame EPG data by matching against a live public schedule (93 leagues — every major US team sport, 30+ soccer competitions, tennis, golf, NASCAR, F1, UFC/MMA/boxing/darts, and more).",
   "author": "jstevenscl",
   "license": "MIT",
   "repo_url": "https://github.com/jstevenscl/epgeditarr",


### PR DESCRIPTION
Bumps EPGeditARR to v0.3.01.

## What's new
Sport Templates now covers 93 leagues, up from the original 6 (NFL, NBA, MLB, NHL, NCAA Football, MLS). New this release: tennis (ATP/WTA), golf (PGA TOUR/LPGA), all three NASCAR series, Formula 1, UFC/boxing/MMA/darts, 30+ soccer competitions worldwide (Premier League, La Liga, Bundesliga, Serie A, Ligue 1, FIFA World Cup, and more), softball, and additional baseball/basketball/volleyball/lacrosse/NCAA variants.

Two matching engines now run under the hood depending on the sport — the original away/home matcher (team sports, plus a person-vs-person variant for tennis/UFC/boxing/MMA/darts), and a new single-title matcher for sports with no fixed two-sided structure (golf/NASCAR/F1/surfing/fishing). Automatic per sport, nothing to configure.

## Links
- Release: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.3.01
- Full guide: https://github.com/jstevenscl/epgeditarr/blob/master/docs/SPORT_TEMPLATES.md

## Checksums (v0.3.01 zip)
- MD5: `d88ed41227654b78fd2aafbdf8a65aab`
- SHA-256: `5be870b22493b72b1acfab141614ad4bad7bb68ca7e8b6ec77bdfc07ceac4560`