### PR TITLE
[tickarr]: bump to v0.4.02 — fix mappings.json corruption handling, confirm Dispatcharr v0.30.0 compat

### DIFF
--- a/plugins/tickarr/plugin.json
+++ b/plugins/tickarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Tickarr",
-  "version": "0.4.01",
+  "version": "0.4.02",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## What's new in v0.4.02

Fixed a bug where a corrupt or transiently-unreadable `mappings.json` would spam `ERROR` logs on every sweep tick forever. The plugin's internal mapping-state reader now backs up and self-heals genuinely corrupt content on first read, while a transient I/O error (file lock, permission blip, race with a concurrent writer) is logged once without touching or resetting the file — so valid mapping data can't be destroyed by a passing glitch.

Also reviewed against Dispatcharr v0.30.0's release notes (in particular the logo-assignment changes) — Tickarr assigns logos directly via the Django ORM rather than the REST upload endpoint those changes touch, so no code changes were needed for v0.30.0 compatibility.

Full release notes: https://github.com/jstevenscl/tickarr/releases/tag/v0.4.02

## Checklist
- [x] Tested in my own Dispatcharr instance (live-reproduced both the corruption and transient-I/O-error paths on a test instance and confirmed correct behavior)
- [x] Version bumped in `plugin.json` (0.4.01 → 0.4.02)
- [x] `source_url` release asset verified reachable at the new version tag