### PR TITLE
[vod2mlib]: bump to v1.18.0

### DIFF
--- a/plugins/vod2mlib/plugin.json
+++ b/plugins/vod2mlib/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "VOD to Media Library",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Generate .strm files (with optional NFO metadata) from your Dispatcharr VOD catalogue so Jellyfin / Emby / Kodi / ChannelsDVR can index your movies and series. Adds a cron-driven auto-rescan that picks up newly-added episodes nightly. Optional category-nested folder layout for genre-organised libraries.",
   "author": "R3XCHRIS",
   "license": "MIT",


### PR DESCRIPTION
Version bump only — the manifest here is the slim external entry, so this changes one line.

**[v1.18.0](https://github.com/R3XCHRIS/VOD2MLIB/releases/tag/v1.18.0) — NFO titles your media server can actually match**

- NFO `<title>` elements now get provider tags, edge quality tokens and trailing years stripped. Jellyfin/Emby treat an NFO title as authoritative, so `4K-A+ Blade Runner 2049` stayed mis-titled no matter what TMDB said. Verified against a live 6,877-title catalogue: 0 titles emptied, and real names that look like junk (`Love+War`, `NTSF:SD:SUV::`, `WWII in HD`, `Chicago P.D.`, `[REC] 2`) all survive.
- New `Omit <title> from NFO files` setting for providers whose naming is beyond rescue.
- Duplicate episode relations are collapsed by episode UUID, fixing `S01E05 (2)` duplicates that pointed at the same URL.
- Series batch sizes 50/100/250; missing TMDB IDs are now reported instead of silently untagged.

224 unit tests passing. Release asset `plugin-vod2mlib-v1.18.0.zip` is attached and the `source_url` template resolves (HTTP 200, 168 KB).