### PR TITLE
[vod2mlib] Bump version to 1.16.1

### DIFF
--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "VOD to Media Library",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Generate .strm files (with optional NFO metadata) from your Dispatcharr VOD catalogue so Jellyfin / Emby / Kodi / ChannelsDVR can index your movies and series. Adds a cron-driven auto-rescan that picks up newly-added episodes nightly. Optional category-nested folder layout for genre-organised libraries.",
   "author": "R3XCHRIS",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bugfix release for the [vod2mlib](https://github.com/R3XCHRIS/VOD2MLIB) plugin: v1.16.0 → v1.16.1. Two field-reported fixes, both defaults-preserving.

- **`.strm` files are no longer rewritten when nothing changed, and keep their mtime when they are** ([#11](https://github.com/R3XCHRIS/VOD2MLIB/issues/11)). Rewriting bumped mtime, so every nightly rescan made Emby/Jellyfin re-index the entire library. Identical files are now left untouched; genuinely-changed URLs are written with the original mtime restored.
- **Selectable TMDB folder tag format** ([#9](https://github.com/R3XCHRIS/VOD2MLIB/issues/9)). Was Plex-only `{tmdb-123}`, which Jellyfin/Emby ignore; new setting offers `[tmdbid-123]`. Defaults to the previous behaviour.

194 unit tests pass (was 181). No backend code outside the plugin.

[Full release notes](https://github.com/R3XCHRIS/VOD2MLIB/releases/tag/v1.16.1) · SHA256 `8bc8d8f48e02b4d67c2a53aa13dafe69756d963689cb3f015776963b5024b1c6`