### PR TITLE
[iptv-checker] Update to 1.26.2481600

### DIFF
--- a/plugins/iptv-checker/plugin.json
+++ b/plugins/iptv-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "IPTV Checker",
-  "version": "1.26.2402308",
+  "version": "1.26.2481600",
   "description": "Check IPTV stream status and quality with ffprobe, then rename, move, restore or delete channels based on the result. Judges a channel by all of its streams, so a working backup never marks it dead.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Updates the IPTV Checker listing to 1.26.2481600.

External listing, so this is a version bump only. The download URL template is
unchanged and I confirmed the resolved asset returns HTTP 200 at 415474 bytes.

What is in this release:

- A scheduler stop no longer makes the plugin behave as though a running scan
  had finished. A scan cut short no longer writes an emailed report or applies
  the rename, move and delete actions, because its verdicts are incomplete.
- Schedules are described in plain language when saved, and a schedule that can
  never fire is refused rather than accepted and silently ignored. Day of week 7
  now means Sunday, as in standard cron.
- Old CSV exports can be deleted after a chosen number of days. Only files this
  plugin wrote are removed, because that directory is shared with other plugins.
- The settings form is grouped under 17 headings, and action button colour now
  tracks consequence: red marks only the action that deletes channels.
- Every boolean setting is read through one parser, so a value stored as the
  string "false" can no longer arm an action that was switched off.

The plugin's own test suite covers this at 1757 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2SMtKn2YcP86orGpcQHo9
