### PR TITLE
[dispatcharr-ranked-matchups]: release v1.27.1 - language preferences, provenance ordering, per-group stream policy

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/README.md
+++ b/plugins/dispatcharr-ranked-matchups/README.md
@@ -1,13 +1,32 @@
 # Ranked Matchups (Top Games)
 
-A cross-sport "interestingness" curator for Dispatcharr. It pulls upcoming games for each sport you enable, scores every matchup on how interesting it is (rankings, standings, rivalries, betting lines, playoff/knockout stakes), matches the worthwhile games to your existing Dispatcharr channels via EPG, and renames + groups them into a dedicated **Top Matchups** channel profile. Your guide ends up showing the games worth watching instead of the full firehose.
+A cross-sport "interestingness" curator for Dispatcharr. It pulls upcoming games for each sport you enable, scores every matchup on how interesting it is (rankings, standings, rivalries, betting lines, playoff/knockout stakes), matches the worthwhile games against your lineup, and renames + groups them into a dedicated **!Top Matchups** channel group. Your guide ends up showing the games worth watching instead of the full firehose.
 
 ## What it does
 
 - Per-sport adapters (college football/basketball, NFL, NBA, MLB, NHL, WNBA, NWSL, MLS, top-flight soccer leagues, internationals/friendlies, World Cup, and more), each toggleable.
 - Scores matchups with a transparent model (see `SCORING.md` in the source repo): ranked-vs-ranked, standings importance, rivalries, and betting-line signal where available.
-- Matches scored games to your channels through EPG and builds a curated **Top Matchups** profile with clean, renamed entries.
+- Matches scored games against your lineup and builds a curated **!Top Matchups** channel group with clean, renamed entries.
 - Runs on demand from the plugin UI or on a schedule.
+
+## How games are matched
+
+Three independent paths, all of which can contribute (results merge and stack as
+fallback streams):
+
+- **EPG programme title, sub-title or description** inside the game's window.
+- **Channel name**, for providers that name the fixture on the channel.
+- **Stream name, whether or not that stream is attached to a channel.** This is
+  what lets a large M3U produce per-match feeds without curating them into
+  channels first, and it is why a matchup channel can pick up feeds you never
+  added yourself.
+
+Because that third path sweeps your whole M3U, three settings decide what
+happens to feeds you did not curate, and none of them removes a stream unless
+you say so: **Preferred languages** (an ordered list like `en` or `de, en`),
+**Demote stream groups** (used only as a last resort, still playable), and
+**Exclude stream groups** (never attached at all). Streams you have attached to
+a channel of your own always sort ahead of ones found only by the sweep.
 
 ## Requirements
 

--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.26.0",
+  "version": "1.27.1",
   "description": "Never miss a good game. Scores every upcoming game across 39 leagues, tours and competitions (22 of them soccer, plus NFL, NBA, MLB, NHL, NCAA D1 football and basketball, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description. Finished games can clear themselves out and be replaced from a bench of the next-best fixtures.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps the listing from `1.26.0` to `1.27.1`.

### What's in the release

Path C matches stream names whether or not the stream is attached to a channel, which is what makes a large M3U work without curating feeds into channels first (#138). The flip side, reported by a user, is that a matchup channel could pick up foreign-language backup feeds they never added — and because ordering was quality-only, one could lead the stack.

- **Preferred languages** (`language_preferences`) — an ordered comma-separated list (`en`, or `de, en`). Replaces English-first ordering that was previously reachable only by enabling an unrelated pool-widening setting. Nothing is ever removed for its language.
- **Demote stream groups** — named channel groups used only as a last resort, still playable.
- **Exclude stream groups** — never attached at all, applied at candidate lookup as well as at apply.
- **Provenance ordering** — a stream the user attached to a channel of their own sorts ahead of one found only by the sweep. Zero configuration.

Language tags were enumerated from 16,970 real stream names rather than guessed: 480 detections, zero false positives. `PL` and `US:` are deliberately not language tags (Premier League; US Spanish-language broadcasting). The honest limit is documented in the setting's help text: a German Bundesliga feed named `Bayern Munich vs Dortmund` is character-for-character what an English one would be called, so group demotion is the reliable control for those.

### 1.27.0 is withdrawn

Its `apply` crashed with `name 'source' is not defined`. 1.27.1 fixes it and adds a `pyflakes` gate over every module for that whole class of defect. The 1.27.0 release has been deleted so nothing can install it.

### Also in this PR

Two corrections to the listing README that predate this release:

- It builds a channel **group**, not a channel *profile*. The plugin's own code carries a do-not-confuse comment about that misnomer, since `channel_profile_name` is a legacy name for the group and `enabled_channel_profiles` is the separate real ChannelProfile setting.
- Matching was described as EPG-only. It has had three paths since 1.8.0, and the third (stream names, attached or not) is the one users actually get surprised by, so it is now spelled out along with the settings that control it.

Both are outside the metadata-only allowlist, which the version bump covers.

### Verification

`.github/scripts/validate/validate.sh dispatcharr-ranked-matchups Jacob-Lasky main` run locally against this branch: `result=pass`, exit 0, every check green (required fields, release artifact reachable, maintainers, license, permission, version, version bump). Release asset confirmed byte-identical to the local build, top-level folder `dispatcharr_ranked_matchups/` (snake_case, as the loader's module aliasing requires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188u2GWGvTvTT2GKK26HTzj