### PR TITLE
[iptv-checker] Bump to 1.26.2402308

### DIFF
--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.2201040",
+  "version": "1.26.2402308",
   "description": "Check IPTV stream status and quality with ffprobe, then rename, move, restore or delete channels based on the result. Judges a channel by all of its streams, so a working backup never marks it dead.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Bumps the IPTV Checker listing to 1.26.2402308.

This release fixes a cron expression containing a list of values, for example `0 0,8,16 * * *`, being rejected as an invalid format when the schedule was saved. The setting accepts several cron expressions, and the separator was a comma, which is also legal inside a single cron field. The parser split on every comma before validating, so one valid expression was broken into fragments. It now splits on a semicolon or a newline first and takes a complete five field expression whole, with the comma still working as a separator so existing saved schedules are unaffected.

Reported as issue 27 on the plugin repository.

The listing is external. The archive is the GitHub release asset for tag `v1.26.2402308`, and the substituted `source_url` was confirmed to return HTTP 200 before opening this pull request.