### PR TITLE
[event-channel-managarr]: release v1.26.2420322 - stop a clock time being read as the event slot number

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.2351639",
+  "version": "1.26.2420322",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Release v1.26.2420322 of Event Channel Managarr.

Fixes the dummy guide title on event channels whose slot number is followed by text rather than by a date or a time. A channel named like `Boxing 3 : MOSES vs HRGOVIC  4:00pm` showed the guide title `00pm`, because the title pattern started matching inside the air time and read `4` as the slot number. The pattern now refuses to begin a match inside a clock time, so such a name falls back to the channel name as it did before v1.26.2261346.

Listing change is the version field only. The listing is external, and the asset at the source URL is published and verified byte for byte against the archive built from the tag.
