### PR TITLE
[event-channel-managarr]: release v1.26.2451734 - a dummy EPG source per channel group

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.2450117",
+  "version": "1.26.2451734",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
External listing, so this changes only the `version` field.

**What is new in v1.26.2451734:** an operator can map a channel group to its own dummy EPG source, so groups whose events are labelled in different timezones, or which need different durations or title patterns, no longer have to share one source. The plugin creates the source, seeds it from the existing settings, and then leaves it alone for the operator to edit in Dispatcharr's EPG source editor. A group that is not mapped keeps the shared source, so an existing installation is unaffected.

Requested in PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin#29.

**Checks done before opening this:**

- The release asset at the `source_url` was downloaded back and compared byte for byte with what was uploaded (sha256 `82c731a4872cad0f222f4b075859af66cb880c75e647b8a5fafcade9f0a8c549`, 234,348 bytes).
- The `v`-prefixed URL returns 200 and the bare form returns 404, so the `{version}` placeholder keeps its `v`.
- Archive entry names match the previous release exactly, forward slashes only, no CRLF in any text entry.
- The plugin's own test suite passes, 430 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WUEXgnPXhHNgyXQzMhFcT
