### PR TITLE
[event-channel-managarr]: release v1.26.2351639

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.2341504",
+  "version": "1.26.2351639",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Bumps the listing to the published release `v1.26.2351639`.

## What it fixes

The run ledger added in `1.26.2341504` never recorded anything. Its writer read a constant defined on a different class in the plugin, so it raised `AttributeError` on every applied run that changed a channel and the ledger file was never created.

The writer catches `Exception` on purpose, so that failing to record a run can never fail a scan that has already changed channels. That meant the only trace was a line in the container log, while scans, the managed dummy EPG, the CSV exports and the scheduler all continued to behave correctly. **Only the run ledger was affected**; channel visibility was always handled properly.

Anyone on `1.26.2341504` should update, since its counter is silently dead.

## Test coverage

A new contract test asserts that every `self.SOME_CONSTANT` read anywhere in the plugin's main class is actually defined on that class, which catches the whole category rather than this one instance. The existing tests missed it because they checked structure rather than attribute resolution.

## Checks

- `source_url` with `{version}` substituted returns HTTP 200; the bare form 404s, so the `v` prefix is correct for this repository's tags.
- The published release asset is byte-identical to the archive built from the tag (217,277 bytes).
- Version strictly increases: `1.26.2341504` to `1.26.2351639`.
- Branched from `upstream/main`; the diff touches only `plugins/event-channel-managarr/plugin.json`.
- No setting or action was added, removed or renamed.