### PR TITLE
[dispatcharr-ranked-matchups] Bump to 1.28.0

### DIFF
--- a/plugins/dispatcharr-ranked-matchups/plugin.json
+++ b/plugins/dispatcharr-ranked-matchups/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "Ranked Matchups (Top Games)",
-  "version": "1.27.1",
+  "version": "1.28.0",
   "description": "Never miss a good game. Scores every upcoming game across 39 leagues, tours and competitions (22 of them soccer, plus NFL, NBA, MLB, NHL, NCAA D1 football and basketball, UFC, boxing, tennis, golf and motorsport), then builds a Top Matchups group holding only the ones worth watching and shows why each game ranked where it did in its EPG description. Finished games can clear themselves out and be replaced from a bench of the next-best fixtures.",
   "author": "Jacob-Lasky",
   "license": "MIT",


### PR DESCRIPTION
Bumps the listing to [v1.28.0](https://github.com/Jacob-Lasky/dispatcharr_ranked_matchups/releases/tag/v1.28.0). Version field only; no other listing metadata changed.

## What's in it

An audit of the live guide found **16 of 21 LLM-written previews contained at least one false, checkable claim**, verified by reproducing the exact production prompt for every described game and checking each claim against live standings data.

The cause was not a thin prompt. Early in a season the soccer source deliberately substitutes **last season's final table** as an early-season ranking prior, and the description builder rendered that as the current standings with nothing marking the swap. The model faithfully described what it was told: "Arsenal's seven-point cushion at the top" when Arsenal were 3rd and three points behind, and one fixture had the two teams' positions fully inverted.

The seeded table now travels alongside the real one rather than replacing it. The scoring path is unchanged; only the human-facing text switched to the current-season table, in all four places it was read.

Also adds last season's finish and previous meetings (both explicitly labelled), season phase for every sport, win-loss records and threshold distances for win-count sports, and poll ranks, conferences and venues that were already present in the upstream API payloads and simply never rendered. Plus 224 rivalry pairs with 150 named trophies and derbies across 17 competitions.

## Verification

4486 tests pass. Deployed and driven end-to-end against a live Dispatcharr container before release: the plugin API serves 1.28.0, `apply` runs through the HTTP entry point, and the resulting channels, streams and EPG rows were read back from the database.

The release asset was downloaded from the published URL and confirmed byte-identical to the local build, with the required snake_case top-level folder.