### PR TITLE
[epgeditarr] bump to v0.3.02 — fix Sport Templates noise-stripping for original 6 team sports

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.3.01",
+  "version": "0.3.02",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and includes a Sports Editor: automatically renames Auto Channel Sync-created sports channels, assigns matchup logos, and generates real Pregame/Live/Postgame EPG data by matching against a live public schedule (93 leagues — every major US team sport, 30+ soccer competitions, tennis, golf, NASCAR, F1, UFC/MMA/boxing/darts, and more).",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
Bumps EPGeditARR to v0.3.02.

## What's fixed
The original 6 team sports (NFL, NBA, MLB, NHL, NCAA Football, MLS) were excluded from Sport Templates' automatic provider-noise stripping (leading feed-tag prefixes, trailing date/tag suffixes), on the assumption users would configure Rename Rules to strip that noise first. In practice that's often skipped, and a channel name like `MLB 01 | Toronto Blue Jays at New York Yankees HOME 22 Aug 01:35 PM ET` could fail to match a live game even though the same shape of noise was already handled correctly for every other sport. Noise stripping now applies consistently across all 93 sports.

Verified end-to-end against the live sports-data-platform schedule feed.

## Links
- Release: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.3.02
- Full guide: https://github.com/jstevenscl/epgeditarr/blob/master/docs/SPORT_TEMPLATES.md

## Checksums (v0.3.02 zip)
- MD5: `c8ef3d1672907063ef126c73a225bce0`
- SHA-256: `b48510d79480ab7d15072d3edf46a798fde7fe8997ee47a2f52dc1f8f63746a9`