### PR TITLE
[event-channel-managarr]: release v1.26.2450117 - hide undated event channels once the event has ended

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.2420322",
+  "version": "1.26.2450117",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Updates the Event Channel Managarr listing to 1.26.2450117.

This is an external listing, so only the `version` field changes. The release asset it points at is published and the download URL resolves:
https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/download/v1.26.2450117/Event-Channel-Managarr.zip

What is in the release:

- A new hide rule, `[UndatedEnded]`, for event channel names that carry a clock time but no date. It infers the event window from the date the channel was first seen plus the time in the name, the event duration, and a configurable grace period, and hides the channel once that has passed.
- A fix to the time pattern, which had no boundary after the am or pm marker and so could read the opening two letters of an ordinary word as a clock time.
- Error handlers that previously substituted a smaller value now decline to act instead, and every substitution the plugin does make is reported in the log.

Full notes: https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/tag/v1.26.2450117

I am the author and maintainer listed in the manifest.
