### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.21.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.20.0",
-  "description": "Never miss a good game. Scores every upcoming game across 37 leagues, tours and competitions (20 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
+  "version": "1.21.0",
+  "description": "Never miss a good game. Scores every upcoming game across 39 leagues, tours and competitions (22 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
   "author": "Jacob-Lasky",
   "license": "MIT",
   "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",


### PR DESCRIPTION
Bumps `dispatcharr-ranked-matchups` from 1.20.0 to 1.21.0.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.21.0

## What's new in 1.21.0

**English domestic cups: EFL Cup (Carabao Cup) and FA Cup.** Two new sources, both off by default, via ESPN's keyless site API.

These can't come from Football-Data.org, which the plugin uses for its other 12 soccer competitions: FD.org gates every domestic cup behind a paid plan (`FLC` is TIER_THREE, `FAC` is TIER_TWO, both returning HTTP 403 on a free-tier key, while `PL` returns fixtures on the same key). So they needed their own adapter rather than a competition-table entry, which would have 403'd on every refresh and contributed zero games silently.

Rounds come from ESPN's per-event `season.slug`, and early rounds get their own low stage-score band so a second-round tie sorts below a marquee league game while a cup final sorts at the top.

**Two dedupe fixes in the shared ESPN scoreboard sweep**, which also affected the existing friendlies sources:

- The event id was claimed *before* the drop filters ran. The lookback bucket and the first forward bucket carry the same event from separate ESPN cache entries, so one can lag; a stale finished copy in the earlier bucket consumed the id and was then discarded, silently suppressing the live copy and dropping a real fixture from the guide.
- A missing event id was itself used as a dedupe key, so the first id-less fixture claimed the slot for every later one.

**Cosmetic:** the tournament-stage line in the EPG description no longer leaks the internal stage enum (`SEMI_FINALS` rendered as "semi finals", now reads "Semifinal").

## Description change

Also updates `description`: the plugin now covers **39** leagues, tours and competitions (**22** of them soccer), up from 37/20. That figure is held to the actual settings-toggle count by a test in the plugin repo, so it is not a marketing estimate.

## Note on the version jump

1.20.1 was never cut as a release, so this goes 1.20.0 to 1.21.0 in the listing. That version's change (match identity no longer depending on kickoff time, across eleven sources) is included in this release. No retroactive tag is being backfilled, since nobody installs from one.

## Pre-flight

Every check in `.github/scripts/validate/validate.sh` was run locally before opening this:

| Check | Result |
|---|---|
| Folder is lowercase-kebab | `dispatcharr-ranked-matchups` |
| Strict semver, no `v` prefix | `1.21.0` |
| `name` / `version` / `description` present | yes |
| `author` equals the PR author's login | `Jacob-Lasky` |
| `license` is an OSI-approved SPDX id | `MIT`, checked against the live SPDX list |
| `source_type` | `external` |
| `source_url` contains literal `{version}`, is https | yes |
| `repo_url` present | yes |
| Resolved `source_url` returns 200 | 200 |
| Version exceeds the published one | 1.20.0 to 1.21.0 |

The published release asset was also downloaded and confirmed byte-identical to the local build (sha256 `20b7c2a9...`), unzipping to the snake_case top-level folder `dispatcharr_ranked_matchups/` that the loader needs for intra-plugin imports.
