### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.24.0 — NCAA D1 football scoping, rank percentile scoring, finished-game cleanup

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.21.0",
-  "description": "Never miss a good game. Scores every upcoming game across 39 leagues, tours and competitions (22 of them soccer, plus NFL, NBA, MLB, NHL, NCAA, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description.",
+  "version": "1.24.0",
+  "description": "Never miss a good game. Scores every upcoming game across 39 leagues, tours and competitions (22 of them soccer, plus NFL, NBA, MLB, NHL, NCAA D1 football and basketball, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description. Finished games can clear themselves out and be replaced from a bench of the next-best fixtures.",
   "author": "Jacob-Lasky",
   "license": "MIT",
   "repo_url": "https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups",


### PR DESCRIPTION
Listing bump for **Ranked Matchups (Top Games)**, `1.21.0` -> `1.24.0`. `source_type` is `external`, so this entry only repoints at the new release zip; the source lives in the plugin's own repo.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.24.0

## What changed for users

**NCAA Football now pulls Division I only, and that fixes an outage.** The source filtered CollegeFootballData's feed by time window alone, so every Division II and III fixture entered the pipeline. Each emitted game costs a Monte Carlo importance simulation, and those rows could never score, because the simulated season population was already FBS-only. Opening week 2026 measured 157 games in a 7-day window of which 27 involved an FBS team, which spent roughly 1100s of a 1500s subprocess budget and made the refresh time out on most runs once the season started. New `NCAA Football divisions` setting: `D1 FBS only` (default) or `D1 FBS + FCS`.

**Team rank is scored as a percentile of its own ranked pool.** Previously two formulas both hard-coded a 25-team pool, so a league table (which ranks every club) always took the branch worth up to 10 points while a poll (top 25 of a much larger field) took one capped at 4.17. The effect was that any league fixture whose ranks summed to 30 or less outscored a `#1 vs unranked` game. League tables and polls are now normalized separately, since last place in a league is genuinely the worst team while the last entry in a poll is still elite.

**Finished games can clear themselves out.** Two new settings, both off by default so nothing changes on upgrade: `remove_finished_after_minutes` reaps a game some minutes past its estimated end, and `bench_size` keeps extra scored games in reserve so the group backfills rather than draining through the day. There is also a `Remove finished games now` action.

## Upgrade safety

Nothing changes for an existing install unless the user opts in. Both reaping settings default to `0`, and the new divisions setting defaults to FBS-only, which is a strict narrowing of what NCAA Football pulls.

## Checks run locally before opening this

- folder name matches `^[a-z0-9]+(-[a-z0-9]+)*$`
- `version` is strict semver and greater than the published `1.21.0`
- `source_type: external` with an HTTPS `source_url` containing `{version}`
- the resolved URL returns **HTTP 200** (475401 bytes); the release exists and the published asset is byte-identical to the local build
- the zip's top-level directory is `dispatcharr_ranked_matchups/` (snake_case, required so intra-plugin imports resolve on install), 54 entries, `testzip()` clean
- `license: MIT` is OSI-approved SPDX
- `author` matches the PR author's GitHub login

Plugin repo test suite: 3979 passing.