### PR TITLE
[epgeditarr] bump to v0.3.03

### DIFF
--- a/plugins/epgeditarr/plugin.json
+++ b/plugins/epgeditarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPGeditARR",
-  "version": "0.3.02",
+  "version": "0.3.03",
   "description": "Transform and clean your EPG data using regex and find/replace rules. Creates virtual copies of your sources — originals are never touched. Fills placeholder schedules for channels with no EPG, and includes a Sports Editor: automatically renames Auto Channel Sync-created sports channels, assigns matchup logos, and generates real Pregame/Live/Postgame EPG data by matching against a live public schedule (93 leagues — every major US team sport, 30+ soccer competitions, tennis, golf, NASCAR, F1, UFC/MMA/boxing/darts, and more).",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
Bumps `plugins/epgeditarr/plugin.json` to v0.3.03.

## Fixes
- HOME/AWAY/NATIONAL regional-feed channels (MLB reported, same shape applies to NBA/NFL/any matchup sport) were being left unmatched — a provider's trailing feed-tag/date suffix wasn't stripped before matchup parsing. Fixed, plus added `{feed_tag}`/`{feed_line}` template variables so split-feed providers can distinguish the two channels.
- Added a "Restart Dispatcharr" action so plugin updates don't require a manual container restart.

Release: https://github.com/jstevenscl/epgeditarr/releases/tag/v0.3.03