### PR TITLE
[vod2mlib] Bump version to 1.17.0

### DIFF
--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "VOD to Media Library",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "description": "Generate .strm files (with optional NFO metadata) from your Dispatcharr VOD catalogue so Jellyfin / Emby / Kodi / ChannelsDVR can index your movies and series. Adds a cron-driven auto-rescan that picks up newly-added episodes nightly. Optional category-nested folder layout for genre-organised libraries.",
   "author": "R3XCHRIS",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bump for the [vod2mlib](https://github.com/R3XCHRIS/VOD2MLIB) plugin: v1.16.1 → v1.17.0.

Addresses [#8](https://github.com/R3XCHRIS/VOD2MLIB/issues/8), where a Category Filter appeared to do nothing (users filter on a tag their provider puts in the *title*, while the filter matches the *category* name):

- **New `Category Exclude (block list)`** — skip categories by name prefix, applied after the include filter. The right tool for "everything except adult content".
- **Scan now prints the real category names** with counts, marking ✓/✗ against the current filter/exclude and warning loudly when nothing matches.
- **Generate no longer reports a filtered-out run as an empty catalogue.**

No behaviour change unless the category filters are in use. 201 unit tests pass (was 194). No backend code outside the plugin.

[Full release notes](https://github.com/R3XCHRIS/VOD2MLIB/releases/tag/v1.17.0) · SHA256 `8d2ce537e6b2a9ade947e746c87d8d944753c73ee702598af8846dc34b45a27a`