### PR TITLE
[dustarr] Update to 1.26.2481620

### DIFF
--- a/plugins/dustarr/README.md
+++ b/plugins/dustarr/README.md
@@ -6,7 +6,7 @@ Records which channels are actually watched, and reports the ones that are not, 
 
 ## What it produces
 
-A self-contained HTML report and a CSV export, written to `/config/dustarr/`. The HTML page opens as an index of seven collapsed sections, each with its own count:
+A self-contained HTML report and a CSV export, written to `/config/dustarr/`. The CSV opens with a commented preamble recording what the run found and which settings it used, so tell your spreadsheet to skip lines beginning with a hash when you import it. The HTML page opens as an index of seven collapsed sections, each with its own count:
 
 | Section | What it holds |
 |---|---|
@@ -37,13 +37,13 @@ Some channels look unused but are not, so they are kept out of the never-watched
 
 ## What to expect at first
 
-**Your first month of reports will carry a red "not trustworthy" banner, and that is the plugin working rather than failing.** A dataset younger than the unused threshold cannot honestly call anything unused. There is no way to shorten this by importing history: Dispatcharr does not retain the state Dustarr reads, so a fresh installation genuinely starts at zero.
+**Your first month of reports will carry a red "not trustworthy" banner, and that is the plugin working rather than failing.** A dataset younger than the unused threshold cannot honestly call anything unused. There is no way to shorten this by importing history: Dispatcharr does not retain the state Dustarr reads, so a fresh installation really does start at zero.
 
-**Most of a typical lineup is excluded from judgment, and that is the point.** The actionable answer comes from the channels the plugin is willing to judge, not from the whole lineup.
+**Most of a typical lineup is excluded from judgment, and that is the point.** The answer you can act on comes from the channels the plugin is willing to judge, not from the whole lineup.
 
 ## Optional: emailed reports
 
-Dustarr does not send mail itself. It can hand its report to the [Newsflasharr](https://github.com/PiratesIRC/Dispatcharr_Newsflasharr) plugin, which delivers it. This is off by default, and with Newsflasharr absent or disabled nothing is sent and nothing fails.
+Dustarr does not send mail itself. It can hand its report to the [Newsflasharr](https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin) plugin, which delivers it. This is off by default, and with Newsflasharr absent or disabled nothing is sent and nothing fails.
 
 ## After installing
 

--- a/plugins/dustarr/plugin.json
+++ b/plugins/dustarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Dustarr",
-  "version": "1.26.2362242",
+  "version": "1.26.2481620",
   "description": "Records which channels are actually watched and reports the ones that are not, so you can turn off the dead weight in your lineup. Read only: it never changes a channel and never contacts your provider.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Updates the Dustarr listing to 1.26.2481620.

External listing, so this changes only the version and the listing README; the registry downloads the archive from the release.

**Release artifact**
`https://github.com/PiratesIRC/Dispatcharr-Dustarr-Plugin/releases/download/1.26.2481620/Dustarr-1.26.2481620.zip` returns HTTP 200 at 128,485 bytes, sha256 `280bc46c6de5af6ed3cef44f4e84a9a4704bfee4933e9245303c13df8e4a3990`. Verified by downloading it back and byte comparing against the archive built from the tag.

**What the release changes for a user**
- A new setting deletes saved reports after a number of days. It defaults to 0, which is off.
- The CSV export now opens with a commented preamble recording what the run found and which settings it used. **A reader importing it into a spreadsheet has to skip lines beginning with a hash**, which is why the listing README now says so.
- The settings form is divided into four sections, and one setting was renamed from Top/bottom N to Rows in the Most used and Least used tables. Its stored id is unchanged, so no saved value is affected.
- Two button colours corrected so colour tracks consequence. Nothing is red; the plugin never changes anything in Dispatcharr.

**Also in this pull request**
The listing README linked to `PiratesIRC/Dispatcharr_Newsflasharr`, which returns 404. The live repository is `PiratesIRC/Dispatcharr-Newsflasharr-Plugin`. A listing README change needs a version bump to pass validation, so the correction rides along with this release rather than going in alone.