### PR TITLE
[ticker]: bump to v0.5.01 — Migrate from Tickarr bridge-migration action

### DIFF
--- a/plugins/ticker/plugin.json
+++ b/plugins/ticker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ticker",
-  "version": "0.5.00",
+  "version": "0.5.01",
   "description": "Dynamic text overlays for IPTV channels — Satellite Radio Now Playing, Sports Ticker, Custom Text, EAS/JAS Weather Alerts",
   "author": "jstevenscl",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bumps Ticker to v0.5.01, which adds a **Migrate from Tickarr** action — a one-time bridge-migration helper for users still running the pre-v0.5.00 "Tickarr" plugin (renamed to Ticker in v0.5.00) alongside Ticker. It imports Tickarr's channel configuration, re-clones active overlays under Ticker's own paths, and tears down Tickarr's leftover data/profiles on a clean run.

Release: https://github.com/jstevenscl/ticker/releases/tag/v0.5.01
SHA-256: d052b2bc110d75959f715bda3813d0bb11de54341f48c202295bc9ceb8ed5445
MD5: d780ae1b75d76ba6f5ffaca17bd3dc63

🤖 Generated with [Claude Code](https://claude.com/claude-code)