### PR TITLE
[event-channel-managarr]: Update to 1.26.2490035

### DIFF
--- a/plugins/event-channel-managarr/plugin.json
+++ b/plugins/event-channel-managarr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Channel Managarr",
-  "version": "1.26.2451734",
+  "version": "1.26.2490035",
   "description": "Automates channel visibility by hiding channels without events and showing those with events, based on EPG data and channel names. Optionally manages dummy EPG for channels without real EPG.",
   "author": "PiratesIRC",
   "maintainers": [


### PR DESCRIPTION
Updates the Event Channel Managarr listing to 1.26.2490035.

This is an external listing, so the only change is the `version` field; the Hub
fetches the release asset from the plugin repository.

Release: https://github.com/PiratesIRC/Dispatcharr-Event-Channel-Managarr-Plugin/releases/tag/v1.26.2490035

What is in it, briefly. Two fixes change guide data: channels held visible by the
force-visible regex were never given the managed dummy EPG, and a channel matched
by the ignore regex could have its managed EPG removed. An operator's own wording
in the two fallback template fields is no longer overwritten on every run. There
is a new setting for age-based cleanup of the plugin's own CSV exports, off by
default. Validate Configuration now warns about regex alternatives that compile
but do not mean what they look like. The action button colours and the CSV
preamble were reworked so colour tracks consequence and the report explains
itself.

Checked before opening: the `source_url` with the `v` prefix resolves to the
published asset with HTTP 200, the asset is 248,552 bytes and byte-identical to
what was built from the tag, and its eight entry names match the previous
release exactly. 724 tests pass and `ruff check .` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BySSx8ijN2cRGZQQDBHxu3
