### PR TITLE
[epg-janitor] Update to 1.26.2481223

### DIFF
--- a/plugins/epg-janitor/plugin.json
+++ b/plugins/epg-janitor/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "EPG Janitor",
-  "version": "1.26.2281111",
+  "version": "1.26.2481223",
   "description": "Scans for channels with EPG assignments but no program data. Auto-matches EPG to channels using intelligent fuzzy matching with aliases, removes EPG from hidden channels, and manages EPG assignments.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Version-only bump of the EPG Janitor listing. The listing is external mode, so the archive is downloaded from the release rather than copied here.

Release: https://github.com/PiratesIRC/Dispatcharr-EPG-Janitor-Plugin/releases/tag/1.26.2481223

Verified before opening this:

- the download URL resolves for this version (HTTP 200 on the bare tag form the listing uses)
- the published asset is byte-identical to the archive built from the tag, sha256 2cc9ba6b40733bf4, 480772 bytes, 26 entries
- the archive was built from the tag with line endings forced to LF, validated for forward-slash paths, and every entry hashes equal to the blob at the tag
- CI is green on the tagged commit

What changed since 1.26.2281111: age-based cleanup of the plugin's own CSV exports, a sectioned settings form, button colours that track consequence, and a CSV export preamble that says what the file is and what the run did. Full notes are on the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpSYEn4jg94EMzKjh2JzJP