### PR TITLE
[channel-mapparr] Update to 1.26.2291823

### DIFF
--- a/plugins/channel-mapparr/plugin.json
+++ b/plugins/channel-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Channel Mapparr",
-  "version": "1.26.2241315",
+  "version": "1.26.2291823",
   "description": "Standardizes broadcast (OTA) and premium/cable channel names using network data and channel lists. Supports M3U stream import, category organization, and fuzzy matching across 42K+ channels in 11 countries.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Version bump for the Channel Mapparr external listing to 1.26.2291823.

This release fixes a name-normalization defect in the plugin's matcher: a bracketed, parenthesized or regional group in the middle of a channel name glued its neighbouring words together, so the name matched nothing. Release notes: https://github.com/PiratesIRC/Dispatcharr-Channel-Maparr-Plugin/releases/tag/1.26.2291823

The release asset at the source_url resolves (HTTP 200, verified).