### PR TITLE
[stream-mapparr] 1.26.2491549

### DIFF
--- a/plugins/stream-mapparr/README.md
+++ b/plugins/stream-mapparr/README.md
@@ -5,6 +5,13 @@
 A Dispatcharr plugin that automatically matches and assigns streams to channels
 using fuzzy matching, quality prioritization, and OTA callsign recognition.
 
+The "streams matched" badge counts stream-to-channel assignments this plugin has
+written on the maintainer's own installation, added up since the counter was
+added on 5 September 2026. It measures work done rather than distinct streams: a
+daily schedule matches the same library again and counts it again. Dry runs are
+not counted, and neither is sorting alternate streams, which reorders
+assignments that already exist.
+
 ## Backup Your Database
 
 Before installing or using this plugin, create a backup of your Dispatcharr
@@ -23,14 +30,14 @@ database. This plugin modifies channel and stream assignments.
 
 **From the Dispatcharr Plugin Hub (recommended):**
 
-1. In Dispatcharr, go to **Settings → Plugin Hub**
+1. In Dispatcharr, go to **Settings -> Plugin Hub**
 2. Find **Stream-Mapparr** in the catalog and click **Install**
 3. Enable the plugin
 
 **Manual install:**
 
 1. Download the latest zip from [Releases](https://github.com/PiratesIRC/Stream-Mapparr/releases)
-2. In Dispatcharr, go to **Plugins → Import Plugin** and upload the zip
+2. In Dispatcharr, go to **Plugins -> Import Plugin** and upload the zip
 3. Enable the plugin
 
 ## Further reading
@@ -56,11 +63,12 @@ database. This plugin modifies channel and stream assignments.
   stream names before anything else. See
   [Regex pre-processing](https://github.com/PiratesIRC/Stream-Mapparr/blob/main/docs/regex-preprocessing.md)
 - **Stylized-name normalization**: handles superscript and small-caps markers
-  such as `ᴿᴬᵂ`, emoji used as letters (`beIN SP⚽RTS`), and numeric resolution
+  such as superscript RAW, emoji used as letters (a ball glyph standing in for the O of SPORTS), and numeric resolution
   tags like `3840P`
-- **Box-bar tag stripping**: removes provider and country tags built from `┃`
-  and `│`, such as `┃CANAL+┃ NPO 1` or `NL┃ NPO 1`. A stray single bar is left
-  alone
+- **Box-bar tag stripping**: removes provider and country tags built from the
+  box-drawing bars U+2503 and U+2502 (not the ASCII pipe), such as a bouquet name
+  enclosed in those bars before `NPO 1`, or a two-letter country code followed by
+  one. A stray single bar is left alone
 - **Invisible character stripping**: removes zero-width spaces, joiners, word
   joiners, byte order marks, soft hyphens and bidi marks. Providers use these as
   padding, often around a decorative glyph, and they used to wreck matching for
@@ -158,7 +166,7 @@ the operation lock prevents concurrent runs and auto-expires after 10 minutes.
 | **Stream Groups** | string | (all) | Stream groups to draw candidate streams from, comma-separated |
 | **Stream Groups Mode** | select | Only the groups listed | The same choice for stream groups, resolved separately from the channel-group list |
 | **M3U Sources** | string | (all) | M3U sources to use, comma-separated. Order sets priority |
-| **Custom Aliases** | string | (none) | JSON object of extra `"channel": ["alias", …]` mappings. Channel names and aliases are both matched case-insensitively, and whitespace around a channel name is ignored |
+| **Custom Aliases** | string | (none) | JSON object of extra `"channel": ["alias", ...]` mappings. Channel names and aliases are both matched case-insensitively, and whitespace around a channel name is ignored |
 | **Stream Name Regex Rules** | string | (none) | JSON list of `[find, replace]` pairs applied to stream names before matching. See [Regex pre-processing](https://github.com/PiratesIRC/Stream-Mapparr/blob/main/docs/regex-preprocessing.md) |
 | **Prioritize Quality** | boolean | False | Sort by quality first, then by M3U source priority |
 | **Custom Ignore Tags** | string | (none) | Tags to strip before matching, for example `[Dead], (Backup)` |
@@ -175,7 +183,7 @@ the operation lock prevents concurrent runs and auto-expires after 10 minutes.
 | **Stream Prefix Countries** | string | (empty) | Tell the country filter what a provider prefix means, as comma-separated `PREFIX=COUNTRY` entries such as `NOW=UK, GO=US`. Use it when a prefix names a platform rather than a country, which the plugin cannot know: NOW is Sky's service in the United Kingdom and also in Italy, so no default is right for everyone. Consulted last, so it fills a gap and never overrules a country the provider stated. Matches only at the start of a name, never a word inside a title |
 | **Keep Same-Named Streams From One Source** | boolean | False | Enable if your provider publishes several genuinely different feeds under one identical name. By default those are treated as duplicates |
 | **Enable EPG-Based Placeholder Matching** | boolean | False | Match a placeholder-named channel or stream by the programme currently airing on it, taken from EPG data, instead of by its literal name. For providers that name event slots generically, such as `PPV EVENT 04`, and put the real event only in the guide. Channel and stream names are never modified |
-| **Placeholder Name Patterns** | string | (see plugin) | One regex per line. A name is only ever treated as a placeholder if it matches one of these, so nothing else changes behaviour |
+| **Placeholder Name Patterns** | string | (see plugin) | One regex per line. A name is only ever treated as a placeholder if it matches one of these, so nothing else changes behaviour. Press **Scan for Placeholder Patterns** to find the families your patterns miss |
 | **EPG Title Cleanup Rules** | string | (see plugin) | JSON list of `[find, replace]` pairs applied to the raw programme title before it is used for matching, for example stripping a `Next Event: X at 6:00AM` wrapper down to `X` |
 | **Skip Titles** | string | (see plugin) | Comma-separated. If the cleaned programme title matches one of these, the channel keeps its literal name for that pass, because an idle slot carries no useful event |
 | **Channel Schedule Suffix Cleanup Rules** | string | (see plugin) | JSON list of `[find, replace]` pairs that strip a schedule annotation such as `\| Monday @ 5` from the channel name before it is compared against a programme title |
@@ -203,6 +211,7 @@ the operation lock prevents concurrent runs and auto-expires after 10 minutes.
 | **Validate Settings** | Check configuration, profiles, groups and databases |
 | **Test Regex Rules** | Preview what your regex rules would change, with before and after samples and invisible characters made visible. Writes the full readout to `/config/stream-mapparr/test-regex-rules.txt`, since a notification shows only about 280 characters |
 | **Check Stream Country Labels** | Compare each stream's group country against its EPG identifier suffix and report where they disagree. Reads two database columns, opens no provider connection and changes nothing. A disagreement is not automatically a fault: a channel carried in one country and made in another is ordinary |
+| **Scan for Placeholder Patterns** | Group every stream name into a numbered family, by replacing its numbers with a slot, and report the families that no Placeholder Name Pattern covers, each with a regex to paste. The largest families come first. Each one says how many of its streams carry an EPG identifier, and a family where most of them do is marked, because that is more likely to be an ordinary numbered channel lineup, where a pattern replaces a name that is already matching. A digit followed by K is left alone, since `4K` is a resolution tag rather than a slot number. Writes the full readout to `/config/stream-mapparr/placeholder-name-scan.txt`. Reads one database column, opens no provider connection and changes nothing |
 | **Load/Process Channels** | Load channel and stream data from the database |
 | **Preview Changes** | Dry run with a CSV export |
 | **Match & Assign Streams** | Fuzzy match and assign streams to channels |
@@ -253,12 +262,12 @@ because the exports contain your M3U source names.
 ## Versioning
 
 This plugin uses calver, `1.MAJOR.DDDHHMM`, being the UTC day of year plus the
-UTC time. Run `python3 Stream-Mapparr/bump_version.py` to bump `plugin.json` and
+UTC time. Run `python scripts/bump_version.py` to bump `plugin.json` and
 `plugin.py` together.
 
 ## Changelog
 
-See [CHANGELOG.md](https://github.com/PiratesIRC/Stream-Mapparr/blob/main/Stream-Mapparr/CHANGELOG.md) for full version history.
+See [CHANGELOG.md](https://github.com/PiratesIRC/Stream-Mapparr/blob/main/CHANGELOG.md) for full version history.
 
 ## Disclaimer
 

--- a/plugins/stream-mapparr/plugin.json
+++ b/plugins/stream-mapparr/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Stream-Mapparr",
-  "version": "1.26.2481756",
+  "version": "1.26.2491549",
   "description": "Automatically add matching streams to channels based on name similarity and quality precedence. Supports unlimited stream matching, channel visibility management, and CSV export cleanup.",
   "author": "PiratesIRC",
   "license": "MIT",


### PR DESCRIPTION
Update Stream-Mapparr to 1.26.2491549.

Release: https://github.com/PiratesIRC/Stream-Mapparr/releases/tag/1.26.2491549

Changelog: https://github.com/PiratesIRC/Stream-Mapparr/blob/main/CHANGELOG.md
