### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.19.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "description": "Never miss a good game. Scores every upcoming game across 37 leagues, tours and competitions (20 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
   "author": "Jacob-Lasky",
   "license": "MIT",

--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.19.1",
+  "version": "1.20.0",
   "description": "Never miss a good game. Scores every upcoming game across 37 leagues, tours and competitions (20 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
   "author": "Jacob-Lasky",
   "license": "MIT",

--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Never miss a good game. Scores every upcoming game across 37 leagues, tours and competitions (20 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Metadata-only bump for `dispatcharr-ranked-matchups`: **1.17.0 → 1.19.0**.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.19.0

`source_type`, `source_url`, `author`, `license` and `description` are unchanged.

### Pre-flight against `validate.sh`

| check | result |
| --- | --- |
| `version` strict semver | `1.19.0` |
| version greater than published | `1.19.0` > `1.17.0` |
| required fields (`name`, `version`, `description`) | present |
| `source_url` HTTPS + `{version}` placeholder | unchanged, both hold |
| resolved `source_url` returns 200 | verified, HTTP 200 |
| `author` matches PR author | `Jacob-Lasky` |

The release asset was downloaded after publishing and confirmed **byte-identical** (sha256 `14100eff4527addb…`) to the local build, with the required snake_case top-level folder `dispatcharr_ranked_matchups/` so intra-plugin imports resolve on install.

### What's in 1.19.0

- **Fixed a user-reported mis-match**: tennis and golf events were matching a darts channel, because a tournament title's last token (`Open`, `Championship`, `Masters`, `Prix`) was treated as a keyword strong enough to match on its own. Measured over 22,137 real channel and stream names, `Championship` alone matched 383 of them. Removing the wildcard also recovered correct matches.
- **Fixed MLS importance reading ~0 all season**, caused by the season sweep clamping itself to a 7-day window while the simulator needs the whole season. Nonzero importance went from 9/18 to 18/18 games. The same change collapsed a ~300-request season fetch into 1.
- **Added a second per-matchup logo source** ([game-thumbs](https://github.com/sethwv/game-thumbs), MIT) for the leagues TheSportsDB never indexed a graphic for, plus 27 team-name aliases derived from that API's own team lists. On a live slate this took curated channels from 6 with a real matchup image to 23 of 23, with nothing falling back to a generic league badge. New optional setting for the base URL; blank disables the tier.
- **Added league badges for field-event sports** (F1, NASCAR, PGA, UFC, ATP, WTA, boxing), which can never earn a head-to-head composite.

Full notes in the release. Tests: 3,654 → 3,769, zero failures, zero skips.
