### PR TITLE
[channel-mapparr] Update to 1.26.2481147

### DIFF
--- a/plugins/channel-mapparr/plugin.json
+++ b/plugins/channel-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Channel Mapparr",
-  "version": "1.26.2291823",
+  "version": "1.26.2481147",
   "description": "Standardizes broadcast (OTA) and premium/cable channel names using network data and channel lists. Supports M3U stream import, category organization, and fuzzy matching across 42K+ channels in 11 countries.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Updates the Channel Mapparr listing to 1.26.2481147.

Release: https://github.com/PiratesIRC/Dispatcharr-Channel-Maparr-Plugin/releases/tag/1.26.2481147

This is an external listing, so the only change is the version. The archive at the
substituted `source_url` has been confirmed downloadable.

What is in the release:

- A new setting, Delete CSV Exports Older Than (Days), defaulting to 0, which
  deletes only this plugin's own `channel_mapparr_*.csv` files from the shared
  `/data/exports` directory, never another plugin's, and never the file just
  written.
- The settings form is divided into six sections.
- Action button colour now tracks what an action can do to your channels, with
  red reserved for the two actions that replace a value on an existing channel.
- Corrections to statements the plugin made about itself: the commented preamble
  at the top of each CSV export named six settings by labels the settings page
  stopped using, rendered a setting that is off as "(not set)", omitted ten
  settings and never said what the run did; the form offered eleven country
  databases when twelve ship; Organize by Category described itself as running
  in the background, which it does not; and Show Status printed an internal
  identifier for four of the five operations that report progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAdfstgSwNMZKq2ZrSYFYH
