### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.26.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.24.0",
+  "version": "1.26.0",
   "description": "Never miss a good game. Scores every upcoming game across 39 leagues, tours and competitions (22 of them soccer, plus NFL, NBA, MLB, NHL, NCAA D1 football and basketball, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description. Finished games can clear themselves out and be replaced from a bench of the next-best fixtures.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps **Ranked Matchups (Top Games)** from 1.24.0 to 1.26.0.

Release: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.26.0

### Added

**Compact channel numbering.** A new setting puts the plugin's channels in a range the user names, so "start at 400" with 25 channels gives 400-424 rather than the existing kickoff-time-derived 7-digit numbers. The previous scheme stays the default, so upgrading renumbers nothing.

Numbers already used by the user's other channels are skipped, since the guide identifies a channel by its number alone and two channels sharing one breaks both.

### Fixed

- A finished game's post-game guide entry ran until the next scheduled refresh while the channel itself was removed minutes after the game ended, so the entry outlived its channel. Measured against a live instance: 16 of 17 games, worst case by 7 hours.
- Soccer channels were removed ~30 minutes before their own guide entry said the match had ended: the apply path estimated a game's end at a flat 4 hours for every sport while the cleanup used the per-sport window.
- A boxing card could be listed as live for 24 hours.
- The XMLTV output served a cached guide for up to 5 minutes after every change while the M3U and Xtream Codes endpoints were already current.
- The "Starting channel number" setting's help text described behaviour it did not have.

Full changelog: https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/blob/main/CHANGELOG.md