### PR TITLE
[lineuparr] Update to 1.26.2421451

### DIFF
--- a/plugins/lineuparr/US_Optimum_lineup.json
+++ b/plugins/lineuparr/US_Optimum_lineup.json
@@ -1,0 +1,1392 @@
+{
+  "package": "Optimum",
+  "date": "2026-01-01",
+  "description": "Southern Westchester Channel Guide Lineup",
+  "source": "channel-lineup-SouthernWestchester.pdf",
+  "categories": {
+    "Networks": [
+      {
+        "name": "Cheddar News (HD Only)",
+        "number": 1
+      },
+      {
+        "name": "CBS (WCBS)",
+        "number": 2
+      },
+      {
+        "name": "ION (WPXN)",
+        "number": 3
+      },
+      {
+        "name": "NBC (WNBC)",
+        "number": 4
+      },
+      {
+        "name": "FOX (WNYW)",
+        "number": 5
+      },
+      {
+        "name": "WRNN",
+        "number": 6
+      },
+      {
+        "name": "ABC (WABC)",
+        "number": 7
+      },
+      {
+        "name": "Univisión (WXTV)",
+        "number": 8
+      },
+      {
+        "name": "My9 (WWOR)",
+        "number": 9
+      },
+      {
+        "name": "WLNY",
+        "number": 10
+      },
+      {
+        "name": "CW (WPIX)",
+        "number": 11
+      },
+      {
+        "name": "News 12 Westchester",
+        "number": 12
+      },
+      {
+        "name": "PBS/Thirteen (WNET)",
+        "number": 13
+      },
+      {
+        "name": "i24NEWS",
+        "number": 14
+      },
+      {
+        "name": "WZME StoryTV",
+        "number": 15
+      },
+      {
+        "name": "Telemundo (WNJU)",
+        "number": 16
+      },
+      {
+        "name": "UniMÁS",
+        "number": 17
+      },
+      {
+        "name": "QVC",
+        "number": 18
+      },
+      {
+        "name": "HSN",
+        "number": 19
+      },
+      {
+        "name": "WMBC",
+        "number": 20
+      },
+      {
+        "name": "PBS (WLIW)",
+        "number": 21
+      },
+      {
+        "name": "NYC Life",
+        "number": 22
+      },
+      {
+        "name": "MS Now",
+        "number": 23
+      },
+      {
+        "name": "CNBC",
+        "number": 24
+      },
+      {
+        "name": "CNN",
+        "number": 25
+      },
+      {
+        "name": "FOX News Channel",
+        "number": 26
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 27
+      },
+      {
+        "name": "TLC",
+        "number": 28
+      },
+      {
+        "name": "Food Network",
+        "number": 29
+      },
+      {
+        "name": "HGTV",
+        "number": 30
+      },
+      {
+        "name": "MeTV (WJLP)",
+        "number": 33
+      },
+      {
+        "name": "TV Land",
+        "number": 34
+      },
+      {
+        "name": "TNT",
+        "number": 37
+      },
+      {
+        "name": "USA Network",
+        "number": 38
+      },
+      {
+        "name": "TBS",
+        "number": 39
+      },
+      {
+        "name": "FX",
+        "number": 40
+      },
+      {
+        "name": "Paramount Network",
+        "number": 41
+      },
+      {
+        "name": "WE tv",
+        "number": 42
+      },
+      {
+        "name": "AMC",
+        "number": 43
+      },
+      {
+        "name": "Bravo",
+        "number": 44
+      },
+      {
+        "name": "Lifetime",
+        "number": 45
+      },
+      {
+        "name": "A&E",
+        "number": 46
+      },
+      {
+        "name": "History",
+        "number": 47
+      },
+      {
+        "name": "Syfy",
+        "number": 48
+      },
+      {
+        "name": "Freeform",
+        "number": 49
+      },
+      {
+        "name": "Comedy Central",
+        "number": 50
+      },
+      {
+        "name": "E!",
+        "number": 51
+      },
+      {
+        "name": "VH1",
+        "number": 52
+      },
+      {
+        "name": "MTV",
+        "number": 53
+      },
+      {
+        "name": "BET",
+        "number": 54
+      },
+      {
+        "name": "MTV2",
+        "number": 55
+      },
+      {
+        "name": "Animal Planet",
+        "number": 57
+      },
+      {
+        "name": "truTV",
+        "number": 58
+      },
+      {
+        "name": "CNN Headline News",
+        "number": 59
+      },
+      {
+        "name": "News 12+",
+        "number": 61
+      },
+      {
+        "name": "The Weather Channel",
+        "number": 62
+      },
+      {
+        "name": "C-SPAN 2",
+        "number": 66
+      },
+      {
+        "name": "Turner Classic Movies",
+        "number": 67
+      },
+      {
+        "name": "Religious Programming",
+        "number": 68
+      },
+      {
+        "name": "Government Access",
+        "number": 75
+      },
+      {
+        "name": "Public Access",
+        "number": 76
+      },
+      {
+        "name": "Educational Access",
+        "number": 77
+      },
+      {
+        "name": "Local Programming",
+        "number": 78
+      },
+      {
+        "name": "C-SPAN",
+        "number": 80
+      },
+      {
+        "name": "Oxygen True Crime",
+        "number": 81
+      },
+      {
+        "name": "NewsNation",
+        "number": 82
+      },
+      {
+        "name": "IFC",
+        "number": 83
+      },
+      {
+        "name": "WZME MeTV+",
+        "number": 84
+      },
+      {
+        "name": "fuse",
+        "number": 87
+      },
+      {
+        "name": "GSN",
+        "number": 88
+      },
+      {
+        "name": "Hallmark",
+        "number": 92
+      },
+      {
+        "name": "Hallmark Mystery",
+        "number": 93
+      },
+      {
+        "name": "HSN2",
+        "number": 94
+      },
+      {
+        "name": "BUZZR",
+        "number": 95
+      },
+      {
+        "name": "Travel Channel",
+        "number": 96
+      },
+      {
+        "name": "BBC America",
+        "number": 101
+      },
+      {
+        "name": "Newsmax",
+        "number": 102
+      },
+      {
+        "name": "EuroNews",
+        "number": 103
+      },
+      {
+        "name": "BBC News",
+        "number": 104
+      },
+      {
+        "name": "Bloomberg TV",
+        "number": 105
+      },
+      {
+        "name": "FOX Business Network",
+        "number": 106
+      },
+      {
+        "name": "C-SPAN 3",
+        "number": 107
+      },
+      {
+        "name": "Charge!",
+        "number": 108
+      },
+      {
+        "name": "COZI TV",
+        "number": 109
+      },
+      {
+        "name": "Localish (HD Only)",
+        "number": 110
+      },
+      {
+        "name": "Start TV",
+        "number": 112
+      },
+      {
+        "name": "MOVIES!",
+        "number": 113
+      },
+      {
+        "name": "Antenna TV",
+        "number": 114
+      },
+      {
+        "name": "NYS Legislative TV",
+        "number": 116
+      },
+      {
+        "name": "PBS World (WLIW)",
+        "number": 132
+      },
+      {
+        "name": "PBS Create (WLIW)",
+        "number": 133
+      },
+      {
+        "name": "Trinity Broadcasting Network",
+        "number": 134
+      },
+      {
+        "name": "EWTN",
+        "number": 135
+      },
+      {
+        "name": "Daystar",
+        "number": 136
+      },
+      {
+        "name": "Catholic Faith Network",
+        "number": 137
+      },
+      {
+        "name": "Jewish Broadcasting Service",
+        "number": 138
+      },
+      {
+        "name": "Discovery Life",
+        "number": 141
+      },
+      {
+        "name": "GET",
+        "number": 143
+      },
+      {
+        "name": "PBS All Arts (WLIW) (HD only)",
+        "number": 144
+      },
+      {
+        "name": "DABL",
+        "number": 145
+      },
+      {
+        "name": "True CRMZ",
+        "number": 146
+      },
+      {
+        "name": "Comet",
+        "number": 148
+      },
+      {
+        "name": "Shop LC",
+        "number": 149
+      },
+      {
+        "name": "Discovery Turbo",
+        "number": 150
+      },
+      {
+        "name": "Rewind TV",
+        "number": 151
+      },
+      {
+        "name": "Crime & Investigation Network (HD only)",
+        "number": 152
+      },
+      {
+        "name": "Pop",
+        "number": 154
+      },
+      {
+        "name": "Gem Shopping Network",
+        "number": 155
+      },
+      {
+        "name": "Great American Faith and Living",
+        "number": 156
+      },
+      {
+        "name": "The Cowboy Channel",
+        "number": 157
+      },
+      {
+        "name": "Nat Geo Wild",
+        "number": 158
+      },
+      {
+        "name": "FYI",
+        "number": 160
+      },
+      {
+        "name": "Vice TV",
+        "number": 161
+      },
+      {
+        "name": "National Geographic",
+        "number": 162
+      },
+      {
+        "name": "Smithsonian Channel",
+        "number": 163
+      },
+      {
+        "name": "The Grio",
+        "number": 164
+      },
+      {
+        "name": "Classic Arts Showcase",
+        "number": 165
+      },
+      {
+        "name": "Cooking Channel",
+        "number": 166
+      },
+      {
+        "name": "Magnolia Network",
+        "number": 167
+      },
+      {
+        "name": "Justice Central",
+        "number": 168
+      },
+      {
+        "name": "Recipe.TV",
+        "number": 169
+      },
+      {
+        "name": "Science Channel",
+        "number": 170
+      },
+      {
+        "name": "Investigation Discovery",
+        "number": 171
+      },
+      {
+        "name": "Destination America",
+        "number": 172
+      },
+      {
+        "name": "American Heroes Channel",
+        "number": 173
+      },
+      {
+        "name": "LMN",
+        "number": 174
+      },
+      {
+        "name": "FETV",
+        "number": 175
+      },
+      {
+        "name": "Cleo TV",
+        "number": 176
+      },
+      {
+        "name": "ReelzChannel",
+        "number": 177
+      },
+      {
+        "name": "TV One",
+        "number": 178
+      },
+      {
+        "name": "LOGO TV",
+        "number": 179
+      },
+      {
+        "name": "OWN",
+        "number": 180
+      },
+      {
+        "name": "Jewelry Television",
+        "number": 182
+      },
+      {
+        "name": "QVC2",
+        "number": 183
+      },
+      {
+        "name": "Great American Family",
+        "number": 184
+      },
+      {
+        "name": "BET Her",
+        "number": 185
+      },
+      {
+        "name": "MTV Classic",
+        "number": 186
+      },
+      {
+        "name": "CMT",
+        "number": 187
+      },
+      {
+        "name": "AXS",
+        "number": 188
+      },
+      {
+        "name": "Hallmark Family",
+        "number": 189
+      },
+      {
+        "name": "FX Movie Channel",
+        "number": 190
+      },
+      {
+        "name": "HDNet Movies",
+        "number": 191
+      },
+      {
+        "name": "SundanceTV",
+        "number": 192
+      },
+      {
+        "name": "Fox Weather",
+        "number": 193
+      },
+      {
+        "name": "MTV Tr3s",
+        "number": 195
+      },
+      {
+        "name": "NBC Universo",
+        "number": 197
+      },
+      {
+        "name": "Galavisión",
+        "number": 198
+      }
+    ],
+    "Kids": [
+      {
+        "name": "Discovery Family Channel",
+        "number": 120
+      },
+      {
+        "name": "Nickelodeon",
+        "number": 121
+      },
+      {
+        "name": "Nicktoons TV",
+        "number": 122
+      },
+      {
+        "name": "Nick Jr.",
+        "number": 123
+      },
+      {
+        "name": "Teen Nick",
+        "number": 124
+      },
+      {
+        "name": "Disney Channel",
+        "number": 31
+      },
+      {
+        "name": "Disney Junior",
+        "number": 126
+      },
+      {
+        "name": "Disney XD",
+        "number": 127
+      },
+      {
+        "name": "Cartoon Network",
+        "number": 32
+      },
+      {
+        "name": "Boomerang",
+        "number": 129
+      },
+      {
+        "name": "PBS Kids Thirteen",
+        "number": 131
+      }
+    ],
+    "Sports": [
+      {
+        "name": "YES Network",
+        "number": 70
+      },
+      {
+        "name": "SportsNet New York",
+        "number": 60
+      },
+      {
+        "name": "MSG",
+        "number": 71
+      },
+      {
+        "name": "MSG Sportsnet",
+        "number": 72
+      },
+      {
+        "name": "Sports Overflow 1",
+        "number": 73
+      },
+      {
+        "name": "Sports Overflow 2",
+        "number": 206
+      },
+      {
+        "name": "ESPN",
+        "number": 36
+      },
+      {
+        "name": "ESPN2",
+        "number": 35
+      },
+      {
+        "name": "FOX Sports 1",
+        "number": 56
+      },
+      {
+        "name": "FOX Sports 2",
+        "number": 214
+      },
+      {
+        "name": "CBS Sports Network",
+        "number": 215
+      },
+      {
+        "name": "ESPNEWS",
+        "number": 216
+      },
+      {
+        "name": "ESPNU",
+        "number": 217
+      },
+      {
+        "name": "NFL Network",
+        "number": 219
+      },
+      {
+        "name": "NFL RedZone",
+        "number": 220
+      },
+      {
+        "name": "NHL Network",
+        "number": 223
+      },
+      {
+        "name": "The Golf Channel",
+        "number": 224
+      },
+      {
+        "name": "Tennis Channel (HD only)",
+        "number": 226
+      },
+      {
+        "name": "ESPN Deportes",
+        "number": 227
+      },
+      {
+        "name": "FOX Deportes",
+        "number": 228
+      },
+      {
+        "name": "TUDN",
+        "number": 229
+      },
+      {
+        "name": "beIN Sports en Español",
+        "number": 230
+      },
+      {
+        "name": "beIN Sports",
+        "number": 231
+      },
+      {
+        "name": "FOX Soccer Plus",
+        "number": 232
+      },
+      {
+        "name": "Game+",
+        "number": 238
+      },
+      {
+        "name": "Willow",
+        "number": 239
+      },
+      {
+        "name": "World Fishing Network",
+        "number": 241
+      },
+      {
+        "name": "Sportsman Channel",
+        "number": 242
+      },
+      {
+        "name": "Racer",
+        "number": 243
+      },
+      {
+        "name": "Fight Network",
+        "number": 244
+      },
+      {
+        "name": "FanDuel TV",
+        "number": 245
+      },
+      {
+        "name": "SEC",
+        "number": 246
+      },
+      {
+        "name": "BTN",
+        "number": 247
+      },
+      {
+        "name": "ACC Network",
+        "number": 248
+      }
+    ],
+    "Premiums": [
+      {
+        "name": "HBO On Demand",
+        "number": 300
+      },
+      {
+        "name": "HBO",
+        "number": 301
+      },
+      {
+        "name": "HBO Hits",
+        "number": 302
+      },
+      {
+        "name": "HBO Comedy",
+        "number": 303
+      },
+      {
+        "name": "HBO Movies",
+        "number": 304
+      },
+      {
+        "name": "HBO Latino",
+        "number": 305
+      },
+      {
+        "name": "HBO West",
+        "number": 306
+      },
+      {
+        "name": "HBO Hits West",
+        "number": 307
+      },
+      {
+        "name": "HBO Drama West",
+        "number": 308
+      },
+      {
+        "name": "HBO Drama",
+        "number": 310
+      },
+      {
+        "name": "Showtime On Demand",
+        "number": 320
+      },
+      {
+        "name": "Paramount+ with Showtime",
+        "number": 321
+      },
+      {
+        "name": "Showtime 2",
+        "number": 322
+      },
+      {
+        "name": "SHOxBET",
+        "number": 323
+      },
+      {
+        "name": "Showtime Next",
+        "number": 324
+      },
+      {
+        "name": "Showtime Family Zone",
+        "number": 325
+      },
+      {
+        "name": "Showtime Women",
+        "number": 326
+      },
+      {
+        "name": "Paramount+ with Showtime West",
+        "number": 327
+      },
+      {
+        "name": "Showtime 2 West",
+        "number": 328
+      },
+      {
+        "name": "Showtime Showcase West",
+        "number": 329
+      },
+      {
+        "name": "Showtime Showcase",
+        "number": 330
+      },
+      {
+        "name": "Showtime Extreme",
+        "number": 331
+      },
+      {
+        "name": "Starz On Demand",
+        "number": 340
+      },
+      {
+        "name": "Starz",
+        "number": 341
+      },
+      {
+        "name": "Starz Kids & Family",
+        "number": 342
+      },
+      {
+        "name": "Starz Edge",
+        "number": 343
+      },
+      {
+        "name": "Starz in Black",
+        "number": 344
+      },
+      {
+        "name": "Starz West",
+        "number": 345
+      },
+      {
+        "name": "Starz Comedy",
+        "number": 346
+      },
+      {
+        "name": "Starz Cinema",
+        "number": 347
+      },
+      {
+        "name": "Starz Encore On Demand",
+        "number": 350
+      },
+      {
+        "name": "Starz Encore",
+        "number": 351
+      },
+      {
+        "name": "Starz Encore Suspense",
+        "number": 352
+      },
+      {
+        "name": "Starz Encore Westerns",
+        "number": 353
+      },
+      {
+        "name": "Starz Encore Classic",
+        "number": 354
+      },
+      {
+        "name": "Starz Encore Black",
+        "number": 355
+      },
+      {
+        "name": "Starz Encore Family",
+        "number": 356
+      },
+      {
+        "name": "Starz Encore West",
+        "number": 357
+      },
+      {
+        "name": "Starz Encore Action",
+        "number": 358
+      },
+      {
+        "name": "Starz Encore Espanol",
+        "number": 359
+      },
+      {
+        "name": "Cinemax On Demand",
+        "number": 370
+      },
+      {
+        "name": "Cinemax",
+        "number": 371
+      },
+      {
+        "name": "Cinemax Hits",
+        "number": 372
+      },
+      {
+        "name": "Cinemáx",
+        "number": 375
+      },
+      {
+        "name": "Cinemax Classics",
+        "number": 376
+      },
+      {
+        "name": "Cinemax West",
+        "number": 378
+      },
+      {
+        "name": "Cinemax Action",
+        "number": 379
+      },
+      {
+        "name": "TMC On Demand",
+        "number": 390
+      },
+      {
+        "name": "TMC",
+        "number": 391
+      },
+      {
+        "name": "TMC West",
+        "number": 392
+      },
+      {
+        "name": "TMC Xtra",
+        "number": 393
+      },
+      {
+        "name": "TMC Xtra West",
+        "number": 394
+      },
+      {
+        "name": "Flix",
+        "number": 397
+      }
+    ],
+    "On Demand & PPV": [
+      {
+        "name": "On Demand",
+        "number": 500
+      },
+      {
+        "name": "Free On Demand",
+        "number": 502
+      },
+      {
+        "name": "Anime Network On Demand",
+        "number": 507
+      },
+      {
+        "name": "here! On Demand",
+        "number": 509
+      },
+      {
+        "name": "Adult Programming",
+        "number": 520
+      }
+    ],
+    "Interactive": [
+      {
+        "name": "Netflix",
+        "number": 600
+      },
+      {
+        "name": "You Tube",
+        "number": 603
+      },
+      {
+        "name": "News 12 Interactive",
+        "number": 612
+      },
+      {
+        "name": "Caller ID",
+        "number": 630
+      },
+      {
+        "name": "Most Watched",
+        "number": 907
+      },
+      {
+        "name": "Amazon Prime Video",
+        "number": 901
+      },
+      {
+        "name": "DVR Playback",
+        "number": 1000
+      },
+      {
+        "name": "Multi-Room DVR Playback",
+        "number": 1001
+      }
+    ],
+    "Music": [
+      {
+        "name": "Stingray Music",
+        "number": 850
+      }
+    ],
+    "International": [
+      {
+        "name": "Estrella TV",
+        "number": 1010
+      },
+      {
+        "name": "HITN",
+        "number": 1011
+      },
+      {
+        "name": "CNN en Español",
+        "number": 1012
+      },
+      {
+        "name": "Discovery en Español",
+        "number": 1013
+      },
+      {
+        "name": "DO_Canal America",
+        "number": 1014
+      },
+      {
+        "name": "Nat Geo Mundo",
+        "number": 1016
+      },
+      {
+        "name": "History en Español",
+        "number": 1017
+      },
+      {
+        "name": "Discovery Familia",
+        "number": 1018
+      },
+      {
+        "name": "Tarima",
+        "number": 1019
+      },
+      {
+        "name": "VE_Ve Plus",
+        "number": 1020
+      },
+      {
+        "name": "CO_NTN24",
+        "number": 1021
+      },
+      {
+        "name": "MX_FOROtv",
+        "number": 1022
+      },
+      {
+        "name": "DO_Supercanal Caribe",
+        "number": 1023
+      },
+      {
+        "name": "DO_Telemicro Internacional",
+        "number": 1024
+      },
+      {
+        "name": "DO_Dominican View",
+        "number": 1025
+      },
+      {
+        "name": "WAPA America",
+        "number": 1026
+      },
+      {
+        "name": "DO_TV Quisqueya",
+        "number": 1027
+      },
+      {
+        "name": "CU_Cuba Play",
+        "number": 1028
+      },
+      {
+        "name": "DO_Televisión Dominicana",
+        "number": 1029
+      },
+      {
+        "name": "centroaméricatv",
+        "number": 1030
+      },
+      {
+        "name": "EC_Ecuavisa Internacional",
+        "number": 1031
+      },
+      {
+        "name": "CL_TV Chile",
+        "number": 1032
+      },
+      {
+        "name": "PA_Nuestra Tele",
+        "number": 1033
+      },
+      {
+        "name": "CO_Caracol TV Internacional",
+        "number": 1034
+      },
+      {
+        "name": "PE_SUR Perú",
+        "number": 1039
+      },
+      {
+        "name": "MX_Teleformula",
+        "number": 1041
+      },
+      {
+        "name": "ES_Canal Sur",
+        "number": 1042
+      },
+      {
+        "name": "ES_TVE Internacional",
+        "number": 1043
+      },
+      {
+        "name": "ES_Antena 3",
+        "number": 1044
+      },
+      {
+        "name": "TeleXitos",
+        "number": 1048
+      },
+      {
+        "name": "Kids Street SAP",
+        "number": 1049
+      },
+      {
+        "name": "MX_Cine Mexicano",
+        "number": 1057
+      },
+      {
+        "name": "Cine Latino",
+        "number": 1058
+      },
+      {
+        "name": "ViendoMovies",
+        "number": 1059
+      },
+      {
+        "name": "HOLA TV",
+        "number": 1081
+      },
+      {
+        "name": "Cartoon Network SAP",
+        "number": 1082
+      },
+      {
+        "name": "Disney XD SAP",
+        "number": 1084
+      },
+      {
+        "name": "CO_RCN Novelas",
+        "number": 1085
+      },
+      {
+        "name": "MX_Videorola",
+        "number": 1086
+      },
+      {
+        "name": "Pasiones",
+        "number": 1090
+      },
+      {
+        "name": "Univisión tlnovelas",
+        "number": 1091
+      },
+      {
+        "name": "ES_Atres Series",
+        "number": 1092
+      },
+      {
+        "name": "AR_El Gourmet",
+        "number": 1093
+      },
+      {
+        "name": "PE_INTI Network",
+        "number": 1094
+      },
+      {
+        "name": "EWTN Español",
+        "number": 1097
+      },
+      {
+        "name": "En Español On Demand",
+        "number": 1099
+      },
+      {
+        "name": "Noire Africa",
+        "number": 1100
+      },
+      {
+        "name": "CaribVision",
+        "number": 1104
+      },
+      {
+        "name": "Tempo",
+        "number": 1105
+      },
+      {
+        "name": "i24NEWS French",
+        "number": 1108
+      },
+      {
+        "name": "FR_TV5MONDE",
+        "number": 1109
+      },
+      {
+        "name": "PL_iTVN",
+        "number": 1115
+      },
+      {
+        "name": "PL_TVN24",
+        "number": 1117
+      },
+      {
+        "name": "IL_The Israeli Network",
+        "number": 1118
+      },
+      {
+        "name": "GR_Antenna Satellite",
+        "number": 1122
+      },
+      {
+        "name": "GR_Alpha",
+        "number": 1123
+      },
+      {
+        "name": "PT_RTPi",
+        "number": 1127
+      },
+      {
+        "name": "SPT",
+        "number": 1128
+      },
+      {
+        "name": "BR_TV Globo",
+        "number": 1129
+      },
+      {
+        "name": "BR_TV Record",
+        "number": 1130
+      },
+      {
+        "name": "ART",
+        "number": 1135
+      },
+      {
+        "name": "CN_Phoenix North America Chinese Channel",
+        "number": 1146
+      },
+      {
+        "name": "CN_Phoenix InfoNews",
+        "number": 1147
+      },
+      {
+        "name": "ET Global NY",
+        "number": 1149
+      },
+      {
+        "name": "CN_CCTV-4",
+        "number": 1150
+      },
+      {
+        "name": "CN_NTD TV",
+        "number": 1151
+      },
+      {
+        "name": "MBC",
+        "number": 1153
+      },
+      {
+        "name": "KR_The Korean Channel-TKC",
+        "number": 1154
+      },
+      {
+        "name": "KR_KBS World",
+        "number": 1155
+      },
+      {
+        "name": "TW_CTS America",
+        "number": 1156
+      },
+      {
+        "name": "PH_The Filipino Channel",
+        "number": 1161
+      },
+      {
+        "name": "PH_GMA Pinoy TV",
+        "number": 1162
+      },
+      {
+        "name": "IN_Jus Punjabi",
+        "number": 1164
+      },
+      {
+        "name": "IN_Eros Now On Demand",
+        "number": 1165
+      },
+      {
+        "name": "IN_TV Asia",
+        "number": 1167
+      },
+      {
+        "name": "IN_ITV Gold",
+        "number": 1168
+      },
+      {
+        "name": "IN_Zee TV",
+        "number": 1169
+      },
+      {
+        "name": "IN_SET",
+        "number": 1173
+      },
+      {
+        "name": "RU_RTVi",
+        "number": 1182
+      },
+      {
+        "name": "RU_RTN",
+        "number": 1183
+      },
+      {
+        "name": "RU_Shanson TV",
+        "number": 1188
+      },
+      {
+        "name": "IT_RAI Italia",
+        "number": 1194
+      },
+      {
+        "name": "IT_Mediaset Italia",
+        "number": 1195
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/US_Spectrum-Tampa-Bay-All_lineup.json
+++ b/plugins/lineuparr/US_Spectrum-Tampa-Bay-All_lineup.json
@@ -1,0 +1,4036 @@
+{
+  "package": "Spectrum Tampa Bay - All IPTV Clean",
+  "date": "2026-08-18",
+  "description": "Curated Spectrum Tampa Bay logical-channel lineup optimized for IPTV/Lineuparr.",
+  "source": "Spectrum Tampa Bay source lineup, cross-checked against the supplied TV Passport guide and curated for IPTV/Lineuparr use.",
+  "categories": {
+    "Local": [
+      {
+        "name": "WCLF",
+        "number": 2,
+        "aliases": [
+          "WCLFDT",
+          "WCLF-TV",
+          "11351",
+          "42627",
+          "2 WCLF"
+        ]
+      },
+      {
+        "name": "WEDU",
+        "number": 3,
+        "aliases": [
+          "WEDUDT",
+          "WEDU-TV",
+          "11407",
+          "35193",
+          "3 WEDU"
+        ]
+      },
+      {
+        "name": "WTOG",
+        "number": 4,
+        "aliases": [
+          "WTOGDT",
+          "WTOG-TV",
+          "11894",
+          "30617",
+          "4 WTOG"
+        ]
+      },
+      {
+        "name": "WFTT",
+        "number": 5,
+        "aliases": [
+          "WFTTDT",
+          "WFTT-TV",
+          "11249",
+          "50307",
+          "5 WFTT"
+        ]
+      },
+      {
+        "name": "WTTA",
+        "number": 6,
+        "aliases": [
+          "WTTADT",
+          "WTTA-TV",
+          "11903",
+          "36145",
+          "6 WTTA"
+        ]
+      },
+      {
+        "name": "WFLA-TV",
+        "number": 8,
+        "aliases": [
+          "WFLA",
+          "WFLADT",
+          "11437",
+          "21222",
+          "8 WFLA"
+        ]
+      },
+      {
+        "name": "Bay News 9",
+        "number": 9,
+        "aliases": [
+          "BAY9",
+          "BAY9DT",
+          "19997",
+          "70271",
+          "9 BAY9"
+        ]
+      },
+      {
+        "name": "WTSP",
+        "number": 10,
+        "aliases": [
+          "WTSPDT",
+          "WTSP-TV",
+          "11902",
+          "20495",
+          "10 WTSP"
+        ]
+      },
+      {
+        "name": "WFTS-TV",
+        "number": 11,
+        "aliases": [
+          "WFTS",
+          "WFTSDT",
+          "11447",
+          "21224",
+          "11 WFTS"
+        ]
+      },
+      {
+        "name": "WMOR",
+        "number": 12,
+        "aliases": [
+          "WMORDT",
+          "WMOR-TV",
+          "11891",
+          "33689",
+          "12 WMOR"
+        ]
+      },
+      {
+        "name": "WTVT",
+        "number": 13,
+        "aliases": [
+          "WTVTDT",
+          "WTVT-TV",
+          "11922",
+          "21223",
+          "13 WTVT"
+        ]
+      },
+      {
+        "name": "WXPX-TV",
+        "number": 17,
+        "aliases": [
+          "WXPX",
+          "WXPXDT",
+          "15034",
+          "34842",
+          "17 WXPX"
+        ]
+      },
+      {
+        "name": "WTVTDT3",
+        "number": 603,
+        "aliases": [
+          "WTVTDT3 BUZZR",
+          "WTVTDT3-TV",
+          "94323",
+          "603 WTVTDT3"
+        ]
+      },
+      {
+        "name": "WEDUDT3",
+        "number": 604,
+        "aliases": [
+          "WEDUDT3 NHKWRLD",
+          "WEDUDT3-TV",
+          "56655",
+          "604 WEDUDT3"
+        ]
+      },
+      {
+        "name": "WEDUDT2",
+        "number": 606,
+        "aliases": [
+          "WEDUDT2 WORLD",
+          "WEDUDT2-TV",
+          "35223",
+          "606 WEDUDT2"
+        ]
+      },
+      {
+        "name": "WFLADT2",
+        "number": 607,
+        "aliases": [
+          "WFLADT2 CHARGE",
+          "WFLADT2-TV",
+          "43841",
+          "607 WFLADT2"
+        ]
+      },
+      {
+        "name": "WFTSDT3",
+        "number": 608,
+        "aliases": [
+          "WFTSDT3 GRIT",
+          "WFTSDT3-TV",
+          "91890",
+          "608 WFTSDT3"
+        ]
+      },
+      {
+        "name": "WTTA2",
+        "number": 609,
+        "aliases": [
+          "WTTADT2",
+          "WTTADT2 COZITV",
+          "WTTADT2-TV",
+          "50311",
+          "609 WTTADT2"
+        ]
+      },
+      {
+        "name": "WTSP3",
+        "number": 611,
+        "aliases": [
+          "WTSPDT3",
+          "WTSPDT3 CRIME",
+          "WTSPDT3-TV",
+          "91455",
+          "611 WTSPDT3"
+        ]
+      },
+      {
+        "name": "WTVT2",
+        "number": 613,
+        "aliases": [
+          "WTVTDT2",
+          "WTVTDT2 MVIES",
+          "WTVTDT2-TV",
+          "62802",
+          "613 WTVTDT2"
+        ]
+      },
+      {
+        "name": "HEROICN",
+        "number": 614,
+        "aliases": [
+          "90401",
+          "614 HEROICN"
+        ]
+      },
+      {
+        "name": "WXPXDT2",
+        "number": 615,
+        "aliases": [
+          "WXPXDT2 ION",
+          "WXPXDT2-TV",
+          "43324",
+          "615 WXPXDT2"
+        ]
+      },
+      {
+        "name": "WXPXDT4",
+        "number": 616,
+        "aliases": [
+          "WXPXDT4 LAFF",
+          "WXPXDT4-TV",
+          "43330",
+          "616 WXPXDT4"
+        ]
+      },
+      {
+        "name": "WEDQDT5",
+        "number": 617,
+        "aliases": [
+          "WEDQDT5 HD06",
+          "WEDQDT5-TV",
+          "35226",
+          "617 WEDQDT5"
+        ]
+      },
+      {
+        "name": "WEDUDT6",
+        "number": 618,
+        "aliases": [
+          "WEDUDT6 CREATE",
+          "WEDUDT6-TV",
+          "105774",
+          "618 WEDUDT6"
+        ]
+      },
+      {
+        "name": "WFLADT3",
+        "number": 619,
+        "aliases": [
+          "WFLADT3 ANTENNA",
+          "WFLADT3-TV",
+          "43843",
+          "619 WFLADT3"
+        ]
+      },
+      {
+        "name": "WTSPDT4",
+        "number": 620,
+        "aliases": [
+          "WTSPDT4 THENEST",
+          "WTSPDT4-TV",
+          "107046",
+          "620 WTSPDT4"
+        ]
+      },
+      {
+        "name": "FLACHAN",
+        "number": 623,
+        "aliases": [
+          "35219",
+          "623 FLACHAN"
+        ]
+      },
+      {
+        "name": "WFTSDT2",
+        "number": 629,
+        "aliases": [
+          "WFTSDT2 BOUNCE",
+          "WFTSDT2-TV",
+          "50359",
+          "629 WFTSDT2"
+        ]
+      },
+      {
+        "name": "WMORDT2",
+        "number": 630,
+        "aliases": [
+          "WMORDT2 METVN",
+          "WMORDT2-TV",
+          "62896",
+          "630 WMORDT2"
+        ]
+      },
+      {
+        "name": "MYX",
+        "number": 633,
+        "aliases": [
+          "55451",
+          "633 MYX"
+        ]
+      },
+      {
+        "name": "WMORDT3",
+        "number": 910,
+        "aliases": [
+          "WMORDT3 ESTRLLA",
+          "WMORDT3-TV",
+          "65069",
+          "910 WMORDT3"
+        ]
+      },
+      {
+        "name": "WEDQDT4",
+        "number": 1016,
+        "aliases": [
+          "WEDQDT4-TV",
+          "56744",
+          "1016 WEDQDT4"
+        ]
+      },
+      {
+        "name": "WSNNLD",
+        "number": 1020,
+        "aliases": [
+          "WSNNLD MNT",
+          "WSNNLD-TV",
+          "75548",
+          "1020 WSNNLD"
+        ]
+      }
+    ],
+    "News": [
+      {
+        "name": "CNN",
+        "number": 29,
+        "aliases": [
+          "CNNHD",
+          "10142",
+          "58646",
+          "29 CNN",
+          "US: CNN HD",
+          "cnn.us",
+          "US: CNN 4K",
+          "CNN HD"
+        ]
+      },
+      {
+        "name": "HLN",
+        "number": 30,
+        "aliases": [
+          "HLNHD",
+          "10145",
+          "64549",
+          "30 HLN"
+        ]
+      },
+      {
+        "name": "CNBC",
+        "number": 42,
+        "aliases": [
+          "CNBCFL",
+          "92081",
+          "42 CNBCFL",
+          "US: CNBC HD",
+          "CNBC.us",
+          "CNBCHD",
+          "CNBC HD",
+          "CNBCFHD",
+          "92082",
+          "1219 CNBCFHD"
+        ]
+      },
+      {
+        "name": "The Weather Channel",
+        "number": 63,
+        "aliases": [
+          "WEATH",
+          "WEA",
+          "WEATHHD",
+          "WEATH-TV",
+          "11187",
+          "58812",
+          "63 WEATH"
+        ]
+      },
+      {
+        "name": "Bloomberg Television",
+        "number": 127,
+        "aliases": [
+          "BLOOM",
+          "BLOOMHD",
+          "14755",
+          "71799",
+          "127 BLOOM"
+        ]
+      },
+      {
+        "name": "i24NEWS",
+        "number": 128,
+        "aliases": [
+          "I24NWEN",
+          "87376",
+          "128 I24NWEN",
+          "102309",
+          "1224 I24NEHD",
+          "I24NEHD"
+        ]
+      },
+      {
+        "name": "OANHD",
+        "number": 129,
+        "aliases": [
+          "83953",
+          "129 OANHD"
+        ]
+      },
+      {
+        "name": "CNBC World",
+        "number": 141,
+        "aliases": [
+          "CNBCWLD",
+          "CNBCW",
+          "26849",
+          "141 CNBCWLD"
+        ]
+      },
+      {
+        "name": "FOX Business Network",
+        "number": 149,
+        "aliases": [
+          "FBNHD",
+          "FBN",
+          "58649",
+          "58718",
+          "149 FBN",
+          "US: FOX BUSINESS NETWORK HD",
+          "FoxBusiness.us",
+          "foxbusiness.us"
+        ]
+      },
+      {
+        "name": "CSPAN",
+        "number": 175,
+        "aliases": [
+          "CSPANHD",
+          "10161",
+          "68344",
+          "175 CSPAN"
+        ]
+      },
+      {
+        "name": "CSPAN2",
+        "number": 176,
+        "aliases": [
+          "10162",
+          "176 CSPAN2",
+          "68334",
+          "1227 CSPN2HD",
+          "CSPN2HD"
+        ]
+      },
+      {
+        "name": "CSPAN3",
+        "number": 177,
+        "aliases": [
+          "17665",
+          "177 CSPAN3",
+          "68332",
+          "1228 CSPN3HD",
+          "CSPN3HD"
+        ]
+      },
+      {
+        "name": "NEWSNTN",
+        "number": 1018,
+        "aliases": [
+          "91096",
+          "1018 NEWSNTN"
+        ]
+      },
+      {
+        "name": "NEWSMX",
+        "number": 1217,
+        "aliases": [
+          "87925",
+          "1217 NEWSMX"
+        ]
+      }
+    ],
+    "Sports": [
+      {
+        "name": "ESPN",
+        "number": 27,
+        "aliases": [
+          "ESPNTPA",
+          "77570",
+          "27 ESPNTPA",
+          "US: ESPN HD",
+          "ESPN.us",
+          "ESPNHD",
+          "ESPN HD",
+          "77572",
+          "1127 ESPNHTP",
+          "ESPNHTP"
+        ]
+      },
+      {
+        "name": "GOLF",
+        "number": 67,
+        "aliases": [
+          "GOLFHD",
+          "14899",
+          "61854",
+          "67 GOLF"
+        ]
+      },
+      {
+        "name": "SEC Network",
+        "number": 72,
+        "aliases": [
+          "SEC",
+          "89535",
+          "72 SEC",
+          "SECH",
+          "89714",
+          "1150 SECH"
+        ]
+      },
+      {
+        "name": "FOX Sports 1",
+        "number": 112,
+        "aliases": [
+          "FS1HD",
+          "FS1",
+          "82541",
+          "82547",
+          "112 FS1",
+          "US: FOX SPORTS 1 HD",
+          "US: FOX SPORTS 1",
+          "FoxSports1.us",
+          "FOX SPORTS 1 HD",
+          "Fox Sports 1 HD"
+        ]
+      },
+      {
+        "name": "ESPNews",
+        "number": 150,
+        "aliases": [
+          "ESPNEWS",
+          "16485",
+          "150 ESPNEWS",
+          "ESPNWHD",
+          "ESPNews HD",
+          "59976",
+          "1129 ESPNWHD"
+        ]
+      },
+      {
+        "name": "ESPNU",
+        "number": 151,
+        "aliases": [
+          "ESPNUHD",
+          "45654",
+          "60696",
+          "151 ESPNU"
+        ]
+      },
+      {
+        "name": "NBA TV",
+        "number": 803,
+        "aliases": [
+          "NBAFL",
+          "NBA",
+          "77636",
+          "803 NBAFL",
+          "77637",
+          "1140 NBAHFL",
+          "NBAHFL"
+        ]
+      },
+      {
+        "name": "Tennis Channel",
+        "number": 804,
+        "aliases": [
+          "TENNIS",
+          "TENN",
+          "33395",
+          "804 TENNIS",
+          "TENISHD",
+          "60316",
+          "1155 TENISHD"
+        ]
+      },
+      {
+        "name": "Outdoor Channel",
+        "number": 805,
+        "aliases": [
+          "OUTD",
+          "OUT",
+          "14776",
+          "805 OUTD"
+        ]
+      },
+      {
+        "name": "FOX Sports 2",
+        "number": 806,
+        "aliases": [
+          "FS2HD",
+          "FS2",
+          "33178",
+          "59305",
+          "806 FS2",
+          "US: FOX SPORTS 2 HD",
+          "US: FOX SPORTS 2",
+          "FoxSports2.us",
+          "FOX SPORTS 2 HD",
+          "Fox Sports 2 HD"
+        ]
+      },
+      {
+        "name": "CBS Sports Network",
+        "number": 807,
+        "aliases": [
+          "CBSSN",
+          "CBSSNHD",
+          "16365",
+          "59250",
+          "807 CBSSN"
+        ]
+      },
+      {
+        "name": "NHL Network",
+        "number": 808,
+        "aliases": [
+          "NHLFL",
+          "NHL",
+          "NHLHDFL",
+          "77587",
+          "77588",
+          "808 NHLFL"
+        ]
+      },
+      {
+        "name": "Big Ten Network",
+        "number": 809,
+        "aliases": [
+          "BIGFLA",
+          "61160",
+          "809 BIGFLA",
+          "79660",
+          "1138 BIGFLAH",
+          "BIGFLAH"
+        ]
+      },
+      {
+        "name": "MLB Network",
+        "number": 815,
+        "aliases": [
+          "MLBFL",
+          "MLBFLHD",
+          "77574",
+          "77573",
+          "815 MLBFL"
+        ]
+      },
+      {
+        "name": "NFL Network",
+        "number": 825,
+        "aliases": [
+          "NFLNET",
+          "34710",
+          "825 NFLNET",
+          "45399",
+          "1145 NFLHD",
+          "NFLHD"
+        ]
+      },
+      {
+        "name": "NFL RedZone",
+        "number": 826,
+        "aliases": [
+          "NFLNRZ",
+          "NFLN",
+          "65024",
+          "826 NFLNRZ",
+          "65025",
+          "1146 NFLNRZD",
+          "NFLNRZD"
+        ]
+      },
+      {
+        "name": "World Fishing Network",
+        "number": 827,
+        "aliases": [
+          "WFNUS",
+          "WFNUSHD",
+          "WFNUS-TV",
+          "63234",
+          "64046",
+          "827 WFNUS"
+        ]
+      },
+      {
+        "name": "FSP",
+        "number": 829,
+        "aliases": [
+          "66879",
+          "829 FSP"
+        ]
+      },
+      {
+        "name": "beIN Sports",
+        "number": 831,
+        "aliases": [
+          "BEINS1",
+          "beINS",
+          "76942",
+          "831 BEINS1",
+          "BEIN1HD",
+          "76950",
+          "1163 BEIN1HD"
+        ]
+      },
+      {
+        "name": "Willow",
+        "number": 835,
+        "aliases": [
+          "WILLOW",
+          "WILLOW-TV",
+          "68605",
+          "835 WILLOW"
+        ]
+      },
+      {
+        "name": "RACER Network",
+        "number": 837,
+        "aliases": [
+          "RACER",
+          "RACERHD",
+          "45169",
+          "61036",
+          "837 RACER"
+        ]
+      },
+      {
+        "name": "FanDuel TV",
+        "number": 838,
+        "aliases": [
+          "FDUELTV",
+          "21345",
+          "838 FDUELTV"
+        ]
+      },
+      {
+        "name": "beIN Sports en Español",
+        "number": 913,
+        "aliases": [
+          "BEINSES",
+          "76943",
+          "913 BEINSES"
+        ]
+      },
+      {
+        "name": "ESPN Deportes",
+        "number": 914,
+        "aliases": [
+          "ESPND",
+          "ESPNDHD",
+          "25595",
+          "71914",
+          "914 ESPND"
+        ]
+      },
+      {
+        "name": "ACC Network",
+        "number": 1205,
+        "aliases": [
+          "ACC",
+          "111871",
+          "1205 ACC"
+        ]
+      },
+      {
+        "name": "BEIN2HD",
+        "number": 1919,
+        "aliases": [
+          "76955",
+          "1919 BEIN2HD"
+        ]
+      }
+    ],
+    "Entertainment": [
+      {
+        "name": "NWSNTSD",
+        "number": 18,
+        "aliases": [
+          "91097",
+          "18 NWSNTSD"
+        ]
+      },
+      {
+        "name": "TBS",
+        "number": 23,
+        "aliases": [
+          "TBSTPA",
+          "77582",
+          "23 TBSTPA",
+          "US: TBS HD",
+          "TBSHD",
+          "TBS HD"
+        ]
+      },
+      {
+        "name": "ESPN2",
+        "number": 28,
+        "aliases": [
+          "ESP2TPA",
+          "77577",
+          "28 ESP2TPA",
+          "ESPN2HD",
+          "ESPN 2 HD",
+          "77579",
+          "1128 ESP2HTP",
+          "ESP2HTP"
+        ]
+      },
+      {
+        "name": "USA Network",
+        "number": 32,
+        "aliases": [
+          "USAFL",
+          "USA",
+          "USAFLHD",
+          "92084",
+          "92086",
+          "32 USAFL",
+          "US: USA NETWORK HD",
+          "USANetwork.us",
+          "USAHD",
+          "USA HD"
+        ]
+      },
+      {
+        "name": "TNT",
+        "number": 33,
+        "aliases": [
+          "TNTHD",
+          "11164",
+          "42642",
+          "33 TNT",
+          "US: TNT HD",
+          "TNT.us",
+          "US: TNT SD",
+          "TNT HD"
+        ]
+      },
+      {
+        "name": "Fox News Channel",
+        "number": 37,
+        "aliases": [
+          "FNC",
+          "FNCHD",
+          "16374",
+          "60179",
+          "37 FNC",
+          "US: FOX NEWS HD",
+          "FoxNews.us",
+          "foxnews.us",
+          "US: FOX NEWS CHANNEL 4K",
+          "Fox News HD"
+        ]
+      },
+      {
+        "name": "MSNOW",
+        "number": 41,
+        "aliases": [
+          "MSNOWHD",
+          "16300",
+          "64241",
+          "41 MSNOW"
+        ]
+      },
+      {
+        "name": "Paramount Network",
+        "number": 43,
+        "aliases": [
+          "PAR",
+          "PARHD",
+          "11163",
+          "59186",
+          "43 PAR",
+          "US: PARAMOUNT HD",
+          "PARAMOUNT NETWORK"
+        ]
+      },
+      {
+        "name": "CMT",
+        "number": 45,
+        "aliases": [
+          "CMTV",
+          "CMTVHD",
+          "10138",
+          "59440",
+          "45 CMTV"
+        ]
+      },
+      {
+        "name": "A&E",
+        "number": 48,
+        "aliases": [
+          "AETV",
+          "AETVHD",
+          "10035",
+          "51529",
+          "48 AETV"
+        ]
+      },
+      {
+        "name": "TV Land",
+        "number": 49,
+        "aliases": [
+          "TVLAND",
+          "16123",
+          "49 TVLAND",
+          "TVLNDHD",
+          "73541",
+          "1281 TVLNDHD"
+        ]
+      },
+      {
+        "name": "TRUTV",
+        "number": 55,
+        "aliases": [
+          "TRUTVHD",
+          "truTV",
+          "10153",
+          "64490",
+          "55 TRUTV"
+        ]
+      },
+      {
+        "name": "SYFY",
+        "number": 59,
+        "aliases": [
+          "SYFYHD",
+          "Syfy",
+          "11097",
+          "58623",
+          "59 SYFY"
+        ]
+      },
+      {
+        "name": "Comedy Central",
+        "number": 61,
+        "aliases": [
+          "COMEDY",
+          "10149",
+          "61 COMEDY",
+          "CCHD",
+          "62420",
+          "1292 CCHD"
+        ]
+      },
+      {
+        "name": "VH1",
+        "number": 62,
+        "aliases": [
+          "VH1HD",
+          "11218",
+          "60046",
+          "62 VH1"
+        ]
+      },
+      {
+        "name": "MTV",
+        "number": 66,
+        "aliases": [
+          "MTVHD",
+          "10986",
+          "60964",
+          "66 MTV"
+        ]
+      },
+      {
+        "name": "WE tv",
+        "number": 69,
+        "aliases": [
+          "WE",
+          "16409",
+          "69 WE",
+          "WEHD-TV",
+          "59296",
+          "1272 WEHD",
+          "WEHD"
+        ]
+      },
+      {
+        "name": "E!",
+        "number": 70,
+        "aliases": [
+          "E",
+          "10989",
+          "70 E",
+          "EHD",
+          "61812",
+          "1293 EHD"
+        ]
+      },
+      {
+        "name": "BET",
+        "number": 71,
+        "aliases": [
+          "BETHD",
+          "10051",
+          "63236",
+          "71 BET"
+        ]
+      },
+      {
+        "name": "BBC America",
+        "number": 75,
+        "aliases": [
+          "BBCA",
+          "BBC",
+          "BBCAHD",
+          "18332",
+          "64492",
+          "75 BBCA"
+        ]
+      },
+      {
+        "name": "BET Soul",
+        "number": 96,
+        "aliases": [
+          "BETSOUL",
+          "Soul",
+          "18718",
+          "96 BETSOUL"
+        ]
+      },
+      {
+        "name": "REVOLT",
+        "number": 97,
+        "aliases": [
+          "RVLT",
+          "RVLTHD",
+          "83097",
+          "83098",
+          "97 RVLT"
+        ]
+      },
+      {
+        "name": "Discovery Family",
+        "number": 102,
+        "aliases": [
+          "DFC",
+          "DFCHD",
+          "16618",
+          "67749",
+          "102 DFC"
+        ]
+      },
+      {
+        "name": "TWCTRV",
+        "number": 106,
+        "aliases": [
+          "87180",
+          "106 TWCTRV"
+        ]
+      },
+      {
+        "name": "BET Her",
+        "number": 107,
+        "aliases": [
+          "BHER",
+          "BETHer",
+          "BHERHD",
+          "14897",
+          "63220",
+          "107 BHER"
+        ]
+      },
+      {
+        "name": "FUSE",
+        "number": 109,
+        "aliases": [
+          "FUSEHD",
+          "14929",
+          "59116",
+          "109 FUSE"
+        ]
+      },
+      {
+        "name": "GSN",
+        "number": 116,
+        "aliases": [
+          "GSNHD",
+          "14909",
+          "68827",
+          "116 GSN"
+        ]
+      },
+      {
+        "name": "FX",
+        "number": 119,
+        "aliases": [
+          "14321",
+          "119 FX",
+          "FX.us",
+          "US: FX HD",
+          "FXHD",
+          "FX HD (EAST)",
+          "58574",
+          "1283 FXHD"
+        ]
+      },
+      {
+        "name": "BBC World News",
+        "number": 123,
+        "aliases": [
+          "BBCWDNA",
+          "89542",
+          "123 BBCWDNA",
+          "89690",
+          "1222 BBCNAHD",
+          "BBCNAHD"
+        ]
+      },
+      {
+        "name": "MTV2",
+        "number": 126,
+        "aliases": [
+          "MTV2HD",
+          "16361",
+          "75077",
+          "126 MTV2"
+        ]
+      },
+      {
+        "name": "FM",
+        "number": 132,
+        "aliases": [
+          "18262",
+          "132 FM"
+        ]
+      },
+      {
+        "name": "Great American Family",
+        "number": 133,
+        "aliases": [
+          "GFAM",
+          "GFAMHD",
+          "16062",
+          "82892",
+          "133 GFAM"
+        ]
+      },
+      {
+        "name": "YTA",
+        "number": 134,
+        "aliases": [
+          "10982",
+          "134 YTA"
+        ]
+      },
+      {
+        "name": "MTV Classic",
+        "number": 138,
+        "aliases": [
+          "MTVCLAS",
+          "MTV-C",
+          "22561",
+          "138 MTVCLAS"
+        ]
+      },
+      {
+        "name": "Lifetime Real Women",
+        "number": 143,
+        "aliases": [
+          "LRW",
+          "29612",
+          "143 LRW"
+        ]
+      },
+      {
+        "name": "UPtv",
+        "number": 145,
+        "aliases": [
+          "UP",
+          "44940",
+          "145 UP",
+          "UPHD",
+          "66143",
+          "1317 UPHD"
+        ]
+      },
+      {
+        "name": "TV One",
+        "number": 146,
+        "aliases": [
+          "TVONE",
+          "TVONEHD",
+          "35513",
+          "61960",
+          "146 TVONE"
+        ]
+      },
+      {
+        "name": "LOGO",
+        "number": 147,
+        "aliases": [
+          "LOGOHD",
+          "46762",
+          "96971",
+          "147 LOGO"
+        ]
+      },
+      {
+        "name": "VICE",
+        "number": 152,
+        "aliases": [
+          "VICEHD",
+          "18822",
+          "65732",
+          "152 VICE"
+        ]
+      },
+      {
+        "name": "BET Jams",
+        "number": 154,
+        "aliases": [
+          "BETJ",
+          "30419",
+          "154 BETJ"
+        ]
+      },
+      {
+        "name": "NMZK",
+        "number": 163,
+        "aliases": [
+          "30418",
+          "163 NMZK"
+        ]
+      },
+      {
+        "name": "CLEO",
+        "number": 167,
+        "aliases": [
+          "CLEOHD",
+          "110288",
+          "110289",
+          "167 CLEO"
+        ]
+      },
+      {
+        "name": "TheGrio",
+        "number": 168,
+        "aliases": [
+          "GRIOE",
+          "GRIO",
+          "116533",
+          "168 GRIOE"
+        ]
+      },
+      {
+        "name": "MILH",
+        "number": 169,
+        "aliases": [
+          "48999",
+          "169 MILH"
+        ]
+      },
+      {
+        "name": "CIN",
+        "number": 170,
+        "aliases": [
+          "CINHD",
+          "48543",
+          "61469",
+          "170 CIN"
+        ]
+      },
+      {
+        "name": "DYSTR",
+        "number": 171,
+        "aliases": [
+          "DYSTRHD",
+          "19026",
+          "87001",
+          "171 DYSTR"
+        ]
+      },
+      {
+        "name": "WORD",
+        "number": 173,
+        "aliases": [
+          "WORD-TV",
+          "21781",
+          "173 WORD"
+        ]
+      },
+      {
+        "name": "Pop",
+        "number": 178,
+        "aliases": [
+          "POPSD",
+          "POP",
+          "POPHD",
+          "16715",
+          "68796",
+          "178 POPSD"
+        ]
+      },
+      {
+        "name": "AspireTV",
+        "number": 180,
+        "aliases": [
+          "ASPRE",
+          "ASPiRE",
+          "ASPREHD",
+          "76126",
+          "97409",
+          "180 ASPRE"
+        ]
+      },
+      {
+        "name": "FOXWXSD",
+        "number": 181,
+        "aliases": [
+          "FOXWX",
+          "123194",
+          "93141",
+          "181 FOXWXSD"
+        ]
+      },
+      {
+        "name": "LOVE",
+        "number": 187,
+        "aliases": [
+          "71533",
+          "187 LOVE"
+        ]
+      },
+      {
+        "name": "FETV",
+        "number": 192,
+        "aliases": [
+          "73413",
+          "192 FETV"
+        ]
+      },
+      {
+        "name": "INSP",
+        "number": 196,
+        "aliases": [
+          "INSPHD",
+          "11066",
+          "82773",
+          "196 INSP"
+        ]
+      },
+      {
+        "name": "The Cowboy Channel",
+        "number": 198,
+        "aliases": [
+          "COWBOY",
+          "10188",
+          "198 COWBOY"
+        ]
+      },
+      {
+        "name": "JEWISH",
+        "number": 330,
+        "aliases": [
+          "58400",
+          "330 JEWISH"
+        ]
+      },
+      {
+        "name": "CARSTV",
+        "number": 334,
+        "aliases": [
+          "71302",
+          "334 CARSTV"
+        ]
+      },
+      {
+        "name": "PETSTV",
+        "number": 336,
+        "aliases": [
+          "71297",
+          "336 PETSTV"
+        ]
+      },
+      {
+        "name": "RECIPE",
+        "number": 337,
+        "aliases": [
+          "71294",
+          "337 RECIPE"
+        ]
+      },
+      {
+        "name": "AFRCA",
+        "number": 369,
+        "aliases": [
+          "AFRCAHD",
+          "47472",
+          "68576",
+          "369 AFRCA"
+        ]
+      },
+      {
+        "name": "AWEHD",
+        "number": 376,
+        "aliases": [
+          "45438",
+          "376 AWEHD"
+        ]
+      },
+      {
+        "name": "HERETV",
+        "number": 398,
+        "aliases": [
+          "45210",
+          "398 HERETV"
+        ]
+      },
+      {
+        "name": "IMPACSD",
+        "number": 474,
+        "aliases": [
+          "138982",
+          "474 IMPACSD"
+        ]
+      },
+      {
+        "name": "FREFMHD",
+        "number": 1112,
+        "aliases": [
+          "59615",
+          "1112 FREFMHD"
+        ]
+      },
+      {
+        "name": "SONLFHD",
+        "number": 1116,
+        "aliases": [
+          "91314",
+          "1116 SONLFHD"
+        ]
+      },
+      {
+        "name": "COWBOYH",
+        "number": 1120,
+        "aliases": [
+          "80597",
+          "1120 COWBOYH"
+        ]
+      },
+      {
+        "name": "HFM",
+        "number": 1124,
+        "aliases": [
+          "105723",
+          "1124 HFM"
+        ]
+      },
+      {
+        "name": "LNLC",
+        "number": 1126,
+        "aliases": [
+          "183475",
+          "1126 LNLC"
+        ]
+      },
+      {
+        "name": "SPCTSN",
+        "number": 1134,
+        "aliases": [
+          "77423",
+          "1134 SPCTSN"
+        ]
+      },
+      {
+        "name": "YESNATD",
+        "number": 1142,
+        "aliases": [
+          "63558",
+          "1142 YESNATD"
+        ]
+      },
+      {
+        "name": "SUNNHD",
+        "number": 1148,
+        "aliases": [
+          "54994",
+          "1148 SUNNHD"
+        ]
+      },
+      {
+        "name": "FDFL1HD",
+        "number": 1149,
+        "aliases": [
+          "65773",
+          "1149 FDFL1HD"
+        ]
+      },
+      {
+        "name": "OUTHD",
+        "number": 1156,
+        "aliases": [
+          "46737",
+          "1156 OUTHD"
+        ]
+      },
+      {
+        "name": "FSCPLHD",
+        "number": 1160,
+        "aliases": [
+          "66880",
+          "1160 FSCPLHD"
+        ]
+      },
+      {
+        "name": "NESNATH",
+        "number": 1162,
+        "aliases": [
+          "67518",
+          "1162 NESNATH"
+        ]
+      },
+      {
+        "name": "WLLOHD",
+        "number": 1165,
+        "aliases": [
+          "WLLOHD-TV",
+          "80621",
+          "1165 WLLOHD"
+        ]
+      },
+      {
+        "name": "SPTSNLA",
+        "number": 1179,
+        "aliases": [
+          "87107",
+          "1179 SPTSNLA"
+        ]
+      },
+      {
+        "name": "ACUWTHH",
+        "number": 1208,
+        "aliases": [
+          "91994",
+          "1208 ACUWTHH"
+        ]
+      },
+      {
+        "name": "NY1HD",
+        "number": 1210,
+        "aliases": [
+          "60159",
+          "1210 NY1HD"
+        ]
+      },
+      {
+        "name": "CHDDRHD",
+        "number": 1212,
+        "aliases": [
+          "109332",
+          "1212 CHDDRHD"
+        ]
+      },
+      {
+        "name": "CFLNHD",
+        "number": 1213,
+        "aliases": [
+          "70273",
+          "1213 CFLNHD"
+        ]
+      },
+      {
+        "name": "STELLAR",
+        "number": 1229,
+        "aliases": [
+          "130088",
+          "1229 STELLAR"
+        ]
+      },
+      {
+        "name": "MTHD",
+        "number": 1235,
+        "aliases": [
+          "31046",
+          "1235 MTHD"
+        ]
+      },
+      {
+        "name": "TBSHTPA",
+        "number": 1236,
+        "aliases": [
+          "77583",
+          "1236 TBSHTPA"
+        ]
+      },
+      {
+        "name": "HERICNS",
+        "number": 1243,
+        "aliases": [
+          "110477",
+          "1243 HERICNS"
+        ]
+      },
+      {
+        "name": "EARTHX",
+        "number": 1258,
+        "aliases": [
+          "126128",
+          "1258 EARTHX"
+        ]
+      },
+      {
+        "name": "NGWIHD",
+        "number": 1262,
+        "aliases": [
+          "67331",
+          "1262 NGWIHD"
+        ]
+      },
+      {
+        "name": "TWCTRVH",
+        "number": 1267,
+        "aliases": [
+          "87182",
+          "1267 TWCTRVH"
+        ]
+      },
+      {
+        "name": "STRY",
+        "number": 1274,
+        "aliases": [
+          "122968",
+          "1274 STRY"
+        ]
+      },
+      {
+        "name": "STARTTV",
+        "number": 1275,
+        "aliases": [
+          "109454",
+          "1275 STARTTV"
+        ]
+      },
+      {
+        "name": "CHIMETV",
+        "number": 1276,
+        "aliases": [
+          "131889",
+          "1276 CHIMETV"
+        ]
+      },
+      {
+        "name": "ENVOYTV",
+        "number": 1279,
+        "aliases": [
+          "192894",
+          "1279 ENVOYTV"
+        ]
+      },
+      {
+        "name": "FXX",
+        "number": 1284,
+        "aliases": [
+          "FXXHD",
+          "66379",
+          "1284 FXXHD"
+        ]
+      },
+      {
+        "name": "MTVL",
+        "number": 1300,
+        "aliases": [
+          "MTVLIVE",
+          "49141",
+          "1300 MTVLIVE"
+        ]
+      },
+      {
+        "name": "AXSTV",
+        "number": 1303,
+        "aliases": [
+          "28506",
+          "1303 AXSTV"
+        ]
+      },
+      {
+        "name": "FMHD",
+        "number": 1311,
+        "aliases": [
+          "72094",
+          "1311 FMHD"
+        ]
+      },
+      {
+        "name": "CARSTVH",
+        "number": 1334,
+        "aliases": [
+          "81270",
+          "1334 CARSTVH"
+        ]
+      },
+      {
+        "name": "JUST",
+        "number": 1335,
+        "aliases": [
+          "78850",
+          "1335 JUST"
+        ]
+      },
+      {
+        "name": "PETSTVH",
+        "number": 1336,
+        "aliases": [
+          "81283",
+          "1336 PETSTVH"
+        ]
+      },
+      {
+        "name": "RECIPEH",
+        "number": 1337,
+        "aliases": [
+          "81289",
+          "1337 RECIPEH"
+        ]
+      },
+      {
+        "name": "SMTHHD",
+        "number": 1370,
+        "aliases": [
+          "58532",
+          "1370 SMTHHD"
+        ]
+      },
+      {
+        "name": "HDNETMV",
+        "number": 1375,
+        "aliases": [
+          "33668",
+          "1375 HDNETMV"
+        ]
+      },
+      {
+        "name": "SZECLHD",
+        "number": 1379,
+        "aliases": [
+          "83404",
+          "1379 SZECLHD"
+        ]
+      },
+      {
+        "name": "SZESUHD",
+        "number": 1381,
+        "aliases": [
+          "83076",
+          "1381 SZESUHD"
+        ]
+      },
+      {
+        "name": "SZEAHD",
+        "number": 1382,
+        "aliases": [
+          "72015",
+          "1382 SZEAHD"
+        ]
+      },
+      {
+        "name": "SZEBHD",
+        "number": 1383,
+        "aliases": [
+          "72014",
+          "1383 SZEBHD"
+        ]
+      },
+      {
+        "name": "SZENHP",
+        "number": 1388,
+        "aliases": [
+          "67237",
+          "1388 SZENHP"
+        ]
+      },
+      {
+        "name": "SETHHD",
+        "number": 1561,
+        "aliases": [
+          "79610",
+          "1561 SETHHD"
+        ]
+      }
+    ],
+    "Lifestyle": [
+      {
+        "name": "OWN",
+        "number": 24,
+        "aliases": [
+          "OWNHD",
+          "70387",
+          "70388",
+          "24 OWN"
+        ]
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 34,
+        "aliases": [
+          "DSC",
+          "DISC",
+          "DSCHD",
+          "11150",
+          "56905",
+          "34 DSC"
+        ]
+      },
+      {
+        "name": "Animal Planet",
+        "number": 35,
+        "aliases": [
+          "APL",
+          "ANPL",
+          "APLHD",
+          "16331",
+          "57394",
+          "35 APL"
+        ]
+      },
+      {
+        "name": "Lifetime",
+        "number": 38,
+        "aliases": [
+          "LIFE",
+          "LIFEHD",
+          "10918",
+          "60150",
+          "38 LIFE"
+        ]
+      },
+      {
+        "name": "Oxygen",
+        "number": 44,
+        "aliases": [
+          "OXYGEN",
+          "OXY",
+          "21484",
+          "44 OXYGEN",
+          "70522",
+          "1271 OXYGNHD",
+          "OXYGNHD"
+        ]
+      },
+      {
+        "name": "TLC",
+        "number": 46,
+        "aliases": [
+          "TLCHD",
+          "11158",
+          "57391",
+          "46 TLC"
+        ]
+      },
+      {
+        "name": "Lifetime Movie Network",
+        "number": 50,
+        "aliases": [
+          "LMN",
+          "LMNHD",
+          "18480",
+          "55887",
+          "50 LMN"
+        ]
+      },
+      {
+        "name": "BRAVO",
+        "number": 51,
+        "aliases": [
+          "BRAVOHD",
+          "Bravo",
+          "10057",
+          "58625",
+          "51 BRAVO"
+        ]
+      },
+      {
+        "name": "History",
+        "number": 54,
+        "aliases": [
+          "HISTORY",
+          "HIST",
+          "14771",
+          "54 HISTORY",
+          "HSTRYHD",
+          "57708",
+          "1242 HSTRYHD"
+        ]
+      },
+      {
+        "name": "FOOD",
+        "number": 56,
+        "aliases": [
+          "FOODHD",
+          "12574",
+          "50747",
+          "56 FOOD"
+        ]
+      },
+      {
+        "name": "HGTV",
+        "number": 57,
+        "aliases": [
+          "14902",
+          "57 HGTV",
+          "49788",
+          "1250 HGTVD",
+          "HGTVD"
+        ]
+      },
+      {
+        "name": "National Geographic",
+        "number": 65,
+        "aliases": [
+          "NGC",
+          "NGCHD",
+          "24959",
+          "49438",
+          "65 NGC"
+        ]
+      },
+      {
+        "name": "Hallmark Channel",
+        "number": 68,
+        "aliases": [
+          "HALL",
+          "HALLHD",
+          "11221",
+          "66268",
+          "68 HALL"
+        ]
+      },
+      {
+        "name": "Travel Channel",
+        "number": 90,
+        "aliases": [
+          "TRAV",
+          "TRAVEL",
+          "11180",
+          "90 TRAV"
+        ]
+      },
+      {
+        "name": "RFD-TV",
+        "number": 98,
+        "aliases": [
+          "RFDTV",
+          "RFD",
+          "25148",
+          "98 RFDTV"
+        ]
+      },
+      {
+        "name": "Science Channel",
+        "number": 100,
+        "aliases": [
+          "SCIENCE",
+          "SCI",
+          "16616",
+          "100 SCIENCE",
+          "SCIHD",
+          "57390",
+          "1265 SCIHD"
+        ]
+      },
+      {
+        "name": "American Heroes Channel",
+        "number": 103,
+        "aliases": [
+          "AHC",
+          "AHCHD",
+          "18284",
+          "78808",
+          "103 AHC"
+        ]
+      },
+      {
+        "name": "FYI",
+        "number": 104,
+        "aliases": [
+          "FYISD",
+          "FYIHD",
+          "16834",
+          "58988",
+          "104 FYISD"
+        ]
+      },
+      {
+        "name": "Destination America",
+        "number": 108,
+        "aliases": [
+          "DEST",
+          "DESTHD",
+          "16617",
+          "60468",
+          "108 DEST"
+        ]
+      },
+      {
+        "name": "Discovery Life",
+        "number": 114,
+        "aliases": [
+          "DLC",
+          "DLCHD",
+          "16125",
+          "92204",
+          "114 DLC"
+        ]
+      },
+      {
+        "name": "Investigation Discovery",
+        "number": 135,
+        "aliases": [
+          "ID",
+          "16615",
+          "135 ID",
+          "IDHD",
+          "65342",
+          "1246 IDHD"
+        ]
+      },
+      {
+        "name": "Magnolia Network",
+        "number": 136,
+        "aliases": [
+          "MAGN",
+          "MAGNHD",
+          "18544",
+          "67375",
+          "136 MAGN"
+        ]
+      },
+      {
+        "name": "Cooking Channel",
+        "number": 142,
+        "aliases": [
+          "COOK",
+          "COOKHD",
+          "30156",
+          "68065",
+          "142 COOK"
+        ]
+      },
+      {
+        "name": "Ovation",
+        "number": 164,
+        "aliases": [
+          "OVATION",
+          "OVA",
+          "15807",
+          "164 OVATION",
+          "69061",
+          "1277 OVATNHD",
+          "OVATNHD"
+        ]
+      },
+      {
+        "name": "Smithsonian Channel",
+        "number": 370,
+        "aliases": [
+          "SMITH",
+          "65799",
+          "370 SMITH"
+        ]
+      },
+      {
+        "name": "RFDHD",
+        "number": 1305,
+        "aliases": [
+          "63717",
+          "1305 RFDHD"
+        ]
+      }
+    ],
+    "Movies": [
+      {
+        "name": "TCM",
+        "number": 53,
+        "aliases": [
+          "TCMHD",
+          "12852",
+          "64312",
+          "53 TCM"
+        ]
+      },
+      {
+        "name": "AMC",
+        "number": 64,
+        "aliases": [
+          "AMCHD",
+          "10021",
+          "59337",
+          "64 AMC"
+        ]
+      },
+      {
+        "name": "REELZ",
+        "number": 354,
+        "aliases": [
+          "REELZHD",
+          "52199",
+          "68385",
+          "354 REELZ"
+        ]
+      },
+      {
+        "name": "SundanceTV",
+        "number": 374,
+        "aliases": [
+          "SUNDANC",
+          "16108",
+          "374 SUNDANC"
+        ]
+      },
+      {
+        "name": "IFC",
+        "number": 384,
+        "aliases": [
+          "IFCHD",
+          "14873",
+          "59444",
+          "384 IFC"
+        ]
+      },
+      {
+        "name": "Hallmark Mystery",
+        "number": 385,
+        "aliases": [
+          "HMYS",
+          "HMYSHD",
+          "61522",
+          "46710",
+          "385 HMYS"
+        ]
+      },
+      {
+        "name": "SUNDHD",
+        "number": 1356,
+        "aliases": [
+          "71280",
+          "1356 SUNDHD"
+        ]
+      },
+      {
+        "name": "FXMHD",
+        "number": 1389,
+        "aliases": [
+          "70253",
+          "1389 FXMHD"
+        ]
+      }
+    ],
+    "Kids": [
+      {
+        "name": "Nickelodeon",
+        "number": 36,
+        "aliases": [
+          "NIK",
+          "NICK",
+          "NIKHD",
+          "11006",
+          "59432",
+          "36 NIK"
+        ]
+      },
+      {
+        "name": "DISN",
+        "number": 40,
+        "aliases": [
+          "DISNHD",
+          "10171",
+          "59684",
+          "40 DISN"
+        ]
+      },
+      {
+        "name": "TOON",
+        "number": 58,
+        "aliases": [
+          "TOONHD",
+          "12131",
+          "60048",
+          "58 TOON"
+        ]
+      },
+      {
+        "name": "Boomerang",
+        "number": 124,
+        "aliases": [
+          "BOOM",
+          "21883",
+          "124 BOOM"
+        ]
+      },
+      {
+        "name": "Nick Jr.",
+        "number": 125,
+        "aliases": [
+          "NICJR",
+          "NICKJ",
+          "NICJRHD",
+          "19211",
+          "82649",
+          "125 NICJR"
+        ]
+      },
+      {
+        "name": "TeenNick",
+        "number": 140,
+        "aliases": [
+          "TNCK",
+          "TNICK",
+          "TNCKHD",
+          "59036",
+          "97047",
+          "140 TNCK"
+        ]
+      },
+      {
+        "name": "Nicktoons",
+        "number": 144,
+        "aliases": [
+          "NIKTON",
+          "30420",
+          "144 NIKTON"
+        ]
+      },
+      {
+        "name": "BabyFirst",
+        "number": 174,
+        "aliases": [
+          "BABY1",
+          "50338",
+          "174 BABY1"
+        ]
+      },
+      {
+        "name": "DJCHHD",
+        "number": 1106,
+        "aliases": [
+          "74885",
+          "1106 DJCHHD"
+        ]
+      },
+      {
+        "name": "DXDHD",
+        "number": 1107,
+        "aliases": [
+          "60006",
+          "1107 DXDHD"
+        ]
+      },
+      {
+        "name": "NIKTNHD",
+        "number": 1111,
+        "aliases": [
+          "82654",
+          "1111 NIKTNHD"
+        ]
+      }
+    ],
+    "Premium": [
+      {
+        "name": "HBO",
+        "number": 201,
+        "aliases": [
+          "HBOHD",
+          "10240",
+          "19548",
+          "201 HBO",
+          "HBOP",
+          "10244",
+          "208 HBOP",
+          "HBOHDP",
+          "19566",
+          "1408 HBOHDP"
+        ]
+      },
+      {
+        "name": "HBOHIT",
+        "number": 202,
+        "aliases": [
+          "HBOHTS",
+          "10241",
+          "202 HBOHTS",
+          "HBOHTP",
+          "10242",
+          "209 HBOHTP",
+          "HBOHTHD",
+          "59368",
+          "1402 HBOHTHD"
+        ]
+      },
+      {
+        "name": "HBODRMA",
+        "number": 203,
+        "aliases": [
+          "10243",
+          "203 HBODRMA",
+          "HBODRP",
+          "16576",
+          "210 HBODRP",
+          "HBODRHD",
+          "59363",
+          "1403 HBODRHD"
+        ]
+      },
+      {
+        "name": "HBOC",
+        "number": 205,
+        "aliases": [
+          "HBOCHD",
+          "18429",
+          "59839",
+          "205 HBOC",
+          "HBOCP",
+          "18430",
+          "212 HBOCP"
+        ]
+      },
+      {
+        "name": "HBOMOV",
+        "number": 206,
+        "aliases": [
+          "18431",
+          "206 HBOMOV",
+          "HBOMVP",
+          "18432",
+          "213 HBOMVP",
+          "HBOMVHD",
+          "59845",
+          "1406 HBOMVHD"
+        ]
+      },
+      {
+        "name": "Cinemax",
+        "number": 221,
+        "aliases": [
+          "MAX",
+          "MAX1",
+          "MAXHD",
+          "10120",
+          "34933",
+          "221 MAX",
+          "MAXP",
+          "12508",
+          "229 MAXP",
+          "MAXHDP",
+          "35975",
+          "1429 MAXHDP"
+        ]
+      },
+      {
+        "name": "CINEHIT",
+        "number": 222,
+        "aliases": [
+          "10121",
+          "222 CINEHIT",
+          "CINEHP",
+          "16620",
+          "230 CINEHP",
+          "CINEHHD",
+          "59373",
+          "1422 CINEHHD"
+        ]
+      },
+      {
+        "name": "CINACT",
+        "number": 223,
+        "aliases": [
+          "18433",
+          "223 CINACT",
+          "CINACSP",
+          "18434",
+          "231 CINACSP",
+          "CINACHD",
+          "59948",
+          "1423 CINACHD"
+        ]
+      },
+      {
+        "name": "CINECLS",
+        "number": 227,
+        "aliases": [
+          "25620",
+          "227 CINECLS",
+          "CINCLHD",
+          "59961",
+          "1427 CINCLHD"
+        ]
+      },
+      {
+        "name": "Paramount+ with SHOWTIME",
+        "number": 241,
+        "aliases": [
+          "PARSHO",
+          "11115",
+          "241 PARSHO",
+          "PARSHOW",
+          "11117",
+          "249 PARSHOW",
+          "PARSHOH",
+          "21868",
+          "1441 PARSHOH",
+          "PASHOHW",
+          "22532",
+          "1449 PASHOHW"
+        ]
+      },
+      {
+        "name": "SHO2",
+        "number": 242,
+        "aliases": [
+          "SHO2HD",
+          "11116",
+          "58533",
+          "242 SHO2",
+          "SHO2P",
+          "16444",
+          "250 SHO2P"
+        ]
+      },
+      {
+        "name": "SHOCSE",
+        "number": 243,
+        "aliases": [
+          "16153",
+          "243 SHOCSE",
+          "SHOCSEP",
+          "16584",
+          "251 SHOCSEP",
+          "SHOCSHD",
+          "61001",
+          "1443 SHOCSHD"
+        ]
+      },
+      {
+        "name": "WOMEN",
+        "number": 244,
+        "aliases": [
+          "WOMENHD",
+          "WOMEN-TV",
+          "25272",
+          "68338",
+          "244 WOMEN",
+          "WOMENP",
+          "WOMENP-TV",
+          "25273",
+          "252 WOMENP"
+        ]
+      },
+      {
+        "name": "SHOBET",
+        "number": 245,
+        "aliases": [
+          "20622",
+          "245 SHOBET",
+          "SHOBETP",
+          "20625",
+          "253 SHOBETP",
+          "SHOBETH",
+          "68340",
+          "1445 SHOBETH"
+        ]
+      },
+      {
+        "name": "NEXT",
+        "number": 246,
+        "aliases": [
+          "NEXTHD",
+          "25270",
+          "68342",
+          "246 NEXT",
+          "NEXTP",
+          "25271",
+          "254 NEXTP"
+        ]
+      },
+      {
+        "name": "SHOWX",
+        "number": 247,
+        "aliases": [
+          "SHOWXHD",
+          "18086",
+          "60947",
+          "247 SHOWX",
+          "SHOWXP",
+          "18164",
+          "255 SHOWXP"
+        ]
+      },
+      {
+        "name": "FAMZ",
+        "number": 248,
+        "aliases": [
+          "25274",
+          "248 FAMZ",
+          "FAMZP",
+          "25275",
+          "256 FAMZP"
+        ]
+      },
+      {
+        "name": "The Movie Channel",
+        "number": 261,
+        "aliases": [
+          "TMC",
+          "TMCHD",
+          "11160",
+          "35329",
+          "261 TMC",
+          "TMCP",
+          "12509",
+          "263 TMCP"
+        ]
+      },
+      {
+        "name": "TMCX",
+        "number": 262,
+        "aliases": [
+          "TMCXHD",
+          "17663",
+          "60951",
+          "262 TMCX",
+          "TMCXP",
+          "TMCXPHD",
+          "17687",
+          "60949",
+          "264 TMCXP"
+        ]
+      },
+      {
+        "name": "STARZ",
+        "number": 271,
+        "aliases": [
+          "12719",
+          "271 STARZ",
+          "STZHD",
+          "34941",
+          "1466 STZHD"
+        ]
+      },
+      {
+        "name": "STZE",
+        "number": 272,
+        "aliases": [
+          "STZEHD",
+          "16311",
+          "57573",
+          "272 STZE"
+        ]
+      },
+      {
+        "name": "STZIB",
+        "number": 273,
+        "aliases": [
+          "16833",
+          "273 STZIB",
+          "STRZIBH",
+          "67235",
+          "1469 STRZIBH"
+        ]
+      },
+      {
+        "name": "SRZK",
+        "number": 274,
+        "aliases": [
+          "STZK",
+          "STZKHD",
+          "19635",
+          "57581",
+          "274 STZK"
+        ]
+      },
+      {
+        "name": "STZCI",
+        "number": 275,
+        "aliases": [
+          "19634",
+          "275 STZCI",
+          "STRZCIH",
+          "67236",
+          "1471 STRZCIH"
+        ]
+      },
+      {
+        "name": "SRZC",
+        "number": 276,
+        "aliases": [
+          "STZC",
+          "STZCHD",
+          "34901",
+          "57569",
+          "276 STZC"
+        ]
+      },
+      {
+        "name": "MGM+",
+        "number": 364,
+        "aliases": [
+          "MGM",
+          "MGMHD",
+          "65669",
+          "65687",
+          "364 MGM"
+        ]
+      },
+      {
+        "name": "MGMHIT",
+        "number": 365,
+        "aliases": [
+          "73075",
+          "365 MGMHIT",
+          "MGMHTH",
+          "67929",
+          "1365 MGMHTH",
+          "MGM+ Hits HD"
+        ]
+      },
+      {
+        "name": "MGM+ Drive-In",
+        "number": 367,
+        "aliases": [
+          "MGMDRV",
+          "68409",
+          "367 MGMDRV"
+        ]
+      },
+      {
+        "name": "Flix",
+        "number": 371,
+        "aliases": [
+          "FLIX",
+          "10201",
+          "371 FLIX",
+          "FLIXP",
+          "16575",
+          "372 FLIXP"
+        ]
+      },
+      {
+        "name": "STZENC",
+        "number": 377,
+        "aliases": [
+          "10178",
+          "377 STZENC",
+          "STZENHD",
+          "36225",
+          "1377 STZENHD"
+        ]
+      },
+      {
+        "name": "STZEFM",
+        "number": 378,
+        "aliases": [
+          "STZENFS",
+          "102903",
+          "378 STZENFS"
+        ]
+      },
+      {
+        "name": "STZECL",
+        "number": 379,
+        "aliases": [
+          "STZENCL",
+          "14764",
+          "379 STZENCL"
+        ]
+      },
+      {
+        "name": "STZEWSS",
+        "number": 380,
+        "aliases": [
+          "102906",
+          "380 STZEWSS"
+        ]
+      },
+      {
+        "name": "STZESU",
+        "number": 381,
+        "aliases": [
+          "STZENSU",
+          "14766",
+          "381 STZENSU"
+        ]
+      },
+      {
+        "name": "STZEAC",
+        "number": 382,
+        "aliases": [
+          "STZENAC",
+          "14871",
+          "382 STZENAC"
+        ]
+      },
+      {
+        "name": "STZEBK",
+        "number": 383,
+        "aliases": [
+          "STZENBK",
+          "14870",
+          "383 STZENBK"
+        ]
+      },
+      {
+        "name": "RetroPlex",
+        "number": 386,
+        "aliases": [
+          "RETRO",
+          "RETROHD",
+          "49767",
+          "65791",
+          "386 RETRO"
+        ]
+      },
+      {
+        "name": "IndiePlex",
+        "number": 387,
+        "aliases": [
+          "INDIE",
+          "INDIE-E",
+          "INDIEHD",
+          "49751",
+          "65795",
+          "387 INDIE"
+        ]
+      },
+      {
+        "name": "STZENCP",
+        "number": 388,
+        "aliases": [
+          "17125",
+          "388 STZENCP"
+        ]
+      },
+      {
+        "name": "STZENFP",
+        "number": 389,
+        "aliases": [
+          "17131",
+          "389 STZENFP"
+        ]
+      },
+      {
+        "name": "STZESP",
+        "number": 390,
+        "aliases": [
+          "72016",
+          "390 STZESP"
+        ]
+      },
+      {
+        "name": "MoviePlex",
+        "number": 391,
+        "aliases": [
+          "MPLEX",
+          "PLEX",
+          "MPLEXHD",
+          "15295",
+          "83075",
+          "391 MPLEX"
+        ]
+      },
+      {
+        "name": "MGM+ Marquee",
+        "number": 1366,
+        "aliases": [
+          "74073",
+          "1366 MGMMRHD",
+          "MGMMRHD",
+          "MGM+ Marquee HD"
+        ]
+      }
+    ],
+    "Faith": [
+      {
+        "name": "EWTN",
+        "number": 111,
+        "aliases": [
+          "EWTNHD",
+          "10183",
+          "67164",
+          "111 EWTN"
+        ]
+      },
+      {
+        "name": "TBN",
+        "number": 131,
+        "aliases": [
+          "14767",
+          "131 TBN"
+        ]
+      },
+      {
+        "name": "JLT",
+        "number": 172,
+        "aliases": [
+          "JLTV",
+          "60165",
+          "172 JLTV"
+        ]
+      },
+      {
+        "name": "BYUtv",
+        "number": 197,
+        "aliases": [
+          "BYUTV",
+          "BYU",
+          "BYUTVHD",
+          "21855",
+          "71764",
+          "197 BYUTV"
+        ]
+      },
+      {
+        "name": "SonLife Broadcasting Network",
+        "number": 199,
+        "aliases": [
+          "SBND",
+          "67676",
+          "30324",
+          "199 SBND"
+        ]
+      },
+      {
+        "name": "JBS",
+        "number": 1223,
+        "aliases": [
+          "74978",
+          "1223 JBS"
+        ]
+      }
+    ],
+    "Shopping": [
+      {
+        "name": "HSN",
+        "number": 101,
+        "aliases": [
+          "HSNHD",
+          "10269",
+          "62077",
+          "101 HSN"
+        ]
+      },
+      {
+        "name": "QVC",
+        "number": 130,
+        "aliases": [
+          "QVCHD",
+          "11069",
+          "60222",
+          "130 QVC"
+        ]
+      },
+      {
+        "name": "HSN2",
+        "number": 161,
+        "aliases": [
+          "10270",
+          "161 HSN2"
+        ]
+      },
+      {
+        "name": "QVC2",
+        "number": 162,
+        "aliases": [
+          "QVC2HD",
+          "82682",
+          "82696",
+          "162 QVC2"
+        ]
+      },
+      {
+        "name": "GEMSSD",
+        "number": 184,
+        "aliases": [
+          "GEMSHD",
+          "26643",
+          "109264",
+          "184 GEMSSD"
+        ]
+      },
+      {
+        "name": "SHOPLC",
+        "number": 185,
+        "aliases": [
+          "56032",
+          "185 SHOPLC"
+        ]
+      },
+      {
+        "name": "JTV",
+        "number": 1328,
+        "aliases": [
+          "JTVHD",
+          "65556",
+          "1328 JTVHD"
+        ]
+      },
+      {
+        "name": "SHOPLCH",
+        "number": 1330,
+        "aliases": [
+          "93564",
+          "1330 SHOPLCH"
+        ]
+      },
+      {
+        "name": "QVC3",
+        "number": 1332,
+        "aliases": [
+          "101260",
+          "1332 QVC3"
+        ]
+      }
+    ],
+    "International": [
+      {
+        "name": "ART America",
+        "number": 501,
+        "aliases": [
+          "ARTAMER",
+          "19979",
+          "501 ARTAMER"
+        ]
+      },
+      {
+        "name": "The Arabic Channel",
+        "number": 502,
+        "aliases": [
+          "ARABCH",
+          "23775",
+          "502 ARABCH"
+        ]
+      },
+      {
+        "name": "SBN",
+        "number": 505,
+        "aliases": [
+          "505 SBN"
+        ]
+      },
+      {
+        "name": "TVBV",
+        "number": 506,
+        "aliases": [
+          "53070",
+          "506 TVBV"
+        ]
+      },
+      {
+        "name": "RGTI",
+        "number": 510,
+        "aliases": [
+          "21065",
+          "510 RGTI"
+        ]
+      },
+      {
+        "name": "RTP Internacional",
+        "number": 512,
+        "aliases": [
+          "RTPI",
+          "15717",
+          "512 RTPI"
+        ]
+      },
+      {
+        "name": "TVB1",
+        "number": 515,
+        "aliases": [
+          "16333",
+          "515 TVB1"
+        ]
+      },
+      {
+        "name": "TVBDC",
+        "number": 516,
+        "aliases": [
+          "32145",
+          "516 TVBDC"
+        ]
+      },
+      {
+        "name": "TVBE",
+        "number": 517,
+        "aliases": [
+          "21187",
+          "517 TVBE"
+        ]
+      },
+      {
+        "name": "TVBNW",
+        "number": 518,
+        "aliases": [
+          "32147",
+          "518 TVBNW"
+        ]
+      },
+      {
+        "name": "FILPEHD",
+        "number": 520,
+        "aliases": [
+          "114048",
+          "520 FILPEHD"
+        ]
+      },
+      {
+        "name": "GMAPNY",
+        "number": 521,
+        "aliases": [
+          "46463",
+          "521 GMAPNY"
+        ]
+      },
+      {
+        "name": "GMALIFE",
+        "number": 522,
+        "aliases": [
+          "60152",
+          "522 GMALIFE"
+        ]
+      },
+      {
+        "name": "LSNET",
+        "number": 523,
+        "aliases": [
+          "80214",
+          "523 LSNET"
+        ]
+      },
+      {
+        "name": "DWLSRA",
+        "number": 524,
+        "aliases": [
+          "67374",
+          "524 DWLSRA"
+        ]
+      },
+      {
+        "name": "DZBBRA",
+        "number": 525,
+        "aliases": [
+          "67373",
+          "525 DZBBRA"
+        ]
+      },
+      {
+        "name": "RT",
+        "number": 530,
+        "aliases": [
+          "RTN",
+          "18424",
+          "530 RTN"
+        ]
+      },
+      {
+        "name": "RUSKINO",
+        "number": 531,
+        "aliases": [
+          "61399",
+          "531 RUSKINO"
+        ]
+      },
+      {
+        "name": "RTVi",
+        "number": 536,
+        "aliases": [
+          "RTVINT",
+          "21063",
+          "536 RTVINT"
+        ]
+      },
+      {
+        "name": "ANTEN",
+        "number": 557,
+        "aliases": [
+          "16372",
+          "557 ANTEN"
+        ]
+      },
+      {
+        "name": "ASIA",
+        "number": 560,
+        "aliases": [
+          "14763",
+          "560 ASIA"
+        ]
+      },
+      {
+        "name": "Zee TV",
+        "number": 562,
+        "aliases": [
+          "ZEETVH",
+          "ZEE",
+          "77032",
+          "562 ZEETVH"
+        ]
+      },
+      {
+        "name": "FILMY",
+        "number": 564,
+        "aliases": [
+          "52285",
+          "564 FILMY"
+        ]
+      },
+      {
+        "name": "ABPN",
+        "number": 567,
+        "aliases": [
+          "ABPNWS",
+          "44851",
+          "567 ABPNWS"
+        ]
+      },
+      {
+        "name": "ITVG",
+        "number": 569,
+        "aliases": [
+          "ITVGHD",
+          "21858",
+          "114663",
+          "569 ITVG"
+        ]
+      },
+      {
+        "name": "NDTV2",
+        "number": 570,
+        "aliases": [
+          "49172",
+          "570 NDTV2"
+        ]
+      },
+      {
+        "name": "Rai Italia",
+        "number": 574,
+        "aliases": [
+          "RAII",
+          "17250",
+          "574 RAII"
+        ]
+      },
+      {
+        "name": "MITALIA",
+        "number": 575,
+        "aliases": [
+          "69529",
+          "575 MITALIA"
+        ]
+      },
+      {
+        "name": "TV5MONDE",
+        "number": 577,
+        "aliases": [
+          "TV5MOND",
+          "19059",
+          "577 TV5MOND"
+        ]
+      },
+      {
+        "name": "TVK1",
+        "number": 580,
+        "aliases": [
+          "46384",
+          "580 TVK1"
+        ]
+      },
+      {
+        "name": "TVK2",
+        "number": 581,
+        "aliases": [
+          "66157",
+          "581 TVK2"
+        ]
+      },
+      {
+        "name": "KBS World",
+        "number": 583,
+        "aliases": [
+          "KBSAM",
+          "KBSAM-TV",
+          "34164",
+          "583 KBSAM"
+        ]
+      },
+      {
+        "name": "MBCD",
+        "number": 584,
+        "aliases": [
+          "70622",
+          "584 MBCD"
+        ]
+      },
+      {
+        "name": "CCTV-4",
+        "number": 590,
+        "aliases": [
+          "CCTV4",
+          "24248",
+          "590 CCTV4"
+        ]
+      },
+      {
+        "name": "CITZTC",
+        "number": 591,
+        "aliases": [
+          "CTIZTC",
+          "20655",
+          "591 CTIZTC"
+        ]
+      },
+      {
+        "name": "ETTV",
+        "number": 592,
+        "aliases": [
+          "57753",
+          "592 ETTV"
+        ]
+      },
+      {
+        "name": "ETDRA",
+        "number": 593,
+        "aliases": [
+          "35271",
+          "593 ETDRA"
+        ]
+      },
+      {
+        "name": "ETCHI",
+        "number": 594,
+        "aliases": [
+          "35272",
+          "594 ETCHI"
+        ]
+      },
+      {
+        "name": "ETFINWS",
+        "number": 595,
+        "aliases": [
+          "66487",
+          "595 ETFINWS"
+        ]
+      },
+      {
+        "name": "YOYO",
+        "number": 596,
+        "aliases": [
+          "35270",
+          "596 YOYO"
+        ]
+      },
+      {
+        "name": "Phoenix InfoNews",
+        "number": 597,
+        "aliases": [
+          "PHNIN",
+          "44617",
+          "597 PHNIN"
+        ]
+      },
+      {
+        "name": "PNAX",
+        "number": 598,
+        "aliases": [
+          "24935",
+          "598 PNAX"
+        ]
+      }
+    ],
+    "Spanish": [
+      {
+        "name": "WVEA-TV",
+        "number": 901,
+        "aliases": [
+          "WVEA",
+          "WVEADT",
+          "15444",
+          "44560",
+          "901 WVEA"
+        ]
+      },
+      {
+        "name": "WRMD-CD",
+        "number": 902,
+        "aliases": [
+          "WRMDCA",
+          "WRMDCA-TV",
+          "11247",
+          "902 WRMDCA"
+        ]
+      },
+      {
+        "name": "WVEA6SD",
+        "number": 903,
+        "aliases": [
+          "WVEA6SD-TV",
+          "122157",
+          "903 WVEA6SD"
+        ]
+      },
+      {
+        "name": "CNN en Español",
+        "number": 904,
+        "aliases": [
+          "CNNE",
+          "58631",
+          "904 CNNE"
+        ]
+      },
+      {
+        "name": "CNL24",
+        "number": 905,
+        "aliases": [
+          "92651",
+          "905 CNL24"
+        ]
+      },
+      {
+        "name": "SUR",
+        "number": 906,
+        "aliases": [
+          "12750",
+          "906 SUR"
+        ]
+      },
+      {
+        "name": "CENTROA",
+        "number": 907,
+        "aliases": [
+          "44448",
+          "907 CENTROA"
+        ]
+      },
+      {
+        "name": "CM",
+        "number": 912,
+        "aliases": [
+          "CMEX",
+          "44714",
+          "912 CMEX"
+        ]
+      },
+      {
+        "name": "FOX Deportes",
+        "number": 915,
+        "aliases": [
+          "FXDEP",
+          "FXDEPHD",
+          "15377",
+          "72189",
+          "915 FXDEP"
+        ]
+      },
+      {
+        "name": "Galavisión",
+        "number": 917,
+        "aliases": [
+          "GALA",
+          "GALAHD",
+          "10222",
+          "68367",
+          "917 GALA"
+        ]
+      },
+      {
+        "name": "WAPAUS",
+        "number": 918,
+        "aliases": [
+          "WAPAUS-TV",
+          "44322",
+          "918 WAPAUS"
+        ]
+      },
+      {
+        "name": "TVE",
+        "number": 919,
+        "aliases": [
+          "TVEI",
+          "16217",
+          "919 TVEI"
+        ]
+      },
+      {
+        "name": "SNNOTFL",
+        "number": 920,
+        "aliases": [
+          "174022",
+          "920 SNNOTFL"
+        ]
+      },
+      {
+        "name": "SORPRESA",
+        "number": 921,
+        "aliases": [
+          "25347",
+          "921 SORPRESA"
+        ]
+      },
+      {
+        "name": "DFAM",
+        "number": 922,
+        "aliases": [
+          "58428",
+          "922 DFAM"
+        ]
+      },
+      {
+        "name": "EWTN Español",
+        "number": 924,
+        "aliases": [
+          "EWTNES",
+          "EWTNE",
+          "52649",
+          "924 EWTNES"
+        ]
+      },
+      {
+        "name": "History en Español",
+        "number": 926,
+        "aliases": [
+          "HISTE",
+          "43362",
+          "926 HISTE"
+        ]
+      },
+      {
+        "name": "COMERTVH",
+        "number": 927,
+        "aliases": [
+          "166714",
+          "927 COMERTVH"
+        ]
+      },
+      {
+        "name": "CINLUS",
+        "number": 928,
+        "aliases": [
+          "62401",
+          "928 CINLUS"
+        ]
+      },
+      {
+        "name": "Universo",
+        "number": 929,
+        "aliases": [
+          "UNVSO",
+          "UNVSOHD",
+          "14791",
+          "91588",
+          "929 UNVSO"
+        ]
+      },
+      {
+        "name": "MTV Tr3s",
+        "number": 930,
+        "aliases": [
+          "TR3S",
+          "18715",
+          "930 TR3S"
+        ]
+      },
+      {
+        "name": "UNI-T",
+        "number": 931,
+        "aliases": [
+          "UNITLNO",
+          "74550",
+          "931 UNITLNO"
+        ]
+      },
+      {
+        "name": "TeleN",
+        "number": 932,
+        "aliases": [
+          "TELEN",
+          "48523",
+          "932 TELEN"
+        ]
+      },
+      {
+        "name": "TVV",
+        "number": 934,
+        "aliases": [
+          "49262",
+          "934 TVV"
+        ]
+      },
+      {
+        "name": "ECUAVI",
+        "number": 935,
+        "aliases": [
+          "44644",
+          "935 ECUAVI"
+        ]
+      },
+      {
+        "name": "CARAI",
+        "number": 936,
+        "aliases": [
+          "39719",
+          "936 CARAI"
+        ]
+      },
+      {
+        "name": "NUESTRT",
+        "number": 937,
+        "aliases": [
+          "33431",
+          "937 NUESTRT"
+        ]
+      },
+      {
+        "name": "DOMIN",
+        "number": 938,
+        "aliases": [
+          "49022",
+          "938 DOMIN"
+        ]
+      },
+      {
+        "name": "CANAL11",
+        "number": 939,
+        "aliases": [
+          "36139",
+          "939 CANAL11"
+        ]
+      },
+      {
+        "name": "NMASFOR",
+        "number": 941,
+        "aliases": [
+          "76964",
+          "941 NMASFOR"
+        ]
+      },
+      {
+        "name": "TUDN",
+        "number": 942,
+        "aliases": [
+          "TUDNU",
+          "75176",
+          "942 TUDNU"
+        ]
+      },
+      {
+        "name": "HBO Latino",
+        "number": 944,
+        "aliases": [
+          "HBOLAT",
+          "24553",
+          "944 HBOLAT"
+        ]
+      },
+      {
+        "name": "HBOLATP",
+        "number": 945,
+        "aliases": [
+          "24575",
+          "945 HBOLATP"
+        ]
+      },
+      {
+        "name": "CMAX",
+        "number": 946,
+        "aliases": [
+          "CMAXHD",
+          "25623",
+          "59965",
+          "946 CMAX"
+        ]
+      },
+      {
+        "name": "VM",
+        "number": 947,
+        "aliases": [
+          "VMOV",
+          "VMOVHD",
+          "52208",
+          "102336",
+          "947 VMOV"
+        ]
+      },
+      {
+        "name": "WZRACA",
+        "number": 948,
+        "aliases": [
+          "WZRACA-TV",
+          "31947",
+          "948 WZRACA"
+        ]
+      },
+      {
+        "name": "Cuba",
+        "number": 949,
+        "aliases": [
+          "CUBAPLY",
+          "73318",
+          "949 CUBAPLY"
+        ]
+      },
+      {
+        "name": "XEIMT",
+        "number": 950,
+        "aliases": [
+          "15232",
+          "950 XEIMT"
+        ]
+      },
+      {
+        "name": "ESTUD5",
+        "number": 951,
+        "aliases": [
+          "88506",
+          "951 ESTUD5"
+        ]
+      },
+      {
+        "name": "MULT",
+        "number": 952,
+        "aliases": [
+          "MULTV",
+          "MULTVHD",
+          "50500",
+          "91505",
+          "952 MULTV"
+        ]
+      },
+      {
+        "name": "FORM",
+        "number": 953,
+        "aliases": [
+          "TFORM",
+          "TFORMHD",
+          "34344",
+          "87167",
+          "953 TFORM"
+        ]
+      },
+      {
+        "name": "SURPERU",
+        "number": 955,
+        "aliases": [
+          "46753",
+          "955 SURPERU"
+        ]
+      },
+      {
+        "name": "TVNI",
+        "number": 956,
+        "aliases": [
+          "16046",
+          "956 TVNI"
+        ]
+      },
+      {
+        "name": "TELS",
+        "number": 957,
+        "aliases": [
+          "TELSALV",
+          "65809",
+          "957 TELSALV"
+        ]
+      },
+      {
+        "name": "SUPCAN",
+        "number": 958,
+        "aliases": [
+          "24515",
+          "958 SUPCAN"
+        ]
+      },
+      {
+        "name": "MICRO",
+        "number": 959,
+        "aliases": [
+          "TMICRO",
+          "45243",
+          "959 TMICRO"
+        ]
+      },
+      {
+        "name": "ANT3",
+        "number": 960,
+        "aliases": [
+          "ANT3I",
+          "16800",
+          "960 ANT3I"
+        ]
+      },
+      {
+        "name": "BAND",
+        "number": 961,
+        "aliases": [
+          "BANDAUS",
+          "54867",
+          "961 BANDAUS"
+        ]
+      },
+      {
+        "name": "THMUS",
+        "number": 962,
+        "aliases": [
+          "34394",
+          "962 THMUS"
+        ]
+      },
+      {
+        "name": "THIT",
+        "number": 963,
+        "aliases": [
+          "THITUS",
+          "34393",
+          "963 THITUS"
+        ]
+      },
+      {
+        "name": "KIDSSHD",
+        "number": 967,
+        "aliases": [
+          "KIDSSHD-TV",
+          "102442",
+          "967 KIDSSHD"
+        ]
+      },
+      {
+        "name": "HOGARHD",
+        "number": 969,
+        "aliases": [
+          "114881",
+          "969 HOGARHD"
+        ]
+      },
+      {
+        "name": "TOON en Español",
+        "number": 970,
+        "aliases": [
+          "STOON",
+          "38279",
+          "970 STOON"
+        ]
+      },
+      {
+        "name": "ATRESSD",
+        "number": 972,
+        "aliases": [
+          "ATRES",
+          "90917",
+          "90898",
+          "972 ATRESSD"
+        ]
+      },
+      {
+        "name": "BABY1AS",
+        "number": 974,
+        "aliases": [
+          "78831",
+          "974 BABY1AS"
+        ]
+      },
+      {
+        "name": "BABY",
+        "number": 975,
+        "aliases": [
+          "BABYUS",
+          "70337",
+          "975 BABYUS"
+        ]
+      },
+      {
+        "name": "NGM",
+        "number": 976,
+        "aliases": [
+          "NGMUNDH",
+          "117788",
+          "976 NGMUNDH"
+        ]
+      },
+      {
+        "name": "HITN",
+        "number": 977,
+        "aliases": [
+          "17142",
+          "977 HITN"
+        ]
+      },
+      {
+        "name": "MEXCAN",
+        "number": 978,
+        "aliases": [
+          "47499",
+          "978 MEXCAN"
+        ]
+      },
+      {
+        "name": "DPLUSSD",
+        "number": 979,
+        "aliases": [
+          "100502",
+          "979 DPLUSSD"
+        ]
+      },
+      {
+        "name": "PELIC",
+        "number": 980,
+        "aliases": [
+          "DEPELC",
+          "33628",
+          "980 DEPELC"
+        ]
+      },
+      {
+        "name": "APLAUSD",
+        "number": 981,
+        "aliases": [
+          "109111",
+          "981 APLAUSD"
+        ]
+      },
+      {
+        "name": "VMEHD",
+        "number": 982,
+        "aliases": [
+          "122713",
+          "982 VMEHD"
+        ]
+      },
+      {
+        "name": "SUPCAHD",
+        "number": 1853,
+        "aliases": [
+          "90322",
+          "1853 SUPCAHD"
+        ]
+      },
+      {
+        "name": "APLAUSO",
+        "number": 1854,
+        "aliases": [
+          "80559",
+          "1854 APLAUSO"
+        ]
+      },
+      {
+        "name": "DOCU",
+        "number": 1859,
+        "aliases": [
+          "UDOCU",
+          "79605",
+          "1859 UDOCU"
+        ]
+      },
+      {
+        "name": "UFAMIL",
+        "number": 1866,
+        "aliases": [
+          "80149",
+          "1866 UFAMIL"
+        ]
+      },
+      {
+        "name": "SOCINH",
+        "number": 1868,
+        "aliases": [
+          "76408",
+          "1868 SOCINH"
+        ]
+      },
+      {
+        "name": "PAS",
+        "number": 1870,
+        "aliases": [
+          "PASNUS",
+          "61776",
+          "1870 PASNUS"
+        ]
+      },
+      {
+        "name": "DSCE",
+        "number": 1874,
+        "aliases": [
+          "19247",
+          "1874 DSCE"
+        ]
+      },
+      {
+        "name": "CINE",
+        "number": 1893,
+        "aliases": [
+          "UCINE",
+          "79680",
+          "1893 UCINE"
+        ]
+      },
+      {
+        "name": "UCLAS",
+        "number": 1894,
+        "aliases": [
+          "79695",
+          "1894 UCLAS"
+        ]
+      },
+      {
+        "name": "FIESTA",
+        "number": 1895,
+        "aliases": [
+          "UFEST",
+          "79607",
+          "1895 UFEST"
+        ]
+      },
+      {
+        "name": "UKIDZ",
+        "number": 1896,
+        "aliases": [
+          "79606",
+          "1896 UKIDZ"
+        ]
+      },
+      {
+        "name": "UMACHO",
+        "number": 1897,
+        "aliases": [
+          "79696",
+          "1897 UMACHO"
+        ]
+      },
+      {
+        "name": "ULTMEX",
+        "number": 1898,
+        "aliases": [
+          "79692",
+          "1898 ULTMEX"
+        ]
+      },
+      {
+        "name": "WVEADT6",
+        "number": 1903,
+        "aliases": [
+          "WVEADT6-TV",
+          "122148",
+          "1903 WVEADT6"
+        ]
+      },
+      {
+        "name": "SPCMDEP",
+        "number": 1913,
+        "aliases": [
+          "77428",
+          "1913 SPCMDEP"
+        ]
+      },
+      {
+        "name": "GOLTVIH",
+        "number": 1916,
+        "aliases": [
+          "68608",
+          "1916 GOLTVIH"
+        ]
+      },
+      {
+        "name": "WRMDCD",
+        "number": 1918,
+        "aliases": [
+          "WRMDCD-TV",
+          "84545",
+          "1918 WRMDCD"
+        ]
+      },
+      {
+        "name": "EWTNEHD",
+        "number": 1920,
+        "aliases": [
+          "72123",
+          "1920 EWTNEHD"
+        ]
+      },
+      {
+        "name": "TUDNUH",
+        "number": 1942,
+        "aliases": [
+          "77033",
+          "1942 TUDNUH"
+        ]
+      },
+      {
+        "name": "HBOLAHD",
+        "number": 1944,
+        "aliases": [
+          "59837",
+          "1944 HBOLAHD"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/US_Spectrum-Tampa-Bay-No-Spanish_lineup.json
+++ b/plugins/lineuparr/US_Spectrum-Tampa-Bay-No-Spanish_lineup.json
@@ -1,0 +1,3274 @@
+{
+  "package": "Spectrum Tampa Bay - No Spanish IPTV Clean",
+  "date": "2026-08-18",
+  "description": "Curated Spectrum Tampa Bay logical-channel lineup optimized for IPTV/Lineuparr, excluding Spanish-language channels.",
+  "source": "Spectrum Tampa Bay source lineup, cross-checked against the supplied TV Passport guide and curated for IPTV/Lineuparr use.",
+  "categories": {
+    "Local": [
+      {
+        "name": "WCLF",
+        "number": 2,
+        "aliases": [
+          "WCLFDT",
+          "WCLF-TV",
+          "11351",
+          "42627",
+          "2 WCLF"
+        ]
+      },
+      {
+        "name": "WEDU",
+        "number": 3,
+        "aliases": [
+          "WEDUDT",
+          "WEDU-TV",
+          "11407",
+          "35193",
+          "3 WEDU"
+        ]
+      },
+      {
+        "name": "WTOG",
+        "number": 4,
+        "aliases": [
+          "WTOGDT",
+          "WTOG-TV",
+          "11894",
+          "30617",
+          "4 WTOG"
+        ]
+      },
+      {
+        "name": "WFTT",
+        "number": 5,
+        "aliases": [
+          "WFTTDT",
+          "WFTT-TV",
+          "11249",
+          "50307",
+          "5 WFTT"
+        ]
+      },
+      {
+        "name": "WTTA",
+        "number": 6,
+        "aliases": [
+          "WTTADT",
+          "WTTA-TV",
+          "11903",
+          "36145",
+          "6 WTTA"
+        ]
+      },
+      {
+        "name": "WFLA-TV",
+        "number": 8,
+        "aliases": [
+          "WFLA",
+          "WFLADT",
+          "11437",
+          "21222",
+          "8 WFLA"
+        ]
+      },
+      {
+        "name": "Bay News 9",
+        "number": 9,
+        "aliases": [
+          "BAY9",
+          "BAY9DT",
+          "19997",
+          "70271",
+          "9 BAY9"
+        ]
+      },
+      {
+        "name": "WTSP",
+        "number": 10,
+        "aliases": [
+          "WTSPDT",
+          "WTSP-TV",
+          "11902",
+          "20495",
+          "10 WTSP"
+        ]
+      },
+      {
+        "name": "WFTS-TV",
+        "number": 11,
+        "aliases": [
+          "WFTS",
+          "WFTSDT",
+          "11447",
+          "21224",
+          "11 WFTS"
+        ]
+      },
+      {
+        "name": "WMOR",
+        "number": 12,
+        "aliases": [
+          "WMORDT",
+          "WMOR-TV",
+          "11891",
+          "33689",
+          "12 WMOR"
+        ]
+      },
+      {
+        "name": "WTVT",
+        "number": 13,
+        "aliases": [
+          "WTVTDT",
+          "WTVT-TV",
+          "11922",
+          "21223",
+          "13 WTVT"
+        ]
+      },
+      {
+        "name": "WXPX-TV",
+        "number": 17,
+        "aliases": [
+          "WXPX",
+          "WXPXDT",
+          "15034",
+          "34842",
+          "17 WXPX"
+        ]
+      },
+      {
+        "name": "WTVTDT3",
+        "number": 603,
+        "aliases": [
+          "WTVTDT3 BUZZR",
+          "WTVTDT3-TV",
+          "94323",
+          "603 WTVTDT3"
+        ]
+      },
+      {
+        "name": "WEDUDT3",
+        "number": 604,
+        "aliases": [
+          "WEDUDT3 NHKWRLD",
+          "WEDUDT3-TV",
+          "56655",
+          "604 WEDUDT3"
+        ]
+      },
+      {
+        "name": "WEDUDT2",
+        "number": 606,
+        "aliases": [
+          "WEDUDT2 WORLD",
+          "WEDUDT2-TV",
+          "35223",
+          "606 WEDUDT2"
+        ]
+      },
+      {
+        "name": "WFLADT2",
+        "number": 607,
+        "aliases": [
+          "WFLADT2 CHARGE",
+          "WFLADT2-TV",
+          "43841",
+          "607 WFLADT2"
+        ]
+      },
+      {
+        "name": "WFTSDT3",
+        "number": 608,
+        "aliases": [
+          "WFTSDT3 GRIT",
+          "WFTSDT3-TV",
+          "91890",
+          "608 WFTSDT3"
+        ]
+      },
+      {
+        "name": "WTTA2",
+        "number": 609,
+        "aliases": [
+          "WTTADT2",
+          "WTTADT2 COZITV",
+          "WTTADT2-TV",
+          "50311",
+          "609 WTTADT2"
+        ]
+      },
+      {
+        "name": "WTSP3",
+        "number": 611,
+        "aliases": [
+          "WTSPDT3",
+          "WTSPDT3 CRIME",
+          "WTSPDT3-TV",
+          "91455",
+          "611 WTSPDT3"
+        ]
+      },
+      {
+        "name": "WTVT2",
+        "number": 613,
+        "aliases": [
+          "WTVTDT2",
+          "WTVTDT2 MVIES",
+          "WTVTDT2-TV",
+          "62802",
+          "613 WTVTDT2"
+        ]
+      },
+      {
+        "name": "HEROICN",
+        "number": 614,
+        "aliases": [
+          "90401",
+          "614 HEROICN"
+        ]
+      },
+      {
+        "name": "WXPXDT2",
+        "number": 615,
+        "aliases": [
+          "WXPXDT2 ION",
+          "WXPXDT2-TV",
+          "43324",
+          "615 WXPXDT2"
+        ]
+      },
+      {
+        "name": "WXPXDT4",
+        "number": 616,
+        "aliases": [
+          "WXPXDT4 LAFF",
+          "WXPXDT4-TV",
+          "43330",
+          "616 WXPXDT4"
+        ]
+      },
+      {
+        "name": "WEDQDT5",
+        "number": 617,
+        "aliases": [
+          "WEDQDT5 HD06",
+          "WEDQDT5-TV",
+          "35226",
+          "617 WEDQDT5"
+        ]
+      },
+      {
+        "name": "WEDUDT6",
+        "number": 618,
+        "aliases": [
+          "WEDUDT6 CREATE",
+          "WEDUDT6-TV",
+          "105774",
+          "618 WEDUDT6"
+        ]
+      },
+      {
+        "name": "WFLADT3",
+        "number": 619,
+        "aliases": [
+          "WFLADT3 ANTENNA",
+          "WFLADT3-TV",
+          "43843",
+          "619 WFLADT3"
+        ]
+      },
+      {
+        "name": "WTSPDT4",
+        "number": 620,
+        "aliases": [
+          "WTSPDT4 THENEST",
+          "WTSPDT4-TV",
+          "107046",
+          "620 WTSPDT4"
+        ]
+      },
+      {
+        "name": "FLACHAN",
+        "number": 623,
+        "aliases": [
+          "35219",
+          "623 FLACHAN"
+        ]
+      },
+      {
+        "name": "WFTSDT2",
+        "number": 629,
+        "aliases": [
+          "WFTSDT2 BOUNCE",
+          "WFTSDT2-TV",
+          "50359",
+          "629 WFTSDT2"
+        ]
+      },
+      {
+        "name": "WMORDT2",
+        "number": 630,
+        "aliases": [
+          "WMORDT2 METVN",
+          "WMORDT2-TV",
+          "62896",
+          "630 WMORDT2"
+        ]
+      },
+      {
+        "name": "MYX",
+        "number": 633,
+        "aliases": [
+          "55451",
+          "633 MYX"
+        ]
+      },
+      {
+        "name": "WEDQDT4",
+        "number": 1016,
+        "aliases": [
+          "WEDQDT4-TV",
+          "56744",
+          "1016 WEDQDT4"
+        ]
+      },
+      {
+        "name": "WSNNLD",
+        "number": 1020,
+        "aliases": [
+          "WSNNLD MNT",
+          "WSNNLD-TV",
+          "75548",
+          "1020 WSNNLD"
+        ]
+      }
+    ],
+    "News": [
+      {
+        "name": "CNN",
+        "number": 29,
+        "aliases": [
+          "CNNHD",
+          "10142",
+          "58646",
+          "29 CNN",
+          "US: CNN HD",
+          "cnn.us",
+          "US: CNN 4K",
+          "CNN HD"
+        ]
+      },
+      {
+        "name": "HLN",
+        "number": 30,
+        "aliases": [
+          "HLNHD",
+          "10145",
+          "64549",
+          "30 HLN"
+        ]
+      },
+      {
+        "name": "CNBC",
+        "number": 42,
+        "aliases": [
+          "CNBCFL",
+          "92081",
+          "42 CNBCFL",
+          "US: CNBC HD",
+          "CNBC.us",
+          "CNBCHD",
+          "CNBC HD",
+          "CNBCFHD",
+          "92082",
+          "1219 CNBCFHD"
+        ]
+      },
+      {
+        "name": "The Weather Channel",
+        "number": 63,
+        "aliases": [
+          "WEATH",
+          "WEA",
+          "WEATHHD",
+          "WEATH-TV",
+          "11187",
+          "58812",
+          "63 WEATH"
+        ]
+      },
+      {
+        "name": "Bloomberg Television",
+        "number": 127,
+        "aliases": [
+          "BLOOM",
+          "BLOOMHD",
+          "14755",
+          "71799",
+          "127 BLOOM"
+        ]
+      },
+      {
+        "name": "i24NEWS",
+        "number": 128,
+        "aliases": [
+          "I24NWEN",
+          "87376",
+          "128 I24NWEN",
+          "102309",
+          "1224 I24NEHD",
+          "I24NEHD"
+        ]
+      },
+      {
+        "name": "OANHD",
+        "number": 129,
+        "aliases": [
+          "83953",
+          "129 OANHD"
+        ]
+      },
+      {
+        "name": "CNBC World",
+        "number": 141,
+        "aliases": [
+          "CNBCWLD",
+          "CNBCW",
+          "26849",
+          "141 CNBCWLD"
+        ]
+      },
+      {
+        "name": "FOX Business Network",
+        "number": 149,
+        "aliases": [
+          "FBNHD",
+          "FBN",
+          "58649",
+          "58718",
+          "149 FBN",
+          "US: FOX BUSINESS NETWORK HD",
+          "FoxBusiness.us",
+          "foxbusiness.us"
+        ]
+      },
+      {
+        "name": "CSPAN",
+        "number": 175,
+        "aliases": [
+          "CSPANHD",
+          "10161",
+          "68344",
+          "175 CSPAN"
+        ]
+      },
+      {
+        "name": "CSPAN2",
+        "number": 176,
+        "aliases": [
+          "10162",
+          "176 CSPAN2",
+          "68334",
+          "1227 CSPN2HD",
+          "CSPN2HD"
+        ]
+      },
+      {
+        "name": "CSPAN3",
+        "number": 177,
+        "aliases": [
+          "17665",
+          "177 CSPAN3",
+          "68332",
+          "1228 CSPN3HD",
+          "CSPN3HD"
+        ]
+      },
+      {
+        "name": "NEWSNTN",
+        "number": 1018,
+        "aliases": [
+          "91096",
+          "1018 NEWSNTN"
+        ]
+      },
+      {
+        "name": "NEWSMX",
+        "number": 1217,
+        "aliases": [
+          "87925",
+          "1217 NEWSMX"
+        ]
+      }
+    ],
+    "Sports": [
+      {
+        "name": "ESPN",
+        "number": 27,
+        "aliases": [
+          "ESPNTPA",
+          "77570",
+          "27 ESPNTPA",
+          "US: ESPN HD",
+          "ESPN.us",
+          "ESPNHD",
+          "ESPN HD",
+          "77572",
+          "1127 ESPNHTP",
+          "ESPNHTP"
+        ]
+      },
+      {
+        "name": "GOLF",
+        "number": 67,
+        "aliases": [
+          "GOLFHD",
+          "14899",
+          "61854",
+          "67 GOLF"
+        ]
+      },
+      {
+        "name": "SEC Network",
+        "number": 72,
+        "aliases": [
+          "SEC",
+          "89535",
+          "72 SEC",
+          "SECH",
+          "89714",
+          "1150 SECH"
+        ]
+      },
+      {
+        "name": "FOX Sports 1",
+        "number": 112,
+        "aliases": [
+          "FS1HD",
+          "FS1",
+          "82541",
+          "82547",
+          "112 FS1",
+          "US: FOX SPORTS 1 HD",
+          "US: FOX SPORTS 1",
+          "FoxSports1.us",
+          "FOX SPORTS 1 HD",
+          "Fox Sports 1 HD"
+        ]
+      },
+      {
+        "name": "ESPNews",
+        "number": 150,
+        "aliases": [
+          "ESPNEWS",
+          "16485",
+          "150 ESPNEWS",
+          "ESPNWHD",
+          "ESPNews HD",
+          "59976",
+          "1129 ESPNWHD"
+        ]
+      },
+      {
+        "name": "ESPNU",
+        "number": 151,
+        "aliases": [
+          "ESPNUHD",
+          "45654",
+          "60696",
+          "151 ESPNU"
+        ]
+      },
+      {
+        "name": "NBA TV",
+        "number": 803,
+        "aliases": [
+          "NBAFL",
+          "NBA",
+          "77636",
+          "803 NBAFL",
+          "77637",
+          "1140 NBAHFL",
+          "NBAHFL"
+        ]
+      },
+      {
+        "name": "Tennis Channel",
+        "number": 804,
+        "aliases": [
+          "TENNIS",
+          "TENN",
+          "33395",
+          "804 TENNIS",
+          "TENISHD",
+          "60316",
+          "1155 TENISHD"
+        ]
+      },
+      {
+        "name": "Outdoor Channel",
+        "number": 805,
+        "aliases": [
+          "OUTD",
+          "OUT",
+          "14776",
+          "805 OUTD"
+        ]
+      },
+      {
+        "name": "FOX Sports 2",
+        "number": 806,
+        "aliases": [
+          "FS2HD",
+          "FS2",
+          "33178",
+          "59305",
+          "806 FS2",
+          "US: FOX SPORTS 2 HD",
+          "US: FOX SPORTS 2",
+          "FoxSports2.us",
+          "FOX SPORTS 2 HD",
+          "Fox Sports 2 HD"
+        ]
+      },
+      {
+        "name": "CBS Sports Network",
+        "number": 807,
+        "aliases": [
+          "CBSSN",
+          "CBSSNHD",
+          "16365",
+          "59250",
+          "807 CBSSN"
+        ]
+      },
+      {
+        "name": "NHL Network",
+        "number": 808,
+        "aliases": [
+          "NHLFL",
+          "NHL",
+          "NHLHDFL",
+          "77587",
+          "77588",
+          "808 NHLFL"
+        ]
+      },
+      {
+        "name": "Big Ten Network",
+        "number": 809,
+        "aliases": [
+          "BIGFLA",
+          "61160",
+          "809 BIGFLA",
+          "79660",
+          "1138 BIGFLAH",
+          "BIGFLAH"
+        ]
+      },
+      {
+        "name": "MLB Network",
+        "number": 815,
+        "aliases": [
+          "MLBFL",
+          "MLBFLHD",
+          "77574",
+          "77573",
+          "815 MLBFL"
+        ]
+      },
+      {
+        "name": "NFL Network",
+        "number": 825,
+        "aliases": [
+          "NFLNET",
+          "34710",
+          "825 NFLNET",
+          "45399",
+          "1145 NFLHD",
+          "NFLHD"
+        ]
+      },
+      {
+        "name": "NFL RedZone",
+        "number": 826,
+        "aliases": [
+          "NFLNRZ",
+          "NFLN",
+          "65024",
+          "826 NFLNRZ",
+          "65025",
+          "1146 NFLNRZD",
+          "NFLNRZD"
+        ]
+      },
+      {
+        "name": "World Fishing Network",
+        "number": 827,
+        "aliases": [
+          "WFNUS",
+          "WFNUSHD",
+          "WFNUS-TV",
+          "63234",
+          "64046",
+          "827 WFNUS"
+        ]
+      },
+      {
+        "name": "FSP",
+        "number": 829,
+        "aliases": [
+          "66879",
+          "829 FSP"
+        ]
+      },
+      {
+        "name": "beIN Sports",
+        "number": 831,
+        "aliases": [
+          "BEINS1",
+          "beINS",
+          "76942",
+          "831 BEINS1",
+          "BEIN1HD",
+          "76950",
+          "1163 BEIN1HD"
+        ]
+      },
+      {
+        "name": "Willow",
+        "number": 835,
+        "aliases": [
+          "WILLOW",
+          "WILLOW-TV",
+          "68605",
+          "835 WILLOW"
+        ]
+      },
+      {
+        "name": "RACER Network",
+        "number": 837,
+        "aliases": [
+          "RACER",
+          "RACERHD",
+          "45169",
+          "61036",
+          "837 RACER"
+        ]
+      },
+      {
+        "name": "FanDuel TV",
+        "number": 838,
+        "aliases": [
+          "FDUELTV",
+          "21345",
+          "838 FDUELTV"
+        ]
+      },
+      {
+        "name": "ACC Network",
+        "number": 1205,
+        "aliases": [
+          "ACC",
+          "111871",
+          "1205 ACC"
+        ]
+      }
+    ],
+    "Entertainment": [
+      {
+        "name": "NWSNTSD",
+        "number": 18,
+        "aliases": [
+          "91097",
+          "18 NWSNTSD"
+        ]
+      },
+      {
+        "name": "TBS",
+        "number": 23,
+        "aliases": [
+          "TBSTPA",
+          "77582",
+          "23 TBSTPA",
+          "US: TBS HD",
+          "TBSHD",
+          "TBS HD"
+        ]
+      },
+      {
+        "name": "ESPN2",
+        "number": 28,
+        "aliases": [
+          "ESP2TPA",
+          "77577",
+          "28 ESP2TPA",
+          "ESPN2HD",
+          "ESPN 2 HD",
+          "77579",
+          "1128 ESP2HTP",
+          "ESP2HTP"
+        ]
+      },
+      {
+        "name": "USA Network",
+        "number": 32,
+        "aliases": [
+          "USAFL",
+          "USA",
+          "USAFLHD",
+          "92084",
+          "92086",
+          "32 USAFL",
+          "US: USA NETWORK HD",
+          "USANetwork.us",
+          "USAHD",
+          "USA HD"
+        ]
+      },
+      {
+        "name": "TNT",
+        "number": 33,
+        "aliases": [
+          "TNTHD",
+          "11164",
+          "42642",
+          "33 TNT",
+          "US: TNT HD",
+          "TNT.us",
+          "US: TNT SD",
+          "TNT HD"
+        ]
+      },
+      {
+        "name": "Fox News Channel",
+        "number": 37,
+        "aliases": [
+          "FNC",
+          "FNCHD",
+          "16374",
+          "60179",
+          "37 FNC",
+          "US: FOX NEWS HD",
+          "FoxNews.us",
+          "foxnews.us",
+          "US: FOX NEWS CHANNEL 4K",
+          "Fox News HD"
+        ]
+      },
+      {
+        "name": "MSNOW",
+        "number": 41,
+        "aliases": [
+          "MSNOWHD",
+          "16300",
+          "64241",
+          "41 MSNOW"
+        ]
+      },
+      {
+        "name": "Paramount Network",
+        "number": 43,
+        "aliases": [
+          "PAR",
+          "PARHD",
+          "11163",
+          "59186",
+          "43 PAR",
+          "US: PARAMOUNT HD",
+          "PARAMOUNT NETWORK"
+        ]
+      },
+      {
+        "name": "CMT",
+        "number": 45,
+        "aliases": [
+          "CMTV",
+          "CMTVHD",
+          "10138",
+          "59440",
+          "45 CMTV"
+        ]
+      },
+      {
+        "name": "A&E",
+        "number": 48,
+        "aliases": [
+          "AETV",
+          "AETVHD",
+          "10035",
+          "51529",
+          "48 AETV"
+        ]
+      },
+      {
+        "name": "TV Land",
+        "number": 49,
+        "aliases": [
+          "TVLAND",
+          "16123",
+          "49 TVLAND",
+          "TVLNDHD",
+          "73541",
+          "1281 TVLNDHD"
+        ]
+      },
+      {
+        "name": "TRUTV",
+        "number": 55,
+        "aliases": [
+          "TRUTVHD",
+          "truTV",
+          "10153",
+          "64490",
+          "55 TRUTV"
+        ]
+      },
+      {
+        "name": "SYFY",
+        "number": 59,
+        "aliases": [
+          "SYFYHD",
+          "Syfy",
+          "11097",
+          "58623",
+          "59 SYFY"
+        ]
+      },
+      {
+        "name": "Comedy Central",
+        "number": 61,
+        "aliases": [
+          "COMEDY",
+          "10149",
+          "61 COMEDY",
+          "CCHD",
+          "62420",
+          "1292 CCHD"
+        ]
+      },
+      {
+        "name": "VH1",
+        "number": 62,
+        "aliases": [
+          "VH1HD",
+          "11218",
+          "60046",
+          "62 VH1"
+        ]
+      },
+      {
+        "name": "MTV",
+        "number": 66,
+        "aliases": [
+          "MTVHD",
+          "10986",
+          "60964",
+          "66 MTV"
+        ]
+      },
+      {
+        "name": "WE tv",
+        "number": 69,
+        "aliases": [
+          "WE",
+          "16409",
+          "69 WE",
+          "WEHD-TV",
+          "59296",
+          "1272 WEHD",
+          "WEHD"
+        ]
+      },
+      {
+        "name": "E!",
+        "number": 70,
+        "aliases": [
+          "E",
+          "10989",
+          "70 E",
+          "EHD",
+          "61812",
+          "1293 EHD"
+        ]
+      },
+      {
+        "name": "BET",
+        "number": 71,
+        "aliases": [
+          "BETHD",
+          "10051",
+          "63236",
+          "71 BET"
+        ]
+      },
+      {
+        "name": "BBC America",
+        "number": 75,
+        "aliases": [
+          "BBCA",
+          "BBC",
+          "BBCAHD",
+          "18332",
+          "64492",
+          "75 BBCA"
+        ]
+      },
+      {
+        "name": "BET Soul",
+        "number": 96,
+        "aliases": [
+          "BETSOUL",
+          "Soul",
+          "18718",
+          "96 BETSOUL"
+        ]
+      },
+      {
+        "name": "REVOLT",
+        "number": 97,
+        "aliases": [
+          "RVLT",
+          "RVLTHD",
+          "83097",
+          "83098",
+          "97 RVLT"
+        ]
+      },
+      {
+        "name": "Discovery Family",
+        "number": 102,
+        "aliases": [
+          "DFC",
+          "DFCHD",
+          "16618",
+          "67749",
+          "102 DFC"
+        ]
+      },
+      {
+        "name": "TWCTRV",
+        "number": 106,
+        "aliases": [
+          "87180",
+          "106 TWCTRV"
+        ]
+      },
+      {
+        "name": "BET Her",
+        "number": 107,
+        "aliases": [
+          "BHER",
+          "BETHer",
+          "BHERHD",
+          "14897",
+          "63220",
+          "107 BHER"
+        ]
+      },
+      {
+        "name": "FUSE",
+        "number": 109,
+        "aliases": [
+          "FUSEHD",
+          "14929",
+          "59116",
+          "109 FUSE"
+        ]
+      },
+      {
+        "name": "GSN",
+        "number": 116,
+        "aliases": [
+          "GSNHD",
+          "14909",
+          "68827",
+          "116 GSN"
+        ]
+      },
+      {
+        "name": "FX",
+        "number": 119,
+        "aliases": [
+          "14321",
+          "119 FX",
+          "FX.us",
+          "US: FX HD",
+          "FXHD",
+          "FX HD (EAST)",
+          "58574",
+          "1283 FXHD"
+        ]
+      },
+      {
+        "name": "BBC World News",
+        "number": 123,
+        "aliases": [
+          "BBCWDNA",
+          "89542",
+          "123 BBCWDNA",
+          "89690",
+          "1222 BBCNAHD",
+          "BBCNAHD"
+        ]
+      },
+      {
+        "name": "MTV2",
+        "number": 126,
+        "aliases": [
+          "MTV2HD",
+          "16361",
+          "75077",
+          "126 MTV2"
+        ]
+      },
+      {
+        "name": "FM",
+        "number": 132,
+        "aliases": [
+          "18262",
+          "132 FM"
+        ]
+      },
+      {
+        "name": "Great American Family",
+        "number": 133,
+        "aliases": [
+          "GFAM",
+          "GFAMHD",
+          "16062",
+          "82892",
+          "133 GFAM"
+        ]
+      },
+      {
+        "name": "YTA",
+        "number": 134,
+        "aliases": [
+          "10982",
+          "134 YTA"
+        ]
+      },
+      {
+        "name": "MTV Classic",
+        "number": 138,
+        "aliases": [
+          "MTVCLAS",
+          "MTV-C",
+          "22561",
+          "138 MTVCLAS"
+        ]
+      },
+      {
+        "name": "Lifetime Real Women",
+        "number": 143,
+        "aliases": [
+          "LRW",
+          "29612",
+          "143 LRW"
+        ]
+      },
+      {
+        "name": "UPtv",
+        "number": 145,
+        "aliases": [
+          "UP",
+          "44940",
+          "145 UP",
+          "UPHD",
+          "66143",
+          "1317 UPHD"
+        ]
+      },
+      {
+        "name": "TV One",
+        "number": 146,
+        "aliases": [
+          "TVONE",
+          "TVONEHD",
+          "35513",
+          "61960",
+          "146 TVONE"
+        ]
+      },
+      {
+        "name": "LOGO",
+        "number": 147,
+        "aliases": [
+          "LOGOHD",
+          "46762",
+          "96971",
+          "147 LOGO"
+        ]
+      },
+      {
+        "name": "VICE",
+        "number": 152,
+        "aliases": [
+          "VICEHD",
+          "18822",
+          "65732",
+          "152 VICE"
+        ]
+      },
+      {
+        "name": "BET Jams",
+        "number": 154,
+        "aliases": [
+          "BETJ",
+          "30419",
+          "154 BETJ"
+        ]
+      },
+      {
+        "name": "NMZK",
+        "number": 163,
+        "aliases": [
+          "30418",
+          "163 NMZK"
+        ]
+      },
+      {
+        "name": "CLEO",
+        "number": 167,
+        "aliases": [
+          "CLEOHD",
+          "110288",
+          "110289",
+          "167 CLEO"
+        ]
+      },
+      {
+        "name": "TheGrio",
+        "number": 168,
+        "aliases": [
+          "GRIOE",
+          "GRIO",
+          "116533",
+          "168 GRIOE"
+        ]
+      },
+      {
+        "name": "MILH",
+        "number": 169,
+        "aliases": [
+          "48999",
+          "169 MILH"
+        ]
+      },
+      {
+        "name": "CIN",
+        "number": 170,
+        "aliases": [
+          "CINHD",
+          "48543",
+          "61469",
+          "170 CIN"
+        ]
+      },
+      {
+        "name": "DYSTR",
+        "number": 171,
+        "aliases": [
+          "DYSTRHD",
+          "19026",
+          "87001",
+          "171 DYSTR"
+        ]
+      },
+      {
+        "name": "WORD",
+        "number": 173,
+        "aliases": [
+          "WORD-TV",
+          "21781",
+          "173 WORD"
+        ]
+      },
+      {
+        "name": "Pop",
+        "number": 178,
+        "aliases": [
+          "POPSD",
+          "POP",
+          "POPHD",
+          "16715",
+          "68796",
+          "178 POPSD"
+        ]
+      },
+      {
+        "name": "AspireTV",
+        "number": 180,
+        "aliases": [
+          "ASPRE",
+          "ASPiRE",
+          "ASPREHD",
+          "76126",
+          "97409",
+          "180 ASPRE"
+        ]
+      },
+      {
+        "name": "FOXWXSD",
+        "number": 181,
+        "aliases": [
+          "FOXWX",
+          "123194",
+          "93141",
+          "181 FOXWXSD"
+        ]
+      },
+      {
+        "name": "LOVE",
+        "number": 187,
+        "aliases": [
+          "71533",
+          "187 LOVE"
+        ]
+      },
+      {
+        "name": "FETV",
+        "number": 192,
+        "aliases": [
+          "73413",
+          "192 FETV"
+        ]
+      },
+      {
+        "name": "INSP",
+        "number": 196,
+        "aliases": [
+          "INSPHD",
+          "11066",
+          "82773",
+          "196 INSP"
+        ]
+      },
+      {
+        "name": "The Cowboy Channel",
+        "number": 198,
+        "aliases": [
+          "COWBOY",
+          "10188",
+          "198 COWBOY"
+        ]
+      },
+      {
+        "name": "JEWISH",
+        "number": 330,
+        "aliases": [
+          "58400",
+          "330 JEWISH"
+        ]
+      },
+      {
+        "name": "CARSTV",
+        "number": 334,
+        "aliases": [
+          "71302",
+          "334 CARSTV"
+        ]
+      },
+      {
+        "name": "PETSTV",
+        "number": 336,
+        "aliases": [
+          "71297",
+          "336 PETSTV"
+        ]
+      },
+      {
+        "name": "RECIPE",
+        "number": 337,
+        "aliases": [
+          "71294",
+          "337 RECIPE"
+        ]
+      },
+      {
+        "name": "AFRCA",
+        "number": 369,
+        "aliases": [
+          "AFRCAHD",
+          "47472",
+          "68576",
+          "369 AFRCA"
+        ]
+      },
+      {
+        "name": "AWEHD",
+        "number": 376,
+        "aliases": [
+          "45438",
+          "376 AWEHD"
+        ]
+      },
+      {
+        "name": "HERETV",
+        "number": 398,
+        "aliases": [
+          "45210",
+          "398 HERETV"
+        ]
+      },
+      {
+        "name": "IMPACSD",
+        "number": 474,
+        "aliases": [
+          "138982",
+          "474 IMPACSD"
+        ]
+      },
+      {
+        "name": "FREFMHD",
+        "number": 1112,
+        "aliases": [
+          "59615",
+          "1112 FREFMHD"
+        ]
+      },
+      {
+        "name": "SONLFHD",
+        "number": 1116,
+        "aliases": [
+          "91314",
+          "1116 SONLFHD"
+        ]
+      },
+      {
+        "name": "COWBOYH",
+        "number": 1120,
+        "aliases": [
+          "80597",
+          "1120 COWBOYH"
+        ]
+      },
+      {
+        "name": "HFM",
+        "number": 1124,
+        "aliases": [
+          "105723",
+          "1124 HFM"
+        ]
+      },
+      {
+        "name": "LNLC",
+        "number": 1126,
+        "aliases": [
+          "183475",
+          "1126 LNLC"
+        ]
+      },
+      {
+        "name": "SPCTSN",
+        "number": 1134,
+        "aliases": [
+          "77423",
+          "1134 SPCTSN"
+        ]
+      },
+      {
+        "name": "YESNATD",
+        "number": 1142,
+        "aliases": [
+          "63558",
+          "1142 YESNATD"
+        ]
+      },
+      {
+        "name": "SUNNHD",
+        "number": 1148,
+        "aliases": [
+          "54994",
+          "1148 SUNNHD"
+        ]
+      },
+      {
+        "name": "FDFL1HD",
+        "number": 1149,
+        "aliases": [
+          "65773",
+          "1149 FDFL1HD"
+        ]
+      },
+      {
+        "name": "OUTHD",
+        "number": 1156,
+        "aliases": [
+          "46737",
+          "1156 OUTHD"
+        ]
+      },
+      {
+        "name": "FSCPLHD",
+        "number": 1160,
+        "aliases": [
+          "66880",
+          "1160 FSCPLHD"
+        ]
+      },
+      {
+        "name": "NESNATH",
+        "number": 1162,
+        "aliases": [
+          "67518",
+          "1162 NESNATH"
+        ]
+      },
+      {
+        "name": "WLLOHD",
+        "number": 1165,
+        "aliases": [
+          "WLLOHD-TV",
+          "80621",
+          "1165 WLLOHD"
+        ]
+      },
+      {
+        "name": "SPTSNLA",
+        "number": 1179,
+        "aliases": [
+          "87107",
+          "1179 SPTSNLA"
+        ]
+      },
+      {
+        "name": "ACUWTHH",
+        "number": 1208,
+        "aliases": [
+          "91994",
+          "1208 ACUWTHH"
+        ]
+      },
+      {
+        "name": "NY1HD",
+        "number": 1210,
+        "aliases": [
+          "60159",
+          "1210 NY1HD"
+        ]
+      },
+      {
+        "name": "CHDDRHD",
+        "number": 1212,
+        "aliases": [
+          "109332",
+          "1212 CHDDRHD"
+        ]
+      },
+      {
+        "name": "CFLNHD",
+        "number": 1213,
+        "aliases": [
+          "70273",
+          "1213 CFLNHD"
+        ]
+      },
+      {
+        "name": "STELLAR",
+        "number": 1229,
+        "aliases": [
+          "130088",
+          "1229 STELLAR"
+        ]
+      },
+      {
+        "name": "MTHD",
+        "number": 1235,
+        "aliases": [
+          "31046",
+          "1235 MTHD"
+        ]
+      },
+      {
+        "name": "TBSHTPA",
+        "number": 1236,
+        "aliases": [
+          "77583",
+          "1236 TBSHTPA"
+        ]
+      },
+      {
+        "name": "HERICNS",
+        "number": 1243,
+        "aliases": [
+          "110477",
+          "1243 HERICNS"
+        ]
+      },
+      {
+        "name": "EARTHX",
+        "number": 1258,
+        "aliases": [
+          "126128",
+          "1258 EARTHX"
+        ]
+      },
+      {
+        "name": "NGWIHD",
+        "number": 1262,
+        "aliases": [
+          "67331",
+          "1262 NGWIHD"
+        ]
+      },
+      {
+        "name": "TWCTRVH",
+        "number": 1267,
+        "aliases": [
+          "87182",
+          "1267 TWCTRVH"
+        ]
+      },
+      {
+        "name": "STRY",
+        "number": 1274,
+        "aliases": [
+          "122968",
+          "1274 STRY"
+        ]
+      },
+      {
+        "name": "STARTTV",
+        "number": 1275,
+        "aliases": [
+          "109454",
+          "1275 STARTTV"
+        ]
+      },
+      {
+        "name": "CHIMETV",
+        "number": 1276,
+        "aliases": [
+          "131889",
+          "1276 CHIMETV"
+        ]
+      },
+      {
+        "name": "ENVOYTV",
+        "number": 1279,
+        "aliases": [
+          "192894",
+          "1279 ENVOYTV"
+        ]
+      },
+      {
+        "name": "FXX",
+        "number": 1284,
+        "aliases": [
+          "FXXHD",
+          "66379",
+          "1284 FXXHD"
+        ]
+      },
+      {
+        "name": "MTVL",
+        "number": 1300,
+        "aliases": [
+          "MTVLIVE",
+          "49141",
+          "1300 MTVLIVE"
+        ]
+      },
+      {
+        "name": "AXSTV",
+        "number": 1303,
+        "aliases": [
+          "28506",
+          "1303 AXSTV"
+        ]
+      },
+      {
+        "name": "FMHD",
+        "number": 1311,
+        "aliases": [
+          "72094",
+          "1311 FMHD"
+        ]
+      },
+      {
+        "name": "CARSTVH",
+        "number": 1334,
+        "aliases": [
+          "81270",
+          "1334 CARSTVH"
+        ]
+      },
+      {
+        "name": "JUST",
+        "number": 1335,
+        "aliases": [
+          "78850",
+          "1335 JUST"
+        ]
+      },
+      {
+        "name": "PETSTVH",
+        "number": 1336,
+        "aliases": [
+          "81283",
+          "1336 PETSTVH"
+        ]
+      },
+      {
+        "name": "RECIPEH",
+        "number": 1337,
+        "aliases": [
+          "81289",
+          "1337 RECIPEH"
+        ]
+      },
+      {
+        "name": "SMTHHD",
+        "number": 1370,
+        "aliases": [
+          "58532",
+          "1370 SMTHHD"
+        ]
+      },
+      {
+        "name": "HDNETMV",
+        "number": 1375,
+        "aliases": [
+          "33668",
+          "1375 HDNETMV"
+        ]
+      },
+      {
+        "name": "SZECLHD",
+        "number": 1379,
+        "aliases": [
+          "83404",
+          "1379 SZECLHD"
+        ]
+      },
+      {
+        "name": "SZESUHD",
+        "number": 1381,
+        "aliases": [
+          "83076",
+          "1381 SZESUHD"
+        ]
+      },
+      {
+        "name": "SZEAHD",
+        "number": 1382,
+        "aliases": [
+          "72015",
+          "1382 SZEAHD"
+        ]
+      },
+      {
+        "name": "SZEBHD",
+        "number": 1383,
+        "aliases": [
+          "72014",
+          "1383 SZEBHD"
+        ]
+      },
+      {
+        "name": "SZENHP",
+        "number": 1388,
+        "aliases": [
+          "67237",
+          "1388 SZENHP"
+        ]
+      },
+      {
+        "name": "SETHHD",
+        "number": 1561,
+        "aliases": [
+          "79610",
+          "1561 SETHHD"
+        ]
+      }
+    ],
+    "Lifestyle": [
+      {
+        "name": "OWN",
+        "number": 24,
+        "aliases": [
+          "OWNHD",
+          "70387",
+          "70388",
+          "24 OWN"
+        ]
+      },
+      {
+        "name": "Discovery Channel",
+        "number": 34,
+        "aliases": [
+          "DSC",
+          "DISC",
+          "DSCHD",
+          "11150",
+          "56905",
+          "34 DSC"
+        ]
+      },
+      {
+        "name": "Animal Planet",
+        "number": 35,
+        "aliases": [
+          "APL",
+          "ANPL",
+          "APLHD",
+          "16331",
+          "57394",
+          "35 APL"
+        ]
+      },
+      {
+        "name": "Lifetime",
+        "number": 38,
+        "aliases": [
+          "LIFE",
+          "LIFEHD",
+          "10918",
+          "60150",
+          "38 LIFE"
+        ]
+      },
+      {
+        "name": "Oxygen",
+        "number": 44,
+        "aliases": [
+          "OXYGEN",
+          "OXY",
+          "21484",
+          "44 OXYGEN",
+          "70522",
+          "1271 OXYGNHD",
+          "OXYGNHD"
+        ]
+      },
+      {
+        "name": "TLC",
+        "number": 46,
+        "aliases": [
+          "TLCHD",
+          "11158",
+          "57391",
+          "46 TLC"
+        ]
+      },
+      {
+        "name": "Lifetime Movie Network",
+        "number": 50,
+        "aliases": [
+          "LMN",
+          "LMNHD",
+          "18480",
+          "55887",
+          "50 LMN"
+        ]
+      },
+      {
+        "name": "BRAVO",
+        "number": 51,
+        "aliases": [
+          "BRAVOHD",
+          "Bravo",
+          "10057",
+          "58625",
+          "51 BRAVO"
+        ]
+      },
+      {
+        "name": "History",
+        "number": 54,
+        "aliases": [
+          "HISTORY",
+          "HIST",
+          "14771",
+          "54 HISTORY",
+          "HSTRYHD",
+          "57708",
+          "1242 HSTRYHD"
+        ]
+      },
+      {
+        "name": "FOOD",
+        "number": 56,
+        "aliases": [
+          "FOODHD",
+          "12574",
+          "50747",
+          "56 FOOD"
+        ]
+      },
+      {
+        "name": "HGTV",
+        "number": 57,
+        "aliases": [
+          "14902",
+          "57 HGTV",
+          "49788",
+          "1250 HGTVD",
+          "HGTVD"
+        ]
+      },
+      {
+        "name": "National Geographic",
+        "number": 65,
+        "aliases": [
+          "NGC",
+          "NGCHD",
+          "24959",
+          "49438",
+          "65 NGC"
+        ]
+      },
+      {
+        "name": "Hallmark Channel",
+        "number": 68,
+        "aliases": [
+          "HALL",
+          "HALLHD",
+          "11221",
+          "66268",
+          "68 HALL"
+        ]
+      },
+      {
+        "name": "Travel Channel",
+        "number": 90,
+        "aliases": [
+          "TRAV",
+          "TRAVEL",
+          "11180",
+          "90 TRAV"
+        ]
+      },
+      {
+        "name": "RFD-TV",
+        "number": 98,
+        "aliases": [
+          "RFDTV",
+          "RFD",
+          "25148",
+          "98 RFDTV"
+        ]
+      },
+      {
+        "name": "Science Channel",
+        "number": 100,
+        "aliases": [
+          "SCIENCE",
+          "SCI",
+          "16616",
+          "100 SCIENCE",
+          "SCIHD",
+          "57390",
+          "1265 SCIHD"
+        ]
+      },
+      {
+        "name": "American Heroes Channel",
+        "number": 103,
+        "aliases": [
+          "AHC",
+          "AHCHD",
+          "18284",
+          "78808",
+          "103 AHC"
+        ]
+      },
+      {
+        "name": "FYI",
+        "number": 104,
+        "aliases": [
+          "FYISD",
+          "FYIHD",
+          "16834",
+          "58988",
+          "104 FYISD"
+        ]
+      },
+      {
+        "name": "Destination America",
+        "number": 108,
+        "aliases": [
+          "DEST",
+          "DESTHD",
+          "16617",
+          "60468",
+          "108 DEST"
+        ]
+      },
+      {
+        "name": "Discovery Life",
+        "number": 114,
+        "aliases": [
+          "DLC",
+          "DLCHD",
+          "16125",
+          "92204",
+          "114 DLC"
+        ]
+      },
+      {
+        "name": "Investigation Discovery",
+        "number": 135,
+        "aliases": [
+          "ID",
+          "16615",
+          "135 ID",
+          "IDHD",
+          "65342",
+          "1246 IDHD"
+        ]
+      },
+      {
+        "name": "Magnolia Network",
+        "number": 136,
+        "aliases": [
+          "MAGN",
+          "MAGNHD",
+          "18544",
+          "67375",
+          "136 MAGN"
+        ]
+      },
+      {
+        "name": "Cooking Channel",
+        "number": 142,
+        "aliases": [
+          "COOK",
+          "COOKHD",
+          "30156",
+          "68065",
+          "142 COOK"
+        ]
+      },
+      {
+        "name": "Ovation",
+        "number": 164,
+        "aliases": [
+          "OVATION",
+          "OVA",
+          "15807",
+          "164 OVATION",
+          "69061",
+          "1277 OVATNHD",
+          "OVATNHD"
+        ]
+      },
+      {
+        "name": "Smithsonian Channel",
+        "number": 370,
+        "aliases": [
+          "SMITH",
+          "65799",
+          "370 SMITH"
+        ]
+      },
+      {
+        "name": "RFDHD",
+        "number": 1305,
+        "aliases": [
+          "63717",
+          "1305 RFDHD"
+        ]
+      }
+    ],
+    "Movies": [
+      {
+        "name": "TCM",
+        "number": 53,
+        "aliases": [
+          "TCMHD",
+          "12852",
+          "64312",
+          "53 TCM"
+        ]
+      },
+      {
+        "name": "AMC",
+        "number": 64,
+        "aliases": [
+          "AMCHD",
+          "10021",
+          "59337",
+          "64 AMC"
+        ]
+      },
+      {
+        "name": "REELZ",
+        "number": 354,
+        "aliases": [
+          "REELZHD",
+          "52199",
+          "68385",
+          "354 REELZ"
+        ]
+      },
+      {
+        "name": "SundanceTV",
+        "number": 374,
+        "aliases": [
+          "SUNDANC",
+          "16108",
+          "374 SUNDANC"
+        ]
+      },
+      {
+        "name": "IFC",
+        "number": 384,
+        "aliases": [
+          "IFCHD",
+          "14873",
+          "59444",
+          "384 IFC"
+        ]
+      },
+      {
+        "name": "Hallmark Mystery",
+        "number": 385,
+        "aliases": [
+          "HMYS",
+          "HMYSHD",
+          "61522",
+          "46710",
+          "385 HMYS"
+        ]
+      },
+      {
+        "name": "SUNDHD",
+        "number": 1356,
+        "aliases": [
+          "71280",
+          "1356 SUNDHD"
+        ]
+      },
+      {
+        "name": "FXMHD",
+        "number": 1389,
+        "aliases": [
+          "70253",
+          "1389 FXMHD"
+        ]
+      }
+    ],
+    "Kids": [
+      {
+        "name": "Nickelodeon",
+        "number": 36,
+        "aliases": [
+          "NIK",
+          "NICK",
+          "NIKHD",
+          "11006",
+          "59432",
+          "36 NIK"
+        ]
+      },
+      {
+        "name": "DISN",
+        "number": 40,
+        "aliases": [
+          "DISNHD",
+          "10171",
+          "59684",
+          "40 DISN"
+        ]
+      },
+      {
+        "name": "TOON",
+        "number": 58,
+        "aliases": [
+          "TOONHD",
+          "12131",
+          "60048",
+          "58 TOON"
+        ]
+      },
+      {
+        "name": "Boomerang",
+        "number": 124,
+        "aliases": [
+          "BOOM",
+          "21883",
+          "124 BOOM"
+        ]
+      },
+      {
+        "name": "Nick Jr.",
+        "number": 125,
+        "aliases": [
+          "NICJR",
+          "NICKJ",
+          "NICJRHD",
+          "19211",
+          "82649",
+          "125 NICJR"
+        ]
+      },
+      {
+        "name": "TeenNick",
+        "number": 140,
+        "aliases": [
+          "TNCK",
+          "TNICK",
+          "TNCKHD",
+          "59036",
+          "97047",
+          "140 TNCK"
+        ]
+      },
+      {
+        "name": "Nicktoons",
+        "number": 144,
+        "aliases": [
+          "NIKTON",
+          "30420",
+          "144 NIKTON"
+        ]
+      },
+      {
+        "name": "BabyFirst",
+        "number": 174,
+        "aliases": [
+          "BABY1",
+          "50338",
+          "174 BABY1"
+        ]
+      },
+      {
+        "name": "DJCHHD",
+        "number": 1106,
+        "aliases": [
+          "74885",
+          "1106 DJCHHD"
+        ]
+      },
+      {
+        "name": "DXDHD",
+        "number": 1107,
+        "aliases": [
+          "60006",
+          "1107 DXDHD"
+        ]
+      },
+      {
+        "name": "NIKTNHD",
+        "number": 1111,
+        "aliases": [
+          "82654",
+          "1111 NIKTNHD"
+        ]
+      }
+    ],
+    "Premium": [
+      {
+        "name": "HBO",
+        "number": 201,
+        "aliases": [
+          "HBOHD",
+          "10240",
+          "19548",
+          "201 HBO",
+          "HBOP",
+          "10244",
+          "208 HBOP",
+          "HBOHDP",
+          "19566",
+          "1408 HBOHDP"
+        ]
+      },
+      {
+        "name": "HBOHIT",
+        "number": 202,
+        "aliases": [
+          "HBOHTS",
+          "10241",
+          "202 HBOHTS",
+          "HBOHTP",
+          "10242",
+          "209 HBOHTP",
+          "HBOHTHD",
+          "59368",
+          "1402 HBOHTHD"
+        ]
+      },
+      {
+        "name": "HBODRMA",
+        "number": 203,
+        "aliases": [
+          "10243",
+          "203 HBODRMA",
+          "HBODRP",
+          "16576",
+          "210 HBODRP",
+          "HBODRHD",
+          "59363",
+          "1403 HBODRHD"
+        ]
+      },
+      {
+        "name": "HBOC",
+        "number": 205,
+        "aliases": [
+          "HBOCHD",
+          "18429",
+          "59839",
+          "205 HBOC",
+          "HBOCP",
+          "18430",
+          "212 HBOCP"
+        ]
+      },
+      {
+        "name": "HBOMOV",
+        "number": 206,
+        "aliases": [
+          "18431",
+          "206 HBOMOV",
+          "HBOMVP",
+          "18432",
+          "213 HBOMVP",
+          "HBOMVHD",
+          "59845",
+          "1406 HBOMVHD"
+        ]
+      },
+      {
+        "name": "Cinemax",
+        "number": 221,
+        "aliases": [
+          "MAX",
+          "MAX1",
+          "MAXHD",
+          "10120",
+          "34933",
+          "221 MAX",
+          "MAXP",
+          "12508",
+          "229 MAXP",
+          "MAXHDP",
+          "35975",
+          "1429 MAXHDP"
+        ]
+      },
+      {
+        "name": "CINEHIT",
+        "number": 222,
+        "aliases": [
+          "10121",
+          "222 CINEHIT",
+          "CINEHP",
+          "16620",
+          "230 CINEHP",
+          "CINEHHD",
+          "59373",
+          "1422 CINEHHD"
+        ]
+      },
+      {
+        "name": "CINACT",
+        "number": 223,
+        "aliases": [
+          "18433",
+          "223 CINACT",
+          "CINACSP",
+          "18434",
+          "231 CINACSP",
+          "CINACHD",
+          "59948",
+          "1423 CINACHD"
+        ]
+      },
+      {
+        "name": "CINECLS",
+        "number": 227,
+        "aliases": [
+          "25620",
+          "227 CINECLS",
+          "CINCLHD",
+          "59961",
+          "1427 CINCLHD"
+        ]
+      },
+      {
+        "name": "Paramount+ with SHOWTIME",
+        "number": 241,
+        "aliases": [
+          "PARSHO",
+          "11115",
+          "241 PARSHO",
+          "PARSHOW",
+          "11117",
+          "249 PARSHOW",
+          "PARSHOH",
+          "21868",
+          "1441 PARSHOH",
+          "PASHOHW",
+          "22532",
+          "1449 PASHOHW"
+        ]
+      },
+      {
+        "name": "SHO2",
+        "number": 242,
+        "aliases": [
+          "SHO2HD",
+          "11116",
+          "58533",
+          "242 SHO2",
+          "SHO2P",
+          "16444",
+          "250 SHO2P"
+        ]
+      },
+      {
+        "name": "SHOCSE",
+        "number": 243,
+        "aliases": [
+          "16153",
+          "243 SHOCSE",
+          "SHOCSEP",
+          "16584",
+          "251 SHOCSEP",
+          "SHOCSHD",
+          "61001",
+          "1443 SHOCSHD"
+        ]
+      },
+      {
+        "name": "WOMEN",
+        "number": 244,
+        "aliases": [
+          "WOMENHD",
+          "WOMEN-TV",
+          "25272",
+          "68338",
+          "244 WOMEN",
+          "WOMENP",
+          "WOMENP-TV",
+          "25273",
+          "252 WOMENP"
+        ]
+      },
+      {
+        "name": "SHOBET",
+        "number": 245,
+        "aliases": [
+          "20622",
+          "245 SHOBET",
+          "SHOBETP",
+          "20625",
+          "253 SHOBETP",
+          "SHOBETH",
+          "68340",
+          "1445 SHOBETH"
+        ]
+      },
+      {
+        "name": "NEXT",
+        "number": 246,
+        "aliases": [
+          "NEXTHD",
+          "25270",
+          "68342",
+          "246 NEXT",
+          "NEXTP",
+          "25271",
+          "254 NEXTP"
+        ]
+      },
+      {
+        "name": "SHOWX",
+        "number": 247,
+        "aliases": [
+          "SHOWXHD",
+          "18086",
+          "60947",
+          "247 SHOWX",
+          "SHOWXP",
+          "18164",
+          "255 SHOWXP"
+        ]
+      },
+      {
+        "name": "FAMZ",
+        "number": 248,
+        "aliases": [
+          "25274",
+          "248 FAMZ",
+          "FAMZP",
+          "25275",
+          "256 FAMZP"
+        ]
+      },
+      {
+        "name": "The Movie Channel",
+        "number": 261,
+        "aliases": [
+          "TMC",
+          "TMCHD",
+          "11160",
+          "35329",
+          "261 TMC",
+          "TMCP",
+          "12509",
+          "263 TMCP"
+        ]
+      },
+      {
+        "name": "TMCX",
+        "number": 262,
+        "aliases": [
+          "TMCXHD",
+          "17663",
+          "60951",
+          "262 TMCX",
+          "TMCXP",
+          "TMCXPHD",
+          "17687",
+          "60949",
+          "264 TMCXP"
+        ]
+      },
+      {
+        "name": "STARZ",
+        "number": 271,
+        "aliases": [
+          "12719",
+          "271 STARZ",
+          "STZHD",
+          "34941",
+          "1466 STZHD"
+        ]
+      },
+      {
+        "name": "STZE",
+        "number": 272,
+        "aliases": [
+          "STZEHD",
+          "16311",
+          "57573",
+          "272 STZE"
+        ]
+      },
+      {
+        "name": "STZIB",
+        "number": 273,
+        "aliases": [
+          "16833",
+          "273 STZIB",
+          "STRZIBH",
+          "67235",
+          "1469 STRZIBH"
+        ]
+      },
+      {
+        "name": "SRZK",
+        "number": 274,
+        "aliases": [
+          "STZK",
+          "STZKHD",
+          "19635",
+          "57581",
+          "274 STZK"
+        ]
+      },
+      {
+        "name": "STZCI",
+        "number": 275,
+        "aliases": [
+          "19634",
+          "275 STZCI",
+          "STRZCIH",
+          "67236",
+          "1471 STRZCIH"
+        ]
+      },
+      {
+        "name": "SRZC",
+        "number": 276,
+        "aliases": [
+          "STZC",
+          "STZCHD",
+          "34901",
+          "57569",
+          "276 STZC"
+        ]
+      },
+      {
+        "name": "MGM+",
+        "number": 364,
+        "aliases": [
+          "MGM",
+          "MGMHD",
+          "65669",
+          "65687",
+          "364 MGM"
+        ]
+      },
+      {
+        "name": "MGMHIT",
+        "number": 365,
+        "aliases": [
+          "73075",
+          "365 MGMHIT",
+          "MGMHTH",
+          "67929",
+          "1365 MGMHTH",
+          "MGM+ Hits HD"
+        ]
+      },
+      {
+        "name": "MGM+ Drive-In",
+        "number": 367,
+        "aliases": [
+          "MGMDRV",
+          "68409",
+          "367 MGMDRV"
+        ]
+      },
+      {
+        "name": "Flix",
+        "number": 371,
+        "aliases": [
+          "FLIX",
+          "10201",
+          "371 FLIX",
+          "FLIXP",
+          "16575",
+          "372 FLIXP"
+        ]
+      },
+      {
+        "name": "STZENC",
+        "number": 377,
+        "aliases": [
+          "10178",
+          "377 STZENC",
+          "STZENHD",
+          "36225",
+          "1377 STZENHD"
+        ]
+      },
+      {
+        "name": "STZEFM",
+        "number": 378,
+        "aliases": [
+          "STZENFS",
+          "102903",
+          "378 STZENFS"
+        ]
+      },
+      {
+        "name": "STZECL",
+        "number": 379,
+        "aliases": [
+          "STZENCL",
+          "14764",
+          "379 STZENCL"
+        ]
+      },
+      {
+        "name": "STZEWSS",
+        "number": 380,
+        "aliases": [
+          "102906",
+          "380 STZEWSS"
+        ]
+      },
+      {
+        "name": "STZESU",
+        "number": 381,
+        "aliases": [
+          "STZENSU",
+          "14766",
+          "381 STZENSU"
+        ]
+      },
+      {
+        "name": "STZEAC",
+        "number": 382,
+        "aliases": [
+          "STZENAC",
+          "14871",
+          "382 STZENAC"
+        ]
+      },
+      {
+        "name": "STZEBK",
+        "number": 383,
+        "aliases": [
+          "STZENBK",
+          "14870",
+          "383 STZENBK"
+        ]
+      },
+      {
+        "name": "RetroPlex",
+        "number": 386,
+        "aliases": [
+          "RETRO",
+          "RETROHD",
+          "49767",
+          "65791",
+          "386 RETRO"
+        ]
+      },
+      {
+        "name": "IndiePlex",
+        "number": 387,
+        "aliases": [
+          "INDIE",
+          "INDIE-E",
+          "INDIEHD",
+          "49751",
+          "65795",
+          "387 INDIE"
+        ]
+      },
+      {
+        "name": "STZENCP",
+        "number": 388,
+        "aliases": [
+          "17125",
+          "388 STZENCP"
+        ]
+      },
+      {
+        "name": "STZENFP",
+        "number": 389,
+        "aliases": [
+          "17131",
+          "389 STZENFP"
+        ]
+      },
+      {
+        "name": "STZESP",
+        "number": 390,
+        "aliases": [
+          "72016",
+          "390 STZESP"
+        ]
+      },
+      {
+        "name": "MoviePlex",
+        "number": 391,
+        "aliases": [
+          "MPLEX",
+          "PLEX",
+          "MPLEXHD",
+          "15295",
+          "83075",
+          "391 MPLEX"
+        ]
+      },
+      {
+        "name": "MGM+ Marquee",
+        "number": 1366,
+        "aliases": [
+          "74073",
+          "1366 MGMMRHD",
+          "MGMMRHD",
+          "MGM+ Marquee HD"
+        ]
+      }
+    ],
+    "Faith": [
+      {
+        "name": "EWTN",
+        "number": 111,
+        "aliases": [
+          "EWTNHD",
+          "10183",
+          "67164",
+          "111 EWTN"
+        ]
+      },
+      {
+        "name": "TBN",
+        "number": 131,
+        "aliases": [
+          "14767",
+          "131 TBN"
+        ]
+      },
+      {
+        "name": "JLT",
+        "number": 172,
+        "aliases": [
+          "JLTV",
+          "60165",
+          "172 JLTV"
+        ]
+      },
+      {
+        "name": "BYUtv",
+        "number": 197,
+        "aliases": [
+          "BYUTV",
+          "BYU",
+          "BYUTVHD",
+          "21855",
+          "71764",
+          "197 BYUTV"
+        ]
+      },
+      {
+        "name": "SonLife Broadcasting Network",
+        "number": 199,
+        "aliases": [
+          "SBND",
+          "67676",
+          "30324",
+          "199 SBND"
+        ]
+      },
+      {
+        "name": "JBS",
+        "number": 1223,
+        "aliases": [
+          "74978",
+          "1223 JBS"
+        ]
+      }
+    ],
+    "Shopping": [
+      {
+        "name": "HSN",
+        "number": 101,
+        "aliases": [
+          "HSNHD",
+          "10269",
+          "62077",
+          "101 HSN"
+        ]
+      },
+      {
+        "name": "QVC",
+        "number": 130,
+        "aliases": [
+          "QVCHD",
+          "11069",
+          "60222",
+          "130 QVC"
+        ]
+      },
+      {
+        "name": "HSN2",
+        "number": 161,
+        "aliases": [
+          "10270",
+          "161 HSN2"
+        ]
+      },
+      {
+        "name": "QVC2",
+        "number": 162,
+        "aliases": [
+          "QVC2HD",
+          "82682",
+          "82696",
+          "162 QVC2"
+        ]
+      },
+      {
+        "name": "GEMSSD",
+        "number": 184,
+        "aliases": [
+          "GEMSHD",
+          "26643",
+          "109264",
+          "184 GEMSSD"
+        ]
+      },
+      {
+        "name": "SHOPLC",
+        "number": 185,
+        "aliases": [
+          "56032",
+          "185 SHOPLC"
+        ]
+      },
+      {
+        "name": "JTV",
+        "number": 1328,
+        "aliases": [
+          "JTVHD",
+          "65556",
+          "1328 JTVHD"
+        ]
+      },
+      {
+        "name": "SHOPLCH",
+        "number": 1330,
+        "aliases": [
+          "93564",
+          "1330 SHOPLCH"
+        ]
+      },
+      {
+        "name": "QVC3",
+        "number": 1332,
+        "aliases": [
+          "101260",
+          "1332 QVC3"
+        ]
+      }
+    ],
+    "International": [
+      {
+        "name": "ART America",
+        "number": 501,
+        "aliases": [
+          "ARTAMER",
+          "19979",
+          "501 ARTAMER"
+        ]
+      },
+      {
+        "name": "The Arabic Channel",
+        "number": 502,
+        "aliases": [
+          "ARABCH",
+          "23775",
+          "502 ARABCH"
+        ]
+      },
+      {
+        "name": "SBN",
+        "number": 505,
+        "aliases": [
+          "505 SBN"
+        ]
+      },
+      {
+        "name": "TVBV",
+        "number": 506,
+        "aliases": [
+          "53070",
+          "506 TVBV"
+        ]
+      },
+      {
+        "name": "RGTI",
+        "number": 510,
+        "aliases": [
+          "21065",
+          "510 RGTI"
+        ]
+      },
+      {
+        "name": "RTP Internacional",
+        "number": 512,
+        "aliases": [
+          "RTPI",
+          "15717",
+          "512 RTPI"
+        ]
+      },
+      {
+        "name": "TVB1",
+        "number": 515,
+        "aliases": [
+          "16333",
+          "515 TVB1"
+        ]
+      },
+      {
+        "name": "TVBDC",
+        "number": 516,
+        "aliases": [
+          "32145",
+          "516 TVBDC"
+        ]
+      },
+      {
+        "name": "TVBE",
+        "number": 517,
+        "aliases": [
+          "21187",
+          "517 TVBE"
+        ]
+      },
+      {
+        "name": "TVBNW",
+        "number": 518,
+        "aliases": [
+          "32147",
+          "518 TVBNW"
+        ]
+      },
+      {
+        "name": "FILPEHD",
+        "number": 520,
+        "aliases": [
+          "114048",
+          "520 FILPEHD"
+        ]
+      },
+      {
+        "name": "GMAPNY",
+        "number": 521,
+        "aliases": [
+          "46463",
+          "521 GMAPNY"
+        ]
+      },
+      {
+        "name": "GMALIFE",
+        "number": 522,
+        "aliases": [
+          "60152",
+          "522 GMALIFE"
+        ]
+      },
+      {
+        "name": "LSNET",
+        "number": 523,
+        "aliases": [
+          "80214",
+          "523 LSNET"
+        ]
+      },
+      {
+        "name": "DWLSRA",
+        "number": 524,
+        "aliases": [
+          "67374",
+          "524 DWLSRA"
+        ]
+      },
+      {
+        "name": "DZBBRA",
+        "number": 525,
+        "aliases": [
+          "67373",
+          "525 DZBBRA"
+        ]
+      },
+      {
+        "name": "RT",
+        "number": 530,
+        "aliases": [
+          "RTN",
+          "18424",
+          "530 RTN"
+        ]
+      },
+      {
+        "name": "RUSKINO",
+        "number": 531,
+        "aliases": [
+          "61399",
+          "531 RUSKINO"
+        ]
+      },
+      {
+        "name": "RTVi",
+        "number": 536,
+        "aliases": [
+          "RTVINT",
+          "21063",
+          "536 RTVINT"
+        ]
+      },
+      {
+        "name": "ANTEN",
+        "number": 557,
+        "aliases": [
+          "16372",
+          "557 ANTEN"
+        ]
+      },
+      {
+        "name": "ASIA",
+        "number": 560,
+        "aliases": [
+          "14763",
+          "560 ASIA"
+        ]
+      },
+      {
+        "name": "Zee TV",
+        "number": 562,
+        "aliases": [
+          "ZEETVH",
+          "ZEE",
+          "77032",
+          "562 ZEETVH"
+        ]
+      },
+      {
+        "name": "FILMY",
+        "number": 564,
+        "aliases": [
+          "52285",
+          "564 FILMY"
+        ]
+      },
+      {
+        "name": "ABPN",
+        "number": 567,
+        "aliases": [
+          "ABPNWS",
+          "44851",
+          "567 ABPNWS"
+        ]
+      },
+      {
+        "name": "ITVG",
+        "number": 569,
+        "aliases": [
+          "ITVGHD",
+          "21858",
+          "114663",
+          "569 ITVG"
+        ]
+      },
+      {
+        "name": "NDTV2",
+        "number": 570,
+        "aliases": [
+          "49172",
+          "570 NDTV2"
+        ]
+      },
+      {
+        "name": "Rai Italia",
+        "number": 574,
+        "aliases": [
+          "RAII",
+          "17250",
+          "574 RAII"
+        ]
+      },
+      {
+        "name": "MITALIA",
+        "number": 575,
+        "aliases": [
+          "69529",
+          "575 MITALIA"
+        ]
+      },
+      {
+        "name": "TV5MONDE",
+        "number": 577,
+        "aliases": [
+          "TV5MOND",
+          "19059",
+          "577 TV5MOND"
+        ]
+      },
+      {
+        "name": "TVK1",
+        "number": 580,
+        "aliases": [
+          "46384",
+          "580 TVK1"
+        ]
+      },
+      {
+        "name": "TVK2",
+        "number": 581,
+        "aliases": [
+          "66157",
+          "581 TVK2"
+        ]
+      },
+      {
+        "name": "KBS World",
+        "number": 583,
+        "aliases": [
+          "KBSAM",
+          "KBSAM-TV",
+          "34164",
+          "583 KBSAM"
+        ]
+      },
+      {
+        "name": "MBCD",
+        "number": 584,
+        "aliases": [
+          "70622",
+          "584 MBCD"
+        ]
+      },
+      {
+        "name": "CCTV-4",
+        "number": 590,
+        "aliases": [
+          "CCTV4",
+          "24248",
+          "590 CCTV4"
+        ]
+      },
+      {
+        "name": "CITZTC",
+        "number": 591,
+        "aliases": [
+          "CTIZTC",
+          "20655",
+          "591 CTIZTC"
+        ]
+      },
+      {
+        "name": "ETTV",
+        "number": 592,
+        "aliases": [
+          "57753",
+          "592 ETTV"
+        ]
+      },
+      {
+        "name": "ETDRA",
+        "number": 593,
+        "aliases": [
+          "35271",
+          "593 ETDRA"
+        ]
+      },
+      {
+        "name": "ETCHI",
+        "number": 594,
+        "aliases": [
+          "35272",
+          "594 ETCHI"
+        ]
+      },
+      {
+        "name": "ETFINWS",
+        "number": 595,
+        "aliases": [
+          "66487",
+          "595 ETFINWS"
+        ]
+      },
+      {
+        "name": "YOYO",
+        "number": 596,
+        "aliases": [
+          "35270",
+          "596 YOYO"
+        ]
+      },
+      {
+        "name": "Phoenix InfoNews",
+        "number": 597,
+        "aliases": [
+          "PHNIN",
+          "44617",
+          "597 PHNIN"
+        ]
+      },
+      {
+        "name": "PNAX",
+        "number": 598,
+        "aliases": [
+          "24935",
+          "598 PNAX"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/US_Spectrum-Tampa-Bay-Spanish-Only_lineup.json
+++ b/plugins/lineuparr/US_Spectrum-Tampa-Bay-Spanish-Only_lineup.json
@@ -1,0 +1,770 @@
+{
+  "package": "Spectrum Tampa Bay - Spanish IPTV Clean",
+  "date": "2026-08-18",
+  "description": "Curated Spanish-language Spectrum Tampa Bay logical-channel lineup optimized for IPTV/Lineuparr.",
+  "source": "Spectrum Tampa Bay source lineup, cross-checked against the supplied TV Passport guide and curated for IPTV/Lineuparr use.",
+  "categories": {
+    "Spanish": [
+      {
+        "name": "WVEA-TV",
+        "number": 901,
+        "aliases": [
+          "WVEA",
+          "WVEADT",
+          "15444",
+          "44560",
+          "901 WVEA"
+        ]
+      },
+      {
+        "name": "WRMD-CD",
+        "number": 902,
+        "aliases": [
+          "WRMDCA",
+          "WRMDCA-TV",
+          "11247",
+          "902 WRMDCA"
+        ]
+      },
+      {
+        "name": "WVEA6SD",
+        "number": 903,
+        "aliases": [
+          "WVEA6SD-TV",
+          "122157",
+          "903 WVEA6SD"
+        ]
+      },
+      {
+        "name": "CNN en Español",
+        "number": 904,
+        "aliases": [
+          "CNNE",
+          "58631",
+          "904 CNNE"
+        ]
+      },
+      {
+        "name": "CNL24",
+        "number": 905,
+        "aliases": [
+          "92651",
+          "905 CNL24"
+        ]
+      },
+      {
+        "name": "SUR",
+        "number": 906,
+        "aliases": [
+          "12750",
+          "906 SUR"
+        ]
+      },
+      {
+        "name": "CENTROA",
+        "number": 907,
+        "aliases": [
+          "44448",
+          "907 CENTROA"
+        ]
+      },
+      {
+        "name": "WMORDT3",
+        "number": 910,
+        "aliases": [
+          "WMORDT3 ESTRLLA",
+          "WMORDT3-TV",
+          "65069",
+          "910 WMORDT3"
+        ]
+      },
+      {
+        "name": "CM",
+        "number": 912,
+        "aliases": [
+          "CMEX",
+          "44714",
+          "912 CMEX"
+        ]
+      },
+      {
+        "name": "beIN Sports en Español",
+        "number": 913,
+        "aliases": [
+          "BEINSES",
+          "76943",
+          "913 BEINSES"
+        ]
+      },
+      {
+        "name": "ESPN Deportes",
+        "number": 914,
+        "aliases": [
+          "ESPND",
+          "ESPNDHD",
+          "25595",
+          "71914",
+          "914 ESPND"
+        ]
+      },
+      {
+        "name": "FOX Deportes",
+        "number": 915,
+        "aliases": [
+          "FXDEP",
+          "FXDEPHD",
+          "15377",
+          "72189",
+          "915 FXDEP"
+        ]
+      },
+      {
+        "name": "Galavisión",
+        "number": 917,
+        "aliases": [
+          "GALA",
+          "GALAHD",
+          "10222",
+          "68367",
+          "917 GALA"
+        ]
+      },
+      {
+        "name": "WAPAUS",
+        "number": 918,
+        "aliases": [
+          "WAPAUS-TV",
+          "44322",
+          "918 WAPAUS"
+        ]
+      },
+      {
+        "name": "TVE",
+        "number": 919,
+        "aliases": [
+          "TVEI",
+          "16217",
+          "919 TVEI"
+        ]
+      },
+      {
+        "name": "SNNOTFL",
+        "number": 920,
+        "aliases": [
+          "174022",
+          "920 SNNOTFL"
+        ]
+      },
+      {
+        "name": "SORPRESA",
+        "number": 921,
+        "aliases": [
+          "25347",
+          "921 SORPRESA"
+        ]
+      },
+      {
+        "name": "DFAM",
+        "number": 922,
+        "aliases": [
+          "58428",
+          "922 DFAM"
+        ]
+      },
+      {
+        "name": "EWTN Español",
+        "number": 924,
+        "aliases": [
+          "EWTNES",
+          "EWTNE",
+          "52649",
+          "924 EWTNES"
+        ]
+      },
+      {
+        "name": "History en Español",
+        "number": 926,
+        "aliases": [
+          "HISTE",
+          "43362",
+          "926 HISTE"
+        ]
+      },
+      {
+        "name": "COMERTVH",
+        "number": 927,
+        "aliases": [
+          "166714",
+          "927 COMERTVH"
+        ]
+      },
+      {
+        "name": "CINLUS",
+        "number": 928,
+        "aliases": [
+          "62401",
+          "928 CINLUS"
+        ]
+      },
+      {
+        "name": "Universo",
+        "number": 929,
+        "aliases": [
+          "UNVSO",
+          "UNVSOHD",
+          "14791",
+          "91588",
+          "929 UNVSO"
+        ]
+      },
+      {
+        "name": "MTV Tr3s",
+        "number": 930,
+        "aliases": [
+          "TR3S",
+          "18715",
+          "930 TR3S"
+        ]
+      },
+      {
+        "name": "UNI-T",
+        "number": 931,
+        "aliases": [
+          "UNITLNO",
+          "74550",
+          "931 UNITLNO"
+        ]
+      },
+      {
+        "name": "TeleN",
+        "number": 932,
+        "aliases": [
+          "TELEN",
+          "48523",
+          "932 TELEN"
+        ]
+      },
+      {
+        "name": "TVV",
+        "number": 934,
+        "aliases": [
+          "49262",
+          "934 TVV"
+        ]
+      },
+      {
+        "name": "ECUAVI",
+        "number": 935,
+        "aliases": [
+          "44644",
+          "935 ECUAVI"
+        ]
+      },
+      {
+        "name": "CARAI",
+        "number": 936,
+        "aliases": [
+          "39719",
+          "936 CARAI"
+        ]
+      },
+      {
+        "name": "NUESTRT",
+        "number": 937,
+        "aliases": [
+          "33431",
+          "937 NUESTRT"
+        ]
+      },
+      {
+        "name": "DOMIN",
+        "number": 938,
+        "aliases": [
+          "49022",
+          "938 DOMIN"
+        ]
+      },
+      {
+        "name": "CANAL11",
+        "number": 939,
+        "aliases": [
+          "36139",
+          "939 CANAL11"
+        ]
+      },
+      {
+        "name": "NMASFOR",
+        "number": 941,
+        "aliases": [
+          "76964",
+          "941 NMASFOR"
+        ]
+      },
+      {
+        "name": "TUDN",
+        "number": 942,
+        "aliases": [
+          "TUDNU",
+          "75176",
+          "942 TUDNU"
+        ]
+      },
+      {
+        "name": "HBO Latino",
+        "number": 944,
+        "aliases": [
+          "HBOLAT",
+          "24553",
+          "944 HBOLAT"
+        ]
+      },
+      {
+        "name": "HBOLATP",
+        "number": 945,
+        "aliases": [
+          "24575",
+          "945 HBOLATP"
+        ]
+      },
+      {
+        "name": "CMAX",
+        "number": 946,
+        "aliases": [
+          "CMAXHD",
+          "25623",
+          "59965",
+          "946 CMAX"
+        ]
+      },
+      {
+        "name": "VM",
+        "number": 947,
+        "aliases": [
+          "VMOV",
+          "VMOVHD",
+          "52208",
+          "102336",
+          "947 VMOV"
+        ]
+      },
+      {
+        "name": "WZRACA",
+        "number": 948,
+        "aliases": [
+          "WZRACA-TV",
+          "31947",
+          "948 WZRACA"
+        ]
+      },
+      {
+        "name": "Cuba",
+        "number": 949,
+        "aliases": [
+          "CUBAPLY",
+          "73318",
+          "949 CUBAPLY"
+        ]
+      },
+      {
+        "name": "XEIMT",
+        "number": 950,
+        "aliases": [
+          "15232",
+          "950 XEIMT"
+        ]
+      },
+      {
+        "name": "ESTUD5",
+        "number": 951,
+        "aliases": [
+          "88506",
+          "951 ESTUD5"
+        ]
+      },
+      {
+        "name": "MULT",
+        "number": 952,
+        "aliases": [
+          "MULTV",
+          "MULTVHD",
+          "50500",
+          "91505",
+          "952 MULTV"
+        ]
+      },
+      {
+        "name": "FORM",
+        "number": 953,
+        "aliases": [
+          "TFORM",
+          "TFORMHD",
+          "34344",
+          "87167",
+          "953 TFORM"
+        ]
+      },
+      {
+        "name": "SURPERU",
+        "number": 955,
+        "aliases": [
+          "46753",
+          "955 SURPERU"
+        ]
+      },
+      {
+        "name": "TVNI",
+        "number": 956,
+        "aliases": [
+          "16046",
+          "956 TVNI"
+        ]
+      },
+      {
+        "name": "TELS",
+        "number": 957,
+        "aliases": [
+          "TELSALV",
+          "65809",
+          "957 TELSALV"
+        ]
+      },
+      {
+        "name": "SUPCAN",
+        "number": 958,
+        "aliases": [
+          "24515",
+          "958 SUPCAN"
+        ]
+      },
+      {
+        "name": "MICRO",
+        "number": 959,
+        "aliases": [
+          "TMICRO",
+          "45243",
+          "959 TMICRO"
+        ]
+      },
+      {
+        "name": "ANT3",
+        "number": 960,
+        "aliases": [
+          "ANT3I",
+          "16800",
+          "960 ANT3I"
+        ]
+      },
+      {
+        "name": "BAND",
+        "number": 961,
+        "aliases": [
+          "BANDAUS",
+          "54867",
+          "961 BANDAUS"
+        ]
+      },
+      {
+        "name": "THMUS",
+        "number": 962,
+        "aliases": [
+          "34394",
+          "962 THMUS"
+        ]
+      },
+      {
+        "name": "THIT",
+        "number": 963,
+        "aliases": [
+          "THITUS",
+          "34393",
+          "963 THITUS"
+        ]
+      },
+      {
+        "name": "KIDSSHD",
+        "number": 967,
+        "aliases": [
+          "KIDSSHD-TV",
+          "102442",
+          "967 KIDSSHD"
+        ]
+      },
+      {
+        "name": "HOGARHD",
+        "number": 969,
+        "aliases": [
+          "114881",
+          "969 HOGARHD"
+        ]
+      },
+      {
+        "name": "TOON en Español",
+        "number": 970,
+        "aliases": [
+          "STOON",
+          "38279",
+          "970 STOON"
+        ]
+      },
+      {
+        "name": "ATRESSD",
+        "number": 972,
+        "aliases": [
+          "ATRES",
+          "90917",
+          "90898",
+          "972 ATRESSD"
+        ]
+      },
+      {
+        "name": "BABY1AS",
+        "number": 974,
+        "aliases": [
+          "78831",
+          "974 BABY1AS"
+        ]
+      },
+      {
+        "name": "BABY",
+        "number": 975,
+        "aliases": [
+          "BABYUS",
+          "70337",
+          "975 BABYUS"
+        ]
+      },
+      {
+        "name": "NGM",
+        "number": 976,
+        "aliases": [
+          "NGMUNDH",
+          "117788",
+          "976 NGMUNDH"
+        ]
+      },
+      {
+        "name": "HITN",
+        "number": 977,
+        "aliases": [
+          "17142",
+          "977 HITN"
+        ]
+      },
+      {
+        "name": "MEXCAN",
+        "number": 978,
+        "aliases": [
+          "47499",
+          "978 MEXCAN"
+        ]
+      },
+      {
+        "name": "DPLUSSD",
+        "number": 979,
+        "aliases": [
+          "100502",
+          "979 DPLUSSD"
+        ]
+      },
+      {
+        "name": "PELIC",
+        "number": 980,
+        "aliases": [
+          "DEPELC",
+          "33628",
+          "980 DEPELC"
+        ]
+      },
+      {
+        "name": "APLAUSD",
+        "number": 981,
+        "aliases": [
+          "109111",
+          "981 APLAUSD"
+        ]
+      },
+      {
+        "name": "VMEHD",
+        "number": 982,
+        "aliases": [
+          "122713",
+          "982 VMEHD"
+        ]
+      },
+      {
+        "name": "SUPCAHD",
+        "number": 1853,
+        "aliases": [
+          "90322",
+          "1853 SUPCAHD"
+        ]
+      },
+      {
+        "name": "APLAUSO",
+        "number": 1854,
+        "aliases": [
+          "80559",
+          "1854 APLAUSO"
+        ]
+      },
+      {
+        "name": "DOCU",
+        "number": 1859,
+        "aliases": [
+          "UDOCU",
+          "79605",
+          "1859 UDOCU"
+        ]
+      },
+      {
+        "name": "UFAMIL",
+        "number": 1866,
+        "aliases": [
+          "80149",
+          "1866 UFAMIL"
+        ]
+      },
+      {
+        "name": "SOCINH",
+        "number": 1868,
+        "aliases": [
+          "76408",
+          "1868 SOCINH"
+        ]
+      },
+      {
+        "name": "PAS",
+        "number": 1870,
+        "aliases": [
+          "PASNUS",
+          "61776",
+          "1870 PASNUS"
+        ]
+      },
+      {
+        "name": "DSCE",
+        "number": 1874,
+        "aliases": [
+          "19247",
+          "1874 DSCE"
+        ]
+      },
+      {
+        "name": "CINE",
+        "number": 1893,
+        "aliases": [
+          "UCINE",
+          "79680",
+          "1893 UCINE"
+        ]
+      },
+      {
+        "name": "UCLAS",
+        "number": 1894,
+        "aliases": [
+          "79695",
+          "1894 UCLAS"
+        ]
+      },
+      {
+        "name": "FIESTA",
+        "number": 1895,
+        "aliases": [
+          "UFEST",
+          "79607",
+          "1895 UFEST"
+        ]
+      },
+      {
+        "name": "UKIDZ",
+        "number": 1896,
+        "aliases": [
+          "79606",
+          "1896 UKIDZ"
+        ]
+      },
+      {
+        "name": "UMACHO",
+        "number": 1897,
+        "aliases": [
+          "79696",
+          "1897 UMACHO"
+        ]
+      },
+      {
+        "name": "ULTMEX",
+        "number": 1898,
+        "aliases": [
+          "79692",
+          "1898 ULTMEX"
+        ]
+      },
+      {
+        "name": "WVEADT6",
+        "number": 1903,
+        "aliases": [
+          "WVEADT6-TV",
+          "122148",
+          "1903 WVEADT6"
+        ]
+      },
+      {
+        "name": "SPCMDEP",
+        "number": 1913,
+        "aliases": [
+          "77428",
+          "1913 SPCMDEP"
+        ]
+      },
+      {
+        "name": "GOLTVIH",
+        "number": 1916,
+        "aliases": [
+          "68608",
+          "1916 GOLTVIH"
+        ]
+      },
+      {
+        "name": "WRMDCD",
+        "number": 1918,
+        "aliases": [
+          "WRMDCD-TV",
+          "84545",
+          "1918 WRMDCD"
+        ]
+      },
+      {
+        "name": "BEIN2HD",
+        "number": 1919,
+        "aliases": [
+          "76955",
+          "1919 BEIN2HD"
+        ]
+      },
+      {
+        "name": "EWTNEHD",
+        "number": 1920,
+        "aliases": [
+          "72123",
+          "1920 EWTNEHD"
+        ]
+      },
+      {
+        "name": "TUDNUH",
+        "number": 1942,
+        "aliases": [
+          "77033",
+          "1942 TUDNUH"
+        ]
+      },
+      {
+        "name": "HBOLAHD",
+        "number": 1944,
+        "aliases": [
+          "59837",
+          "1944 HBOLAHD"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/lineuparr/US_Verizon-FIOS-All-11743_lineup.json
+++ b/plugins/lineuparr/US_Verizon-FIOS-All-11743_lineup.json
@@ -540,7 +540,7 @@
         ]
       },
       {
-        "name": "Movies! (WNYWDT2)",
+        "name": "Movies! - WNYWDT2",
         "number": 493,
         "aliases": [
           "WNYWDT2",
@@ -588,8 +588,6 @@
         "number": 496,
         "aliases": [
           "US: CATCHY COMEDY HD",
-          "US: COMEDY CENTRAL HD",
-          "ComedyCentral.us",
           "WNYWDT5",
           "112941",
           "112941268",
@@ -876,7 +874,6 @@
           "26182283",
           "11715",
           "1171510",
-          "PUBLIC BROADCASTING SERVICE",
           "513 WNETDT"
         ],
         "epg_ids": [
@@ -884,7 +881,7 @@
         ]
       },
       {
-        "name": "UniMás 68",
+        "name": "UniMás 68 - WFUTDT",
         "number": 517,
         "aliases": [
           "WFUT",
@@ -895,7 +892,6 @@
           "35364284",
           "11527",
           "1152712",
-          "UNIMAS",
           "517 WFUTDT"
         ],
         "epg_ids": [
@@ -948,7 +944,6 @@
           "34325287",
           "11643",
           "1164315",
-          "PUBLIC BROADCASTING SERVICE",
           "521 WLIWDT"
         ],
         "epg_ids": [
@@ -967,7 +962,6 @@
           "29139288",
           "11723",
           "1172316",
-          "PUBLIC BROADCASTING SERVICE",
           "523 WNJNDT"
         ],
         "epg_ids": [
@@ -1190,14 +1184,16 @@
         ]
       },
       {
-        "name": "NEWSNTN",
+        "name": "NewsNation",
         "number": 604,
         "aliases": [
           "NEWSNTN",
           "91096",
           "91096331",
           "604 NEWSNTN",
-          "NEWSNATION"
+          "NEWSNATION",
+          "NEWS NATION",
+          "WGN AMERICA"
         ],
         "epg_ids": [
           "91096"
@@ -1224,16 +1220,16 @@
         "name": "C-SPAN",
         "number": 606,
         "aliases": [
-          "US: C-SPAN 2 HD",
           "US: C-SPAN 1 HD",
-          "US: C-SPAN 3 HD",
           "CSPANHD",
           "68344",
           "68344333",
           "606 CSPANHD",
           "606 C-SPAN HD",
           "C-SPAN HD",
-          "CSPAN"
+          "CSPAN",
+          "US: C-SPAN HD",
+          "C-SPAN"
         ],
         "epg_ids": [
           "68344"
@@ -1247,7 +1243,9 @@
           "68334",
           "68334334",
           "607 CSPN2HD",
-          "CSPAN2"
+          "CSPAN2",
+          "US: C-SPAN 2 HD",
+          "C-SPAN 2"
         ],
         "epg_ids": [
           "68334"
@@ -1261,7 +1259,9 @@
           "68332",
           "68332335",
           "608 CSPN3HD",
-          "CSPAN3"
+          "CSPAN3",
+          "US: C-SPAN 3 HD",
+          "C-SPAN 3"
         ],
         "epg_ids": [
           "68332"
@@ -1301,7 +1301,6 @@
         "number": 611,
         "aliases": [
           "US: THE WEATHER CHANNEL HD",
-          "TheWeatherNetwork.ca",
           "WEATHER CHANNEL",
           "TWC",
           "WEATHHD",
@@ -1333,13 +1332,15 @@
         ]
       },
       {
-        "name": "CHEDSTR",
+        "name": "Cheddar News",
         "number": 614,
         "aliases": [
           "CHEDSTR",
           "101103",
           "101103340",
-          "614 CHEDSTR"
+          "614 CHEDSTR",
+          "CHEDDAR NEWS",
+          "CHEDDAR"
         ],
         "epg_ids": [
           "101103"
@@ -1403,7 +1404,7 @@
         ]
       },
       {
-        "name": "AWNYHD",
+        "name": "AccuWeather Network",
         "number": 619,
         "aliases": [
           "AWNYHD",
@@ -1411,7 +1412,10 @@
           "102910344",
           "619 AWNYHD",
           "619 AccuWeather NY",
-          "AccuWeather NY"
+          "AccuWeather NY",
+          "ACCUWEATHER NETWORK",
+          "ACCUWEATHER NY",
+          "ACCUWEATHER"
         ],
         "epg_ids": [
           "102910"
@@ -1634,8 +1638,6 @@
         "name": "MSG Sportsnet 2",
         "number": 581,
         "aliases": [
-          "US: MSG 2 HD",
-          "MadisonSquareGarden2.us",
           "MSGSN21",
           "MSG2SNH",
           "70285",
@@ -1658,9 +1660,6 @@
           "FoxSports1.us",
           "US: FOX SPORTS 1 HD",
           "US: FOX SPORTS 1",
-          "US: FOX SPORTS WEST HD",
-          "US: FOX SPORTS WEST",
-          "FOXSports.us",
           "FS1",
           "FOX SPORTS 1 HD",
           "FS1HD",
@@ -1684,9 +1683,6 @@
           "FoxSports2.us",
           "US: FOX SPORTS 2 HD",
           "US: FOX SPORTS 2",
-          "US: FOX SPORTS WEST HD",
-          "US: FOX SPORTS WEST",
-          "FOXSports.us",
           "FS2",
           "FOX SPORTS 2 HD",
           "FS2HD",
@@ -1799,25 +1795,16 @@
           "US: TENNIS HD",
           "TennisChannel.us",
           "US: TENNIS CHANNEL",
-          "US: TENNIS CHANNEL PLUS 1",
-          "US: TENNIS CHANNEL PLUS 2",
-          "US: TENNIS CHANNEL PLUS 3",
-          "US: TENNIS CHANNEL PLUS 4",
-          "US: TENNIS CHANNEL PLUS 5",
-          "US: TENNIS CHANNEL PLUS 6",
-          "US: TENNIS CHANNEL PLUS 7",
-          "US: TENNIS CHANNEL PLUS 8",
-          "US: TENNIS CHANNEL PLUS 9",
-          "US: TENNIS CHANNEL PLUS 10",
-          "US: TENNIS CHANNEL PLUS 11",
-          "US: TENNIS CHANNEL PLUS 12",
           "TENISHD",
           "60316",
           "60316321",
           "TENNIS",
           "33395",
           "3339566",
-          "592 TENISHD"
+          "592 TENISHD",
+          "US: TENNIS CHANNEL HD",
+          "TENNIS CHANNEL",
+          "TENNIS CHANNEL HD"
         ],
         "epg_ids": [
           "60316"
@@ -1944,8 +1931,6 @@
         "aliases": [
           "US: WILLOW CRICKET HD",
           "WillowCricket.us",
-          "US: WILLOW CRICKET EXTRA HD",
-          "WILLX.us",
           "WLLOHD",
           "80621",
           "80621445",
@@ -1956,14 +1941,17 @@
         ]
       },
       {
-        "name": "MAVTV",
+        "name": "RACER Network",
         "number": 810,
         "addon": "Sports Pass",
         "aliases": [
           "RACERHD",
           "61036",
           "61036446",
-          "810 RACERHD"
+          "810 RACERHD",
+          "MAVTV",
+          "RACER NETWORK",
+          "RACER"
         ],
         "epg_ids": [
           "61036"
@@ -1977,7 +1965,9 @@
           "FDUELTV",
           "21345",
           "21345447",
-          "815 FDUELTV"
+          "815 FDUELTV",
+          "FANDUEL TV",
+          "TVG"
         ],
         "epg_ids": [
           "21345"
@@ -2300,7 +2290,7 @@
     ],
     "Movies": [
       {
-        "name": "STARZP",
+        "name": "Starz West",
         "number": 341,
         "addon": "Starz",
         "aliases": [
@@ -2314,20 +2304,7 @@
         ]
       },
       {
-        "name": "VZ32",
-        "number": 343,
-        "aliases": [
-          "VZ32",
-          "106432",
-          "106432181",
-          "343 VZ32"
-        ],
-        "epg_ids": [
-          "106432"
-        ]
-      },
-      {
-        "name": "STZENCP",
+        "name": "Starz Encore West",
         "number": 351,
         "aliases": [
           "STZENCP",
@@ -2337,23 +2314,11 @@
         ],
         "epg_ids": [
           "17125"
-        ]
-      },
-      {
-        "name": "VZ35",
-        "number": 353,
-        "aliases": [
-          "VZ35",
-          "106435",
-          "106435191",
-          "353 VZ35"
         ],
-        "epg_ids": [
-          "106435"
-        ]
+        "addon": "Starz"
       },
       {
-        "name": "STZENWP",
+        "name": "Starz Encore Westerns West - STZENWP",
         "number": 355,
         "aliases": [
           "STZENWP",
@@ -2363,36 +2328,11 @@
         ],
         "epg_ids": [
           "17132"
-        ]
-      },
-      {
-        "name": "VZ36",
-        "number": 357,
-        "aliases": [
-          "VZ36",
-          "106436",
-          "106436195",
-          "357 VZ36"
         ],
-        "epg_ids": [
-          "106436"
-        ]
+        "addon": "Starz"
       },
       {
-        "name": "VZ34",
-        "number": 359,
-        "aliases": [
-          "VZ34",
-          "106434",
-          "106434197",
-          "359 VZ34"
-        ],
-        "epg_ids": [
-          "106434"
-        ]
-      },
-      {
-        "name": "WOMEN",
+        "name": "Showtime Women East",
         "number": 375,
         "aliases": [
           "US: LIFETIME REAL WOMEN HD",
@@ -2405,10 +2345,11 @@
         ],
         "epg_ids": [
           "25272"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "WOMENP",
+        "name": "Showtime Women West",
         "number": 376,
         "aliases": [
           "WOMENP",
@@ -2418,10 +2359,11 @@
         ],
         "epg_ids": [
           "25273"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "NEXT",
+        "name": "Showtime Next East",
         "number": 377,
         "aliases": [
           "NEXT",
@@ -2431,10 +2373,11 @@
         ],
         "epg_ids": [
           "25270"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "NEXTP",
+        "name": "Showtime Next West",
         "number": 378,
         "aliases": [
           "NEXTP",
@@ -2444,10 +2387,11 @@
         ],
         "epg_ids": [
           "25271"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "FAMZ",
+        "name": "Showtime Family Zone East",
         "number": 379,
         "aliases": [
           "FAMZ",
@@ -2457,10 +2401,11 @@
         ],
         "epg_ids": [
           "25274"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "FAMZP",
+        "name": "Showtime Family Zone West",
         "number": 380,
         "aliases": [
           "FAMZP",
@@ -2470,10 +2415,11 @@
         ],
         "epg_ids": [
           "25275"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "TMCP",
+        "name": "The Movie Channel West",
         "number": 386,
         "aliases": [
           "TMCP",
@@ -2483,10 +2429,11 @@
         ],
         "epg_ids": [
           "12509"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "TMCXP",
+        "name": "The Movie Channel Xtra West",
         "number": 388,
         "aliases": [
           "TMCXP",
@@ -2496,10 +2443,11 @@
         ],
         "epg_ids": [
           "17687"
-        ]
+        ],
+        "addon": "Paramount+ with SHOWTIME"
       },
       {
-        "name": "FLIX",
+        "name": "Flix East",
         "number": 390,
         "addon": "Paramount+ with SHOWTIME",
         "aliases": [
@@ -2513,7 +2461,7 @@
         ]
       },
       {
-        "name": "FLIXP",
+        "name": "Flix West",
         "number": 391,
         "addon": "Paramount+ with SHOWTIME",
         "aliases": [
@@ -2527,20 +2475,24 @@
         ]
       },
       {
-        "name": "CINACSP",
+        "name": "Cinemax Action West",
         "number": 425,
         "aliases": [
           "CINACSP",
           "18434",
           "18434238",
-          "425 CINACSP"
+          "425 CINACSP",
+          "CINEMAX ACTION WEST",
+          "ACTIONMAX WEST",
+          "ACTION MAX WEST"
         ],
         "epg_ids": [
           "18434"
-        ]
+        ],
+        "addon": "Cinemax"
       },
       {
-        "name": "HEREHD",
+        "name": "Here TV",
         "number": 445,
         "aliases": [
           "HEREHD",
@@ -2591,7 +2543,6 @@
       {
         "name": "FX Movie Channel",
         "number": 732,
-        "addon": "Paramount+ with SHOWTIME",
         "aliases": [
           "FXM",
           "FOX MOVIE CHANNEL",
@@ -2639,13 +2590,17 @@
         ]
       },
       {
-        "name": "HFM",
+        "name": "Hallmark Family",
         "number": 737,
         "aliases": [
           "HFM",
           "105723",
           "105723412",
-          "737 HFM"
+          "737 HFM",
+          "HALLMARK FAMILY",
+          "HALLMARK FAMILY HD",
+          "HALLMARK DRAMA",
+          "HALLMARK DRAMA HD"
         ],
         "epg_ids": [
           "105723"
@@ -2670,12 +2625,14 @@
         "name": "Hallmark Mystery",
         "number": 739,
         "aliases": [
-          "US: HALLMARK HD",
-          "Hallmark.us",
           "HMYSHD",
           "46710",
           "46710414",
-          "739 HMYSHD"
+          "739 HMYSHD",
+          "HALLMARK MYSTERY",
+          "HALLMARK MYSTERY HD",
+          "HALLMARK MOVIES & MYSTERIES",
+          "HALLMARK MOVIES AND MYSTERIES"
         ],
         "epg_ids": [
           "46710"
@@ -2716,27 +2673,32 @@
         ]
       },
       {
-        "name": "Family Entertainment Television (FEENTTV)",
+        "name": "FETV",
         "number": 742,
         "aliases": [
           "FEENTTV",
           "93195",
           "93195417",
           "FAMILY ENTERTAINMENT TELEVISION",
-          "742 FEENTTV"
+          "742 FEENTTV",
+          "Family Entertainment Television (FEENTTV)"
         ],
         "epg_ids": [
           "93195"
         ]
       },
       {
-        "name": "GFAMHD",
+        "name": "Great American Family",
         "number": 743,
         "aliases": [
           "GFAMHD",
           "82892",
           "82892418",
-          "743 GFAMHD"
+          "743 GFAMHD",
+          "GREAT AMERICAN FAMILY",
+          "GREAT AMERICAN FAMILY HD",
+          "GAC FAMILY",
+          "GREAT AMERICAN COUNTRY"
         ],
         "epg_ids": [
           "82892"
@@ -2765,37 +2727,13 @@
         "aliases": [
           "US: STARZ HD",
           "Starz.us",
-          "US: STARZ BLACK HD",
-          "US: STARZ CINEMA HD",
-          "StarzCinema.us",
-          "US: STARZ CINEMA EAST HD",
-          "US: STARZ COMEDY HD",
-          "StarzComedy.us",
           "US: STARZ EAST HD",
-          "US: STARZ WEST HD",
-          "US: STARZ EDGE HD",
-          "StarzEdge.us",
-          "US: STARZ FAMILY HD",
-          "StarzEncoreFamily.us",
-          "US: STARZ ENCORE HD",
-          "StarzEncore.us",
-          "US: STARZ ENCORE EAST HD",
-          "US: STARZ ENCORE ACTION HD",
-          "StarzEncoreAction.us",
-          "US: STARZ ENCORE BLACK HD",
-          "StarzEncoreBlack.us",
-          "US: STARZ ENCORE CLASSIC HD",
-          "StarzEncoreClassics.us",
-          "US: STARZ ENCORE FAMILY HD",
-          "US: STARZ KIDS & FAMILY HD",
-          "StarzKidsFamily.us",
-          "US: STARZ ENCORE WESTERNS HD",
-          "StarzEncoreWesterns.us",
-          "US: STARZ ENCORE WEST HD",
           "STZHD",
           "34941",
           "34941454",
-          "840 STZHD"
+          "840 STZHD",
+          "STARZ",
+          "STARZ EAST"
         ],
         "epg_ids": [
           "34941"
@@ -2806,16 +2744,14 @@
         "number": 842,
         "addon": "Starz",
         "aliases": [
-          "US: STARZ HD",
-          "Starz.us",
-          "US: STARZ EAST HD",
-          "US: STARZ WEST HD",
           "US: STARZ EDGE HD",
           "StarzEdge.us",
           "STZEHD",
           "57573",
           "57573455",
-          "842 STZEHD"
+          "842 STZEHD",
+          "STARZ EDGE",
+          "STARZ EDGE EAST"
         ],
         "epg_ids": [
           "57573"
@@ -2826,15 +2762,12 @@
         "number": 844,
         "addon": "Starz",
         "aliases": [
-          "US: STARZ HD",
-          "Starz.us",
           "US: STARZ BLACK HD",
-          "US: STARZ EAST HD",
-          "US: STARZ WEST HD",
           "STRZIBH",
           "67235",
           "67235456",
-          "844 STRZIBH"
+          "844 STRZIBH",
+          "STARZ IN BLACK"
         ],
         "epg_ids": [
           "67235"
@@ -2845,31 +2778,29 @@
         "number": 845,
         "addon": "Starz",
         "aliases": [
-          "US: STARZ HD",
-          "Starz.us",
-          "US: STARZ EAST HD",
-          "US: STARZ WEST HD",
-          "US: STARZ FAMILY HD",
-          "StarzEncoreFamily.us",
           "US: STARZ KIDS & FAMILY HD",
           "StarzKidsFamily.us",
           "STZKHD",
           "57581",
           "57581457",
-          "845 STZKHD"
+          "845 STZKHD",
+          "STARZ KIDS & FAMILY"
         ],
         "epg_ids": [
           "57581"
         ]
       },
       {
-        "name": "STRZCIH",
+        "name": "Starz Cinema",
         "number": 846,
         "aliases": [
           "STRZCIH",
           "67236",
           "67236458",
-          "846 STRZCIH"
+          "846 STRZCIH",
+          "STARZ CINEMA",
+          "US: STARZ CINEMA HD",
+          "US: STARZ CINEMA EAST HD"
         ],
         "epg_ids": [
           "67236"
@@ -2880,18 +2811,13 @@
         "number": 847,
         "addon": "Starz",
         "aliases": [
-          "US: COMEDY CENTRAL HD",
-          "ComedyCentral.us",
-          "US: STARZ HD",
-          "Starz.us",
           "US: STARZ COMEDY HD",
           "StarzComedy.us",
-          "US: STARZ EAST HD",
-          "US: STARZ WEST HD",
           "STZCHD",
           "57569",
           "57569459",
-          "847 STZCHD"
+          "847 STZCHD",
+          "STARZ COMEDY"
         ],
         "epg_ids": [
           "57569"
@@ -2930,39 +2856,27 @@
         ]
       },
       {
-        "name": "Starz Encore",
+        "name": "Starz Encore East",
         "number": 850,
         "addon": "Starz",
         "aliases": [
-          "US: STARZ HD",
-          "Starz.us",
-          "US: STARZ EAST HD",
-          "US: STARZ WEST HD",
           "US: STARZ ENCORE HD",
           "StarzEncore.us",
           "US: STARZ ENCORE EAST HD",
-          "US: STARZ ENCORE ACTION HD",
-          "StarzEncoreAction.us",
-          "US: STARZ ENCORE BLACK HD",
-          "StarzEncoreBlack.us",
-          "US: STARZ ENCORE CLASSIC HD",
-          "StarzEncoreClassics.us",
-          "US: STARZ ENCORE FAMILY HD",
-          "StarzEncoreFamily.us",
-          "US: STARZ ENCORE WESTERNS HD",
-          "StarzEncoreWesterns.us",
-          "US: STARZ ENCORE WEST HD",
           "STZENHD",
           "36225",
           "36225462",
-          "850 STZENHD"
+          "850 STZENHD",
+          "Starz Encore",
+          "STARZ ENCORE",
+          "STARZ ENCORE EAST"
         ],
         "epg_ids": [
           "36225"
         ]
       },
       {
-        "name": "SZECLHD",
+        "name": "Starz Encore Classic East",
         "number": 852,
         "aliases": [
           "SZECLHD",
@@ -2975,7 +2889,7 @@
         ]
       },
       {
-        "name": "STZENWS",
+        "name": "Starz Encore Westerns East",
         "number": 854,
         "aliases": [
           "STZENWS",
@@ -2988,7 +2902,7 @@
         ]
       },
       {
-        "name": "SZESUHD",
+        "name": "Starz Encore Suspense East",
         "number": 856,
         "aliases": [
           "SZESUHD",
@@ -3001,7 +2915,7 @@
         ]
       },
       {
-        "name": "SZEBHD",
+        "name": "Starz Encore Black East",
         "number": 858,
         "aliases": [
           "SZEBHD",
@@ -3014,7 +2928,7 @@
         ]
       },
       {
-        "name": "SZEAHD",
+        "name": "Starz Encore Action East",
         "number": 861,
         "aliases": [
           "SZEAHD",
@@ -3027,7 +2941,7 @@
         ]
       },
       {
-        "name": "STZENFM",
+        "name": "Starz Encore Family",
         "number": 862,
         "aliases": [
           "STZENFM",
@@ -3040,7 +2954,7 @@
         ]
       },
       {
-        "name": "STZESP",
+        "name": "Starz Encore Español",
         "number": 863,
         "aliases": [
           "STZESP",
@@ -3057,12 +2971,9 @@
         "number": 865,
         "addon": "Paramount+ with SHOWTIME",
         "aliases": [
-          "US: PARAMOUNT HD",
-          "ParamountNetwork.us",
           "US: SHOWTIME HD",
           "Showtime.us",
           "US: SHOWTIME EAST HD",
-          "US: SHOWTIME WEST HD",
           "SHOWTIME",
           "SHOWTIME HD",
           "SHOWTIME EAST",
@@ -3072,7 +2983,7 @@
           "21868470",
           "865 PARSHOH",
           "865 Paramount+ with",
-          "Paramount+ with"
+          "PARAMOUNT+ WITH SHOWTIME"
         ],
         "epg_ids": [
           "21868"
@@ -3083,11 +2994,6 @@
         "number": 866,
         "addon": "Paramount+ with SHOWTIME",
         "aliases": [
-          "US: PARAMOUNT HD",
-          "ParamountNetwork.us",
-          "US: SHOWTIME HD",
-          "Showtime.us",
-          "US: SHOWTIME EAST HD",
           "US: SHOWTIME WEST HD",
           "SHOWTIME WEST",
           "PARAMOUNT PLUS WITH SHOWTIME WEST",
@@ -3096,7 +3002,7 @@
           "22532471",
           "866 PASHOHW",
           "866 Paramount+ with",
-          "Paramount+ with"
+          "PARAMOUNT+ WITH SHOWTIME WEST"
         ],
         "epg_ids": [
           "22532"
@@ -3121,7 +3027,7 @@
         ]
       },
       {
-        "name": "SHOBETH",
+        "name": "SHOxBET",
         "number": 868,
         "aliases": [
           "SHOBETH",
@@ -3158,8 +3064,6 @@
         "number": 870,
         "addon": "Paramount+ with SHOWTIME",
         "aliases": [
-          "US: SHOWTIME 2 HD",
-          "Showtime2.us",
           "SHO2PHD",
           "60953",
           "60953475",
@@ -3182,8 +3086,7 @@
           "60947",
           "60947476",
           "873 SHOWXHD",
-          "873 Showtime Extrem",
-          "Showtime Extrem"
+          "873 Showtime Extrem"
         ],
         "epg_ids": [
           "60947"
@@ -3194,14 +3097,11 @@
         "number": 874,
         "addon": "Paramount+ with SHOWTIME",
         "aliases": [
-          "US: SHOWTIME EXTREME HD",
-          "ShowtimeExtreme.us",
           "SHWXPHD",
           "60945",
           "60945477",
           "874 SHWXPHD",
-          "874 Showtime Extrem",
-          "Showtime Extrem"
+          "874 Showtime Extrem"
         ],
         "epg_ids": [
           "60945"
@@ -3230,8 +3130,6 @@
         "number": 887,
         "addon": "Paramount+ with SHOWTIME",
         "aliases": [
-          "US: THE MOVIE CHANNEL HD",
-          "TMC.us",
           "TMCXHD",
           "60951",
           "60951479",
@@ -3250,11 +3148,6 @@
         "aliases": [
           "US: EPIX HD",
           "epix.us",
-          "US: EPIX 2",
-          "US: EPIX DRIVE IN",
-          "epixdrivein.us",
-          "US: EPIX HITS",
-          "EpixHits.us",
           "EPIX",
           "EPIX HD",
           "EPIX 1",
@@ -3262,7 +3155,9 @@
           "MGMHD",
           "65687",
           "65687480",
-          "895 MGMHD"
+          "895 MGMHD",
+          "MGM+",
+          "MGM+ HD"
         ],
         "epg_ids": [
           "65687"
@@ -3273,18 +3168,14 @@
         "number": 896,
         "addon": "MGM+",
         "aliases": [
-          "US: EPIX HD",
-          "epix.us",
           "US: EPIX 2",
-          "US: EPIX HITS",
-          "EpixHits.us",
-          "EPIX HITS",
           "EPIX 2",
           "MGM PLUS HITS",
           "MGMHTH",
           "67929",
           "67929481",
-          "896 MGMHTH"
+          "896 MGMHTH",
+          "MGM+ HITS"
         ],
         "epg_ids": [
           "67929"
@@ -3297,13 +3188,14 @@
         "aliases": [
           "US: HBO HD",
           "HBO.us",
-          "US: HBO WEST HD",
           "HBOHD",
           "19548",
           "19548482",
           "899 HBOHD",
           "899 HBO HD",
-          "HBO HD"
+          "HBO HD",
+          "HBO",
+          "HBO EAST"
         ],
         "epg_ids": [
           "19548"
@@ -3327,22 +3219,21 @@
         "number": 901,
         "addon": "HBO",
         "aliases": [
-          "US: HBO HD",
-          "HBO.us",
           "US: HBO WEST HD",
           "HBOHDP",
           "19566",
           "19566484",
           "901 HBOHDP",
           "901 HBO HD West",
-          "HBO HD West"
+          "HBO HD West",
+          "HBO WEST"
         ],
         "epg_ids": [
           "19566"
         ]
       },
       {
-        "name": "HBO 2 East",
+        "name": "HBO Hits East",
         "number": 902,
         "addon": "HBO",
         "aliases": [
@@ -3353,32 +3244,39 @@
           "59368485",
           "902 HBOHTHD",
           "902 HBO Hits HD",
-          "HBO Hits HD"
+          "HBO Hits HD",
+          "HBO 2 East",
+          "HBO HITS",
+          "HBO HITS EAST",
+          "HBO 2",
+          "HBO 2 EAST"
         ],
         "epg_ids": [
           "59368"
         ]
       },
       {
-        "name": "HBO 2 West",
+        "name": "HBO Hits West",
         "number": 903,
         "addon": "HBO",
         "aliases": [
-          "US: HBO 2 HD",
-          "HBO2.us",
           "HBOHHDP",
           "59355",
           "59355486",
           "903 HBOHHDP",
           "903 HBO Hits HD (We",
-          "HBO Hits HD (We"
+          "HBO Hits HD (We",
+          "HBO 2 West",
+          "HBO HITS WEST",
+          "HBO 2 WEST",
+          "US: HBO 2 WEST HD"
         ],
         "epg_ids": [
           "59355"
         ]
       },
       {
-        "name": "HBO Signature East",
+        "name": "HBO Drama East",
         "number": 904,
         "addon": "HBO",
         "aliases": [
@@ -3389,25 +3287,32 @@
           "59363487",
           "904 HBODRHD",
           "904 HBO Drama HD",
-          "HBO Drama HD"
+          "HBO Drama HD",
+          "HBO Signature East",
+          "HBO DRAMA",
+          "HBO DRAMA EAST",
+          "HBO SIGNATURE",
+          "HBO SIGNATURE EAST"
         ],
         "epg_ids": [
           "59363"
         ]
       },
       {
-        "name": "HBO Signature West",
+        "name": "HBO Drama West",
         "number": 905,
         "addon": "HBO",
         "aliases": [
-          "US: HBO SIGNATURE HD",
-          "HBOSignature.us",
           "HBODHDP",
           "59366",
           "59366488",
           "905 HBODHDP",
           "905 HBO Drama HD (W",
-          "HBO Drama HD (W"
+          "HBO Drama HD (W",
+          "HBO Signature West",
+          "HBO DRAMA WEST",
+          "HBO SIGNATURE WEST",
+          "US: HBO SIGNATURE WEST HD"
         ],
         "epg_ids": [
           "59366"
@@ -3418,8 +3323,6 @@
         "number": 908,
         "addon": "HBO",
         "aliases": [
-          "US: COMEDY CENTRAL HD",
-          "ComedyCentral.us",
           "US: HBO COMEDY HD",
           "HBOComedy.us",
           "HBOCHD",
@@ -3427,7 +3330,9 @@
           "59839489",
           "908 HBOCHD",
           "908 HBO Comedy HD",
-          "HBO Comedy HD"
+          "HBO Comedy HD",
+          "HBO COMEDY",
+          "HBO COMEDY EAST"
         ],
         "epg_ids": [
           "59839"
@@ -3438,23 +3343,21 @@
         "number": 909,
         "addon": "HBO",
         "aliases": [
-          "US: COMEDY CENTRAL HD",
-          "ComedyCentral.us",
-          "US: HBO COMEDY HD",
-          "HBOComedy.us",
           "HBOCPHD",
           "59841",
           "59841490",
           "909 HBOCPHD",
           "909 HBO Comedy HD (",
-          "HBO Comedy HD ("
+          "HBO Comedy HD (",
+          "HBO COMEDY WEST",
+          "US: HBO COMEDY WEST HD"
         ],
         "epg_ids": [
           "59841"
         ]
       },
       {
-        "name": "HBO Zone East",
+        "name": "HBO Movies East",
         "number": 910,
         "addon": "HBO",
         "aliases": [
@@ -3465,25 +3368,32 @@
           "59845491",
           "910 HBOMVHD",
           "910 HBO Movies HD",
-          "HBO Movies HD"
+          "HBO Movies HD",
+          "HBO Zone East",
+          "HBO MOVIES",
+          "HBO MOVIES EAST",
+          "HBO ZONE",
+          "HBO ZONE EAST"
         ],
         "epg_ids": [
           "59845"
         ]
       },
       {
-        "name": "HBO Zone West",
+        "name": "HBO Movies West",
         "number": 911,
         "addon": "HBO",
         "aliases": [
-          "US: HBO ZONE HD",
-          "HBOZone.us",
           "HBOMHDP",
           "59847",
           "59847492",
           "911 HBOMHDP",
           "911 HBO Movies HD (",
-          "HBO Movies HD ("
+          "HBO Movies HD (",
+          "HBO Zone West",
+          "HBO MOVIES WEST",
+          "HBO ZONE WEST",
+          "US: HBO ZONE WEST HD"
         ],
         "epg_ids": [
           "59847"
@@ -3513,16 +3423,12 @@
           "US: CINEMAX HD",
           "Cinemax.us",
           "US: CINEMAX EAST HD",
-          "US: CINEMAX ACTION EAST HD",
-          "US: CINEMAX MOREMAX HDAR",
-          "US: CINEMAX THRILLERMAX HD",
-          "US: CINEMAX WEST HD",
-          "US: CINEMAX 5 STAR MAX",
-          "US: CINEMAX 5 STARMAX 4K",
           "MAXHD",
           "34933",
           "34933494",
-          "920 MAXHD"
+          "920 MAXHD",
+          "CINEMAX",
+          "CINEMAX EAST"
         ],
         "epg_ids": [
           "34933"
@@ -3533,88 +3439,80 @@
         "number": 921,
         "addon": "Cinemax",
         "aliases": [
-          "US: CINEMAX HD",
-          "Cinemax.us",
-          "US: CINEMAX EAST HD",
-          "US: CINEMAX ACTION EAST HD",
-          "US: CINEMAX MOREMAX HDAR",
-          "US: CINEMAX THRILLERMAX HD",
           "US: CINEMAX WEST HD",
-          "US: CINEMAX 5 STAR MAX",
-          "US: CINEMAX 5 STARMAX 4K",
           "MAXHDP",
           "35975",
           "35975495",
-          "921 MAXHDP"
+          "921 MAXHDP",
+          "CINEMAX WEST"
         ],
         "epg_ids": [
           "35975"
         ]
       },
       {
-        "name": "MoreMax East",
+        "name": "Cinemax Hits East",
         "number": 922,
         "addon": "Cinemax",
         "aliases": [
           "US: CINEMAX MOREMAX HDAR",
-          "Cinemax.us",
           "US: MOREMAX HD",
           "MoreMax.us",
           "CINEHHD",
           "59373",
           "59373496",
-          "922 CINEHHD"
+          "922 CINEHHD",
+          "MoreMax East",
+          "CINEMAX HITS",
+          "CINEMAX HITS EAST",
+          "MOREMAX",
+          "MOREMAX EAST"
         ],
         "epg_ids": [
           "59373"
         ]
       },
       {
-        "name": "MoreMax West",
+        "name": "Cinemax Hits West",
         "number": 923,
         "addon": "Cinemax",
         "aliases": [
-          "US: CINEMAX MOREMAX HDAR",
-          "Cinemax.us",
-          "US: MOREMAX HD",
-          "MoreMax.us",
           "CINHHDP",
           "59375",
           "59375497",
-          "923 CINHHDP"
+          "923 CINHHDP",
+          "MoreMax West",
+          "CINEMAX HITS WEST",
+          "MOREMAX WEST"
         ],
         "epg_ids": [
           "59375"
         ]
       },
       {
-        "name": "ActionMax",
+        "name": "Cinemax Action East",
         "number": 924,
         "addon": "Cinemax",
         "aliases": [
           "CINACHD",
           "59948",
           "59948498",
-          "924 CINACHD"
+          "924 CINACHD",
+          "ActionMax",
+          "CINEMAX ACTION",
+          "CINEMAX ACTION EAST",
+          "ACTIONMAX",
+          "ACTION MAX"
         ],
         "epg_ids": [
           "59948"
         ]
       },
       {
-        "name": "Cinemáx",
+        "name": "Cinemáx - CMAXHD",
         "number": 929,
         "addon": "Cinemax",
         "aliases": [
-          "US: CINEMAX HD",
-          "Cinemax.us",
-          "US: CINEMAX EAST HD",
-          "US: CINEMAX ACTION EAST HD",
-          "US: CINEMAX MOREMAX HDAR",
-          "US: CINEMAX THRILLERMAX HD",
-          "US: CINEMAX WEST HD",
-          "US: CINEMAX 5 STAR MAX",
-          "US: CINEMAX 5 STARMAX 4K",
           "CMAXHD",
           "59965",
           "59965499",
@@ -3625,14 +3523,18 @@
         ]
       },
       {
-        "name": "5StarMax",
+        "name": "Cinemax Classics",
         "number": 930,
         "addon": "Cinemax",
         "aliases": [
           "CINCLHD",
           "59961",
           "59961500",
-          "930 CINCLHD"
+          "930 CINCLHD",
+          "5StarMax",
+          "CINEMAX CLASSICS",
+          "5STARMAX",
+          "5 STAR MAX"
         ],
         "epg_ids": [
           "59961"
@@ -3671,7 +3573,7 @@
         ]
       },
       {
-        "name": "NICKTOO",
+        "name": "Nickelodeon / Nick at Nite West",
         "number": 253,
         "aliases": [
           "NICKTOO",
@@ -3684,7 +3586,7 @@
         ]
       },
       {
-        "name": "BOOM",
+        "name": "Boomerang",
         "number": 258,
         "aliases": [
           "BOOM",
@@ -3713,7 +3615,7 @@
         ]
       },
       {
-        "name": "DJCH",
+        "name": "Disney Jr.",
         "number": 260,
         "aliases": [
           "DJCH",
@@ -3726,7 +3628,7 @@
         ]
       },
       {
-        "name": "NORAFTV",
+        "name": "NoireTV",
         "number": 269,
         "aliases": [
           "NORAFTV",
@@ -3818,7 +3720,7 @@
         ]
       },
       {
-        "name": "BABY1HD",
+        "name": "BabyFirst",
         "number": 765,
         "aliases": [
           "BABY1HD",
@@ -3861,7 +3763,7 @@
         ]
       },
       {
-        "name": "ASPREHD",
+        "name": "Aspire",
         "number": 772,
         "aliases": [
           "ASPREHD",
@@ -3874,7 +3776,7 @@
         ]
       },
       {
-        "name": "CLEOHD",
+        "name": "Cleo TV",
         "number": 773,
         "aliases": [
           "CLEOHD",
@@ -3900,7 +3802,7 @@
         ]
       },
       {
-        "name": "UNVSOHD",
+        "name": "Universo",
         "number": 775,
         "aliases": [
           "UNVSOHD",
@@ -3913,7 +3815,7 @@
         ]
       },
       {
-        "name": "STELLAR",
+        "name": "Stellar TV",
         "number": 776,
         "aliases": [
           "STELLAR",
@@ -3926,7 +3828,7 @@
         ]
       },
       {
-        "name": "GRIOCH",
+        "name": "TheGrio",
         "number": 777,
         "aliases": [
           "GRIOCH",
@@ -3984,7 +3886,7 @@
         ]
       },
       {
-        "name": "IMPACTV",
+        "name": "The Impact Network",
         "number": 787,
         "aliases": [
           "IMPACTV",
@@ -4054,13 +3956,15 @@
         ]
       },
       {
-        "name": "FDUELRC",
+        "name": "FanDuel Racing",
         "number": 316,
         "aliases": [
           "FDUELRC",
           "32258",
           "32258176",
-          "316 FDUELRC"
+          "316 FDUELRC",
+          "FANDUEL RACING",
+          "TVG2"
         ],
         "epg_ids": [
           "32258"
@@ -4243,10 +4147,9 @@
         ]
       },
       {
-        "name": "Game Show Network",
+        "name": "Game Show Network - GSNHD",
         "number": 684,
         "aliases": [
-          "US: Game Show Central",
           "GSNHD",
           "68827",
           "68827387",
@@ -4293,7 +4196,7 @@
         ]
       },
       {
-        "name": "OVATNHD",
+        "name": "Ovation",
         "number": 688,
         "aliases": [
           "OVATNHD",
@@ -4329,14 +4232,8 @@
         "name": "Comedy Central",
         "number": 690,
         "aliases": [
-          "US: CATCHY COMEDY HD",
           "US: COMEDY CENTRAL HD",
           "ComedyCentral.us",
-          "US: COMEDY TV HD",
-          "US: HBO COMEDY HD",
-          "HBOComedy.us",
-          "US: STARZ COMEDY HD",
-          "StarzComedy.us",
           "CCHD",
           "62420",
           "62420392",
@@ -4367,7 +4264,7 @@
         ]
       },
       {
-        "name": "REELZHD",
+        "name": "Reelz",
         "number": 692,
         "aliases": [
           "REELZHD",
@@ -4398,7 +4295,7 @@
         ]
       },
       {
-        "name": "CMDTVHD",
+        "name": "Comedy.TV",
         "number": 695,
         "aliases": [
           "CMDTVHD",
@@ -4431,7 +4328,7 @@
         ]
       },
       {
-        "name": "VICEHD",
+        "name": "VICE TV",
         "number": 697,
         "aliases": [
           "VICEHD",
@@ -4497,7 +4394,6 @@
         "aliases": [
           "US: LIFETIME HD",
           "LifetimeNetwork.us",
-          "US: LIFETIME REAL WOMEN HD",
           "LIFEHD",
           "60150",
           "60150360",
@@ -4669,7 +4565,7 @@
         ]
       },
       {
-        "name": "GEMSHD",
+        "name": "Gems",
         "number": 658,
         "aliases": [
           "GEMSHD",
@@ -4682,7 +4578,7 @@
         ]
       },
       {
-        "name": "SHOPLCH",
+        "name": "Shop LC",
         "number": 659,
         "aliases": [
           "SHOPLCH",
@@ -4756,7 +4652,11 @@
           "MAGNHD",
           "67375",
           "67375376",
-          "667 MAGNHD"
+          "667 MAGNHD",
+          "DIY NETWORK",
+          "DIY NETWORK HD",
+          "MAGNOLIA NETWORK",
+          "MAGNOLIA NETWORK HD"
         ],
         "epg_ids": [
           "67375"
@@ -4796,7 +4696,7 @@
         ]
       },
       {
-        "name": "MYDESHD",
+        "name": "MyDestination.TV",
         "number": 674,
         "aliases": [
           "MYDESHD",
@@ -4809,7 +4709,7 @@
         ]
       },
       {
-        "name": "RECIPEH",
+        "name": "Recipe.TV",
         "number": 676,
         "aliases": [
           "RECIPEH",
@@ -4822,7 +4722,7 @@
         ]
       },
       {
-        "name": "JUST",
+        "name": "Justice Central.TV",
         "number": 677,
         "aliases": [
           "JUST",
@@ -4835,7 +4735,7 @@
         ]
       },
       {
-        "name": "LCSTR",
+        "name": "Law&Crime Network",
         "number": 678,
         "aliases": [
           "LCSTR",
@@ -4848,7 +4748,7 @@
         ]
       },
       {
-        "name": "CINHD",
+        "name": "Crime & Investigation",
         "number": 679,
         "aliases": [
           "CINHD",
@@ -4914,8 +4814,6 @@
         "aliases": [
           "US: : NATIONAL GEOGRAPHIC HD",
           "NatGeo.us",
-          "US: : NATIONAL GEOGRAPHIC WILD HD",
-          "NatGeoWild.us",
           "NGCHD",
           "49438",
           "49438346",
@@ -4956,14 +4854,15 @@
         ]
       },
       {
-        "name": "DLCHD",
+        "name": "Discovery Life",
         "number": 624,
         "aliases": [
           "DLCHD",
           "92204",
           "92204349",
           "624 DLCHD",
-          "DISCOVERY LIFE"
+          "DISCOVERY LIFE",
+          "DISCOVERY LIFE HD"
         ],
         "epg_ids": [
           "92204"
@@ -5002,14 +4901,15 @@
         ]
       },
       {
-        "name": "FYIHD",
+        "name": "FYI",
         "number": 629,
         "aliases": [
           "FYIHD",
           "58988",
           "58988352",
           "629 FYIHD",
-          "FYI"
+          "FYI",
+          "FYI HD"
         ],
         "epg_ids": [
           "58988"
@@ -5032,13 +4932,18 @@
         ]
       },
       {
-        "name": "MTHD",
+        "name": "Discovery Turbo",
         "number": 631,
         "aliases": [
           "MTHD",
           "31046",
           "31046354",
-          "631 MTHD"
+          "631 MTHD",
+          "DISCOVERY TURBO",
+          "DISCOVERY TURBO HD",
+          "MOTOR TREND",
+          "MOTORTREND",
+          "VELOCITY"
         ],
         "epg_ids": [
           "31046"
@@ -5051,20 +4956,25 @@
           "NGWIHD",
           "67331",
           "67331355",
-          "632 NGWIHD"
+          "632 NGWIHD",
+          "US: NAT GEO WILD HD",
+          "NAT GEO WILD",
+          "NAT GEO WILD HD"
         ],
         "epg_ids": [
           "67331"
         ]
       },
       {
-        "name": "PETSTVH",
+        "name": "Pets.TV",
         "number": 633,
         "aliases": [
           "PETSTVH",
           "81283",
           "81283356",
-          "633 PETSTVH"
+          "633 PETSTVH",
+          "PETS.TV",
+          "PETS TV"
         ],
         "epg_ids": [
           "81283"
@@ -5087,13 +4997,17 @@
         ]
       },
       {
-        "name": "GLIVHD",
+        "name": "Great American Faith & Living",
         "number": 635,
         "aliases": [
           "GLIVHD",
           "90858",
           "90858358",
-          "635 GLIVHD"
+          "635 GLIVHD",
+          "GREAT AMERICAN FAITH & LIVING",
+          "GREAT AMERICAN LIVING",
+          "GAC LIVING",
+          "RIDE TV"
         ],
         "epg_ids": [
           "90858"
@@ -5132,7 +5046,7 @@
         ]
       },
       {
-        "name": "3ANGELS",
+        "name": "3ABN",
         "number": 291,
         "aliases": [
           "3ANGELS",
@@ -5158,7 +5072,7 @@
         ]
       },
       {
-        "name": "LFN",
+        "name": "Faith TV USA",
         "number": 792,
         "aliases": [
           "LFN",
@@ -5171,7 +5085,7 @@
         ]
       },
       {
-        "name": "Daystar Television Network (DYSTRHD)",
+        "name": "Daystar",
         "number": 793,
         "aliases": [
           "US: DAYSTAR HD",
@@ -5180,14 +5094,15 @@
           "87001",
           "87001440",
           "DAYSTAR TELEVISION NETWORK",
-          "793 DYSTRHD"
+          "793 DYSTRHD",
+          "Daystar Television Network (DYSTRHD)"
         ],
         "epg_ids": [
           "87001"
         ]
       },
       {
-        "name": "PTL",
+        "name": "PTL Television Network",
         "number": 795,
         "aliases": [
           "PTL",
@@ -5200,21 +5115,22 @@
         ]
       },
       {
-        "name": "Sonlife Broadcasting Network (SONLFHD)",
+        "name": "SonLife Broadcasting Network",
         "number": 797,
         "aliases": [
           "SONLFHD",
           "91314",
           "91314442",
           "SONLIFE BROADCASTING NETWORK",
-          "797 SONLFHD"
+          "797 SONLFHD",
+          "Sonlife Broadcasting Network (SONLFHD)"
         ],
         "epg_ids": [
           "91314"
         ]
       },
       {
-        "name": "JBSHD",
+        "name": "Jewish Broadcasting Service",
         "number": 798,
         "aliases": [
           "JBSHD",
@@ -5229,7 +5145,7 @@
     ],
     "Music": [
       {
-        "name": "MTVU",
+        "name": "mtvU",
         "number": 212,
         "aliases": [
           "MTVU",
@@ -5242,7 +5158,7 @@
         ]
       },
       {
-        "name": "BETJ",
+        "name": "BET Jams",
         "number": 213,
         "aliases": [
           "BETJ",
@@ -5255,7 +5171,7 @@
         ]
       },
       {
-        "name": "NMZK",
+        "name": "NickMusic",
         "number": 214,
         "aliases": [
           "NMZK",
@@ -5268,7 +5184,7 @@
         ]
       },
       {
-        "name": "MTVCLAS",
+        "name": "MTV Classic",
         "number": 218,
         "aliases": [
           "MTVCLAS",
@@ -5294,7 +5210,7 @@
         ]
       },
       {
-        "name": "CMTMUS",
+        "name": "CMT Music",
         "number": 222,
         "aliases": [
           "CMTMUS",
@@ -5307,7 +5223,7 @@
         ]
       },
       {
-        "name": "GSPLSD",
+        "name": "BET Gospel",
         "number": 225,
         "aliases": [
           "GSPLSD",
@@ -5352,7 +5268,7 @@
         ]
       },
       {
-        "name": "MTVLIVE",
+        "name": "MTV Live",
         "number": 715,
         "aliases": [
           "MTVLIVE",
@@ -5381,7 +5297,7 @@
         ]
       },
       {
-        "name": "BHERHD",
+        "name": "BET Her",
         "number": 720,
         "aliases": [
           "BHERHD",
@@ -5413,7 +5329,7 @@
         ]
       },
       {
-        "name": "RVLTHD",
+        "name": "REVOLT",
         "number": 726,
         "aliases": [
           "RVLTHD",
@@ -5755,7 +5671,6 @@
           "XHAW",
           "32752",
           "32752530",
-          "MULTIMEDIOS TV HD",
           "1511 XHAW"
         ],
         "epg_ids": [
@@ -5812,7 +5727,6 @@
           "XHAWTDT",
           "54300",
           "54300534",
-          "MULTIMEDIOS TV HD",
           "1516 XHAWTDT"
         ],
         "epg_ids": [

--- a/plugins/lineuparr/plugin.json
+++ b/plugins/lineuparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Lineuparr",
-  "version": "1.26.2291211",
+  "version": "1.26.2421451",
   "description": "Mirror real-world provider channel lineups by creating channel groups, channels, and fuzzy-matching IPTV streams to them.",
   "author": "PiratesIRC",
   "license": "MIT",

--- a/plugins/lineuparr/plugin.py
+++ b/plugins/lineuparr/plugin.py
@@ -99,7 +99,7 @@ def _clean_json_text(s):
 
 
 class PluginConfig:
-    PLUGIN_VERSION = "1.26.2291211"
+    PLUGIN_VERSION = "1.26.2421451"
 
     DEFAULT_FUZZY_MATCH_THRESHOLD = 80
     DEFAULT_PRIORITIZE_QUALITY = True


### PR DESCRIPTION
Lineup data only. No code, matcher or settings changes.

## Added

- `US_Spectrum-Tampa-Bay-All_lineup.json` (409 channels), `US_Spectrum-Tampa-Bay-No-Spanish_lineup.json` (322) and `US_Spectrum-Tampa-Bay-Spanish-Only_lineup.json` (87), covering Hillsborough, Pinellas, Pasco and Hernando Counties, Florida.
- `US_Optimum_lineup.json` (342 channels), from Optimum's published Southern Westchester channel listing.

## Changed

- `US_Verizon-FIOS-All-11743_lineup.json` refreshed: 512 to 508 channels, provider shortcodes replaced with real channel names, and aliases that resolved to more than one channel removed.

## Notes

The listing now carries 34 files, up from 30. The four new files are lineup data that the plugin discovers at run time.

Release: https://github.com/PiratesIRC/Dispatcharr-Lineuparr-Plugin/releases/tag/v1.26.2421451