### PR TITLE
[newsflasharr] Update to 1.26.2481646

### DIFF
--- a/plugins/newsflasharr/README.md
+++ b/plugins/newsflasharr/README.md
@@ -2,8 +2,8 @@
 
 Central notification service for Dispatcharr plugins. One plugin owns all
 delivery: other plugins drop lightweight events into a file queue, and
-Newsflasharr routes them to Discord, a generic webhook, ntfy, Apprise, email,
-or a banner drawn over live video. Configured once, in one place, instead of
+Newsflasharr routes them to Discord, a generic webhook, a Dispatcharr Connect
+Integration, ntfy, Apprise, email, or a banner drawn over live video. Configured once, in one place, instead of
 every plugin re-inventing its own webhook code.
 
 ## What it does
@@ -22,6 +22,20 @@ every plugin re-inventing its own webhook code.
 - **It is read-only on Dispatcharr.** It writes nothing outside its own
   directory, and it never creates or edits an output profile, a channel or a
   stream.
+
+## Delivering through a Dispatcharr Connect Integration
+
+Dispatcharr has its own Connect page where you create webhook Integrations,
+each holding a URL and any headers it needs. Type the exact name of one into
+the **Dispatcharr Connect Integration** setting and Newsflasharr posts through
+that row, reusing the address and headers already configured there. It reads
+that row and never changes it.
+
+The Integration must be of type webhook, because Newsflasharr never runs a
+script. The name is looked up live rather than stored, so renaming the row
+stops delivery. These deliveries do not appear on the Connect page's own Logs
+tab, which records only Dispatcharr's own system events, so use Show status
+instead.
 
 ## After installing
 

--- a/plugins/newsflasharr/plugin.json
+++ b/plugins/newsflasharr/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "Newsflasharr",
-  "version": "1.26.2241159",
-  "description": "Central notification service: other plugins drop events, Newsflasharr routes them to Discord, a webhook, ntfy, Apprise, email, or an on-screen banner over live TV, with deduplication, storm throttling, quiet hours and per-channel retry.",
+  "version": "1.26.2481646",
+  "description": "Central notification service: other plugins drop events, Newsflasharr routes them to Discord, a webhook, ntfy, Apprise, email, a Dispatcharr Connect Integration, or an on-screen banner over live TV, with deduplication, storm throttling, quiet hours and per-channel retry.",
   "author": "PiratesIRC",
   "license": "MIT",
   "source_type": "external",


### PR DESCRIPTION
Updates the Newsflasharr listing from 1.26.2241159 to 1.26.2481646.

This is an external listing, so only the manifest and the README change here. The archive is served from the plugin's own GitHub release:
https://github.com/PiratesIRC/Dispatcharr-Newsflasharr-Plugin/releases/tag/1.26.2481646

**What the release adds.** A seventh delivery destination: a Dispatcharr Connect Integration. You create a webhook Integration on Dispatcharr's own Connect page, type its name into the plugin, and Newsflasharr posts notifications through that row, reusing the URL and headers already configured there. It reads that row and never changes it.

**What it corrects.** Fourteen statements the plugin or its guide made that were wrong, including action output files naming a location they were often not at on a stock image, ages printed as raw seconds rather than readable durations, and a settings heading that miscounted the settings under it.

The listing description and the README both still described six destinations, so both are updated here.

I verified the download URL resolves for the new tag before opening this: the bare calver form returns HTTP 200 and the v-prefixed form returns 404, matching the existing source_url which has no v.