### PR TITLE
[pirate-weatharr-station] Update to 1.3.2 

### DIFF
--- a/plugins/pirate-weatharr-station/plugin.json
+++ b/plugins/pirate-weatharr-station/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "PWS - Pirate Weatharr Station",
-  "version": "1.0.0",
+  "version": "1.3.2",
   "description": "TV-style weather channels powered by the Pirate Weather API. Runs up to three stations, each with its own location and Dispatcharr channel.",
   "author": "dexdeadly",
   "license": "MIT",


### PR DESCRIPTION


## About this submission

New Version Updates:
- Fixed channel location-name resolution for both ZIP and Latitude/Longitude stations — plugin.py's own imports of the location-lookup modules were silently failing inside Dispatcharr's process, so every channel fell back to a generic "Station N - PWS" name.
- Widened the worldwide nearest-city match radius (60 → 150 miles) for Lat/Long stations, so moderately sparse regions outside the US (rural Australia, etc.) resolve to a real place name instead of falling back.
- Better fallback for unresolvable coordinates — when no location can be found at all, the channel name now uses raw coordinates instead of the meaningless "Station N".
- New "Data Refresh Interval" setting (default 10 min, 5–60 min range) — configurable Pirate Weather polling frequency, still auto-scaled per station count to protect the free tier.
- Synced the on-screen watermark (assets/logo.png) with the updated plugin/channel icon.
- README updated to document the new refresh interval setting.

Release: https://github.com/dexdeadly/pirate-weatharr-station/releases/download/v1.3.2/pirate-weatharr-station-1.3.2.zip

## Pre-submission checklist

- [ x ] `version` in `plugin.json` is incremented 
- [ x ] I am listed in `author` or `maintainers` of the existing plugin
