### PR TITLE
[tickarr]: bump to v0.4.01

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.4.0",
+  "version": "0.4.01",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.4.01

Patch release: demoted a noisy sweep log line to DEBUG. Tickarr's background poller was logging `tickarr: sweep N active, M stale (of T)` at INFO level every 15-second cycle whenever there was anything to poll, flooding the Dispatcharr log. No behavior change.

Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.4.01

## Checklist
- [x] Tested in my own Dispatcharr instance
- [x] Version bumped in `plugin.json` (0.4.0 → 0.4.01)
- [x] `source_url` release asset verified reachable at the new version tag